### PR TITLE
Add support for other torch devices to uniformer, fix uniformer model name to prevent unnecessary redownload

### DIFF
--- a/annotator/uniformer/__init__.py
+++ b/annotator/uniformer/__init__.py
@@ -1,6 +1,7 @@
 from annotator.uniformer.mmseg.apis import init_segmentor, inference_segmentor, show_result_pyplot
 from annotator.uniformer.mmseg.core.evaluation import get_palette
 from modules.shared import extensions
+from modules import devices
 import os
 
 modeldir = os.path.join(extensions.extensions_dir, "sd-webui-controlnet", "annotator", "uniformer")
@@ -11,13 +12,31 @@ model = None
 def apply_uniformer(img):
     global model
     if model is None:
-        modelpath = os.path.join(modeldir, "body_pose_model.pth")
+        modelpath = os.path.join(modeldir, "upernet_global_small.pth")
         if not os.path.exists(modelpath):
             from basicsr.utils.download_util import load_file_from_url
             load_file_from_url(checkpoint_file, model_dir=modeldir)
             
-        model = init_segmentor(config_file, checkpoint_file).cuda()
+        model = init_segmentor(config_file, checkpoint_file).to(devices.get_device_for("controlnet"))
     
-    result = inference_segmentor(model, img)
+    if devices.get_device_for("controlnet").type == 'mps':
+        # adaptive_avg_pool2d can fail on MPS, workaround with CPU
+        import torch.nn.functional
+        
+        orig_adaptive_avg_pool2d = torch.nn.functional.adaptive_avg_pool2d
+        def cpu_if_exception(input, *args, **kwargs):
+            try:
+                return orig_adaptive_avg_pool2d(input, *args, **kwargs)
+            except:
+                return orig_adaptive_avg_pool2d(input.cpu(), *args, **kwargs).to(input.device)
+        
+        try:
+            torch.nn.functional.adaptive_avg_pool2d = cpu_if_exception
+            result = inference_segmentor(model, img)
+        finally:
+            torch.nn.functional.adaptive_avg_pool2d = orig_adaptive_avg_pool2d
+    else:
+        result = inference_segmentor(model, img)
+    
     res_img = show_result_pyplot(model, img, result, get_palette('ade'), opacity=1)
     return res_img

--- a/annotator/uniformer/mmseg/apis/inference.py
+++ b/annotator/uniformer/mmseg/apis/inference.py
@@ -6,9 +6,10 @@ from annotator.uniformer.mmcv.runner import load_checkpoint
 
 from annotator.uniformer.mmseg.datasets.pipelines import Compose
 from annotator.uniformer.mmseg.models import build_segmentor
+from modules import devices
 
 
-def init_segmentor(config, checkpoint=None, device='cuda:0'):
+def init_segmentor(config, checkpoint=None, device=devices.get_device_for("controlnet")):
     """Initialize a segmentor from config file.
 
     Args:
@@ -90,6 +91,7 @@ def inference_segmentor(model, img):
         # scatter to specified GPU
         data = scatter(data, [device])[0]
     else:
+        data['img'][0] = data['img'][0].to(devices.get_device_for("controlnet"))
         data['img_metas'] = [i.data[0] for i in data['img_metas']]
 
     # forward the model


### PR DESCRIPTION
This adds support for other torch devices, although more modifications may still be needed to select the correct CUDA device if the default is not being used. Regardless, the changes here shouldn't break anything that currently works.

This PR also fixes the model name for the uniformer model (changes `"body_pose_model.pth"` to `"upernet_global_small.pth"` in `annotator/uniformer/__init__.py`) so it isn't redownloaded every time.