### PR TITLE
Partially fix --device-id

### DIFF
--- a/scripts/cldm.py
+++ b/scripts/cldm.py
@@ -4,6 +4,8 @@ from omegaconf import OmegaConf
 import torch
 import torch as th
 import torch.nn as nn
+from modules.shared import cmd_opts
+from modules import devices, lowvram
 
 from ldm.modules.diffusionmodules.util import (
     conv_nd,
@@ -15,7 +17,6 @@ from ldm.modules.diffusionmodules.util import (
 from ldm.modules.attention import SpatialTransformer
 from ldm.modules.diffusionmodules.openaimodel import UNetModel, TimestepEmbedSequential, ResBlock, Downsample, AttentionBlock
 from ldm.util import exists
-import modules.devices as devices
 
 
 def load_state_dict(ckpt_path, location='cpu'):
@@ -39,21 +40,20 @@ class PlugableControlModel(nn.Module):
     def __init__(self, model_path, config_path, weight=1.0, lowvram=False) -> None:
         super().__init__()
         config = OmegaConf.load(config_path)
-
+        
         self.control_model = ControlNet(**config.model.params.control_stage_config.params)
         state_dict = load_state_dict(model_path)
-
         if any([k.startswith("control_model.") for k, v in state_dict.items()]):
             state_dict = {k.replace("control_model.", ""): v for k, v in state_dict.items() if k.startswith("control_model.")}
         
         self.control_model.load_state_dict(state_dict)
-        self.control_model.to(devices.get_device_for("controlnet"))
-
+        self.lowvram = lowvram            
         self.weight = weight
         self.only_mid_control = False
         self.control = None
         self.hint_cond = None
-        self.lowvram = lowvram
+        if not self.lowvram:
+            self.control_model.to(devices.get_device_for("controlnet"))
 
     def hook(self, model, parent_model):
         outer = self
@@ -88,17 +88,16 @@ class PlugableControlModel(nn.Module):
             return self.out(h)
 
         def forward2(*args, **kwargs):
+            # webui will handle other compoments 
             try:
+                if cmd_opts.lowvram or cmd_opts.medvram:
+                    lowvram.send_everything_to_cpu()
                 if self.lowvram:
-                    parent_model.first_stage_model.cpu()
-                    parent_model.cond_stage_model.cpu()
-                    self.control_model.cuda()
+                    self.control_model.to(devices.get_device_for("controlnet"))
                 return forward(*args, **kwargs)
             finally:
                 if self.lowvram:
                     self.control_model.cpu()
-                    parent_model.first_stage_model.cuda()
-                    parent_model.cond_stage_model.cuda()
         
         model._original_forward = model.forward
         model.forward = forward2.__get__(model, UNetModel)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import torch
 
 import modules.scripts as scripts
-from modules import shared
+from modules import shared, devices
 import gradio as gr
 
 import numpy as np
@@ -266,7 +266,7 @@ class Script(scripts.Script):
         detected_map = preprocessor(input_image)
         detected_map = HWC3(detected_map)
 
-        control = torch.from_numpy(detected_map.copy()).float().cuda() / 255.0
+        control = torch.from_numpy(detected_map.copy()).float().to(devices.get_device_for("controlnet")) / 255.0
         control = rearrange(control, 'h w c -> c h w')
         
         if resize_mode == "Scale to Fit (Inner Fit)":


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40241855/218570332-460d5e83-c0f9-4e8e-bd40-6e929dbf92a6.png)

Fixes the error shown above when `--device-id` is set to non-zero.

Note that the current implementation of lowvram is suboptimal to say atleast, it should follow the `--lowvram` CLI flag and be compatible with `--device-id`, and follow `modules.devices` API, I will not fix it in this PR.