### PR TITLE
Add support for using the web UI torch device

### DIFF
--- a/annotator/hed/__init__.py
+++ b/annotator/hed/__init__.py
@@ -4,7 +4,7 @@ import torch
 from einops import rearrange
 
 import os 
-from modules import extensions
+from modules import extensions, devices
 
 class Network(torch.nn.Module):
     def __init__(self, model_path):
@@ -106,12 +106,12 @@ def apply_hed(input_image):
         if not os.path.exists(modelpath):
             from basicsr.utils.download_util import load_file_from_url
             load_file_from_url(remote_model_path, model_dir=modeldir)
-        netNetwork = Network(modelpath).cuda().eval()
+        netNetwork = Network(modelpath).to(devices.get_device_for("controlnet")).eval()
         
     assert input_image.ndim == 3
     input_image = input_image[:, :, ::-1].copy()
     with torch.no_grad():
-        image_hed = torch.from_numpy(input_image).float().cuda()
+        image_hed = torch.from_numpy(input_image).float().to(devices.get_device_for("controlnet"))
         image_hed = image_hed / 255.0
         image_hed = rearrange(image_hed, 'h w c -> 1 c h w')
         edge = netNetwork(image_hed)[0]

--- a/annotator/midas/__init__.py
+++ b/annotator/midas/__init__.py
@@ -4,15 +4,16 @@ import torch
 
 from einops import rearrange
 from .api import MiDaSInference
+from modules import devices
 
-model = MiDaSInference(model_type="dpt_hybrid").cuda()
+model = MiDaSInference(model_type="dpt_hybrid").to(devices.get_device_for("controlnet"))
 
 
 def apply_midas(input_image, a=np.pi * 2.0, bg_th=0.1):
     assert input_image.ndim == 3
     image_depth = input_image
     with torch.no_grad():
-        image_depth = torch.from_numpy(image_depth).float().cuda()
+        image_depth = torch.from_numpy(image_depth).float().to(devices.get_device_for("controlnet"))
         image_depth = image_depth / 127.5 - 1.0
         image_depth = rearrange(image_depth, 'h w c -> 1 c h w')
         depth = model(image_depth)[0]

--- a/annotator/mlsd/__init__.py
+++ b/annotator/mlsd/__init__.py
@@ -7,7 +7,7 @@ from einops import rearrange
 from .models.mbv2_mlsd_tiny import  MobileV2_MLSD_Tiny
 from .models.mbv2_mlsd_large import  MobileV2_MLSD_Large
 from .utils import  pred_lines
-from modules import extensions
+from modules import extensions, devices
 
 mlsdmodel = None
 remote_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/mlsd_large_512_fp32.pth"
@@ -22,7 +22,7 @@ def apply_mlsd(input_image, thr_v, thr_d):
             load_file_from_url(remote_model_path, model_dir=modeldir)
         mlsdmodel = MobileV2_MLSD_Large()
         mlsdmodel.load_state_dict(torch.load(modelpath), strict=True)
-        mlsdmodel = mlsdmodel.cuda().eval()
+        mlsdmodel = mlsdmodel.to(devices.get_device_for("controlnet")).eval()
         
     model = mlsdmodel
     assert input_image.ndim == 3

--- a/annotator/mlsd/utils.py
+++ b/annotator/mlsd/utils.py
@@ -14,6 +14,7 @@ import numpy as np
 import cv2
 import torch
 from  torch.nn import  functional as F
+from modules import devices
 
 
 def deccode_output_score_and_ptss(tpMap, topk_n = 200, ksize = 5):
@@ -58,7 +59,7 @@ def pred_lines(image, model,
     batch_image = np.expand_dims(resized_image, axis=0).astype('float32')
     batch_image = (batch_image / 127.5) - 1.0
 
-    batch_image = torch.from_numpy(batch_image).float().cuda()
+    batch_image = torch.from_numpy(batch_image).float().to(devices.get_device_for("controlnet"))
     outputs = model(batch_image)
     pts, pts_score, vmap = deccode_output_score_and_ptss(outputs, 200, 3)
     start = vmap[:, :, :2]
@@ -109,7 +110,7 @@ def pred_squares(image,
     batch_image = np.expand_dims(resized_image, axis=0).astype('float32')
     batch_image = (batch_image / 127.5) - 1.0
 
-    batch_image = torch.from_numpy(batch_image).float().cuda()
+    batch_image = torch.from_numpy(batch_image).float().to(devices.get_device_for("controlnet"))
     outputs = model(batch_image)
 
     pts, pts_score, vmap = deccode_output_score_and_ptss(outputs, 200, 3)

--- a/annotator/openpose/body.py
+++ b/annotator/openpose/body.py
@@ -10,13 +10,12 @@ from torchvision import transforms
 
 from . import util
 from .model import bodypose_model
+from modules import devices
 
 class Body(object):
     def __init__(self, model_path):
         self.model = bodypose_model()
-        if torch.cuda.is_available():
-            self.model = self.model.cuda()
-            print('cuda')
+        self.model = self.model.to(devices.get_device_for("controlnet"))
         model_dict = util.transfer(self.model, torch.load(model_path))
         self.model.load_state_dict(model_dict)
         self.model.eval()
@@ -41,8 +40,7 @@ class Body(object):
             im = np.ascontiguousarray(im)
 
             data = torch.from_numpy(im).float()
-            if torch.cuda.is_available():
-                data = data.cuda()
+            data = data.to(devices.get_device_for("controlnet"))
             # data = data.permute([2, 0, 1]).unsqueeze(0).float()
             with torch.no_grad():
                 Mconv7_stage6_L1, Mconv7_stage6_L2 = self.model(data)

--- a/annotator/openpose/hand.py
+++ b/annotator/openpose/hand.py
@@ -11,13 +11,12 @@ from skimage.measure import label
 
 from .model import handpose_model
 from . import util
+from modules import devices
 
 class Hand(object):
     def __init__(self, model_path):
         self.model = handpose_model()
-        if torch.cuda.is_available():
-            self.model = self.model.cuda()
-            print('cuda')
+        self.model = self.model.to(devices.get_device_for("controlnet"))
         model_dict = util.transfer(self.model, torch.load(model_path))
         self.model.load_state_dict(model_dict)
         self.model.eval()
@@ -41,8 +40,7 @@ class Hand(object):
             im = np.ascontiguousarray(im)
 
             data = torch.from_numpy(im).float()
-            if torch.cuda.is_available():
-                data = data.cuda()
+            data = data.to(devices.get_device_for("controlnet"))
             # data = data.permute([2, 0, 1]).unsqueeze(0).float()
             with torch.no_grad():
                 output = self.model(data).cpu().numpy()


### PR DESCRIPTION
Instead of assuming the default CUDA device is being used, this change will use the torch device from web UI. This is needed if the CUDA device ID web UI is using is not 0, or if the user is running from CPU or MPS (the torch device Macs use).