### PR TITLE
Add `--controlnet-dir PTH_DIR` cli argument

### DIFF
--- a/preload.py
+++ b/preload.py
@@ -1,0 +1,7 @@
+import os.path
+
+EXTENSION_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_CN_DIR = os.path.join(EXTENSION_DIR, "models")
+
+def preload(parser):
+    parser.add_argument("--controlnet-dir", type=str, help="Path to directory with ControlNet models", default=DEFAULT_CN_DIR)

--- a/preload.py
+++ b/preload.py
@@ -1,7 +1,2 @@
-import os.path
-
-EXTENSION_DIR = os.path.dirname(os.path.abspath(__file__))
-DEFAULT_CN_DIR = os.path.join(EXTENSION_DIR, "models")
-
 def preload(parser):
-    parser.add_argument("--controlnet-dir", type=str, help="Path to directory with ControlNet models", default=DEFAULT_CN_DIR)
+    parser.add_argument("--controlnet-dir", type=str, help="Path to directory with ControlNet models", default=None)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -18,7 +18,7 @@ from scripts.processor import *
 CN_MODEL_EXTS = [".pt", ".pth", ".ckpt", ".safetensors"]
 cn_models = {}      # "My_Lora(abcd1234)" -> C:/path/to/model.safetensors
 cn_models_names = {}  # "my_lora" -> "My_Lora(abcd1234)"
-cn_models_dir = os.path.join(scripts.basedir(), "models")
+cn_models_dir = shared.cmd_opts.controlnet_dir
 os.makedirs(cn_models_dir, exist_ok=True)
 
 def traverse_all_files(curr_path, model_list):

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import torch
 
 import modules.scripts as scripts
-from modules import shared, devices
+from modules import shared, devices, script_callbacks
 import gradio as gr
 
 import numpy as np
@@ -18,7 +18,7 @@ from scripts.processor import *
 CN_MODEL_EXTS = [".pt", ".pth", ".ckpt", ".safetensors"]
 cn_models = {}      # "My_Lora(abcd1234)" -> C:/path/to/model.safetensors
 cn_models_names = {}  # "my_lora" -> "My_Lora(abcd1234)"
-cn_models_dir = shared.cmd_opts.controlnet_dir
+cn_models_dir = os.path.join(scripts.basedir(), "models")
 os.makedirs(cn_models_dir, exist_ok=True)
 
 def traverse_all_files(curr_path, model_list):
@@ -76,10 +76,11 @@ def find_closest_lora_model_name(search: str):
 def update_cn_models():
     global cn_models, cn_models_names
     res = OrderedDict()
-    paths = [cn_models_dir]
-    extra_lora_path = shared.opts.data.get("control_net_models_path", None)
-    if extra_lora_path and os.path.exists(extra_lora_path):
-        paths.append(extra_lora_path)
+    extra_lora_paths = (extra_lora_path
+                        for extra_lora_path
+                        in (shared.opts.data.get("control_net_models_path", None), shared.cmd_opts.controlnet_dir)
+                        if extra_lora_path is not None and os.path.exists(extra_lora_path))
+    paths = [cn_models_dir, *extra_lora_paths]
 
     for path in paths:
         sort_by = shared.opts.data.get(
@@ -326,9 +327,9 @@ def update_script_args(p, value, arg_idx):
 #         if not find_closest_lora_model_name(x):
 #             raise RuntimeError(f"Unknown ControlNet model: {x}")
 
-# def on_ui_settings():
-#   section = ('control_net', "ControlNet")
-#   shared.opts.add_option("control_net_path", shared.OptionInfo(
-#       "", "Extra path to scan for ControlNet models (e.g. training output directory)", section=section))
+def on_ui_settings():
+  section = ('control_net', "ControlNet")
+  shared.opts.add_option("control_net_models_path", shared.OptionInfo(
+      "", "Extra path to scan for ControlNet models (e.g. training output directory)", section=section))
 
-# script_callbacks.on_ui_settings(on_ui_settings)
+script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
Adds the `--controlnet-dir` cli argument to webui to be able to customize the path to the models. One use case for this is loading control net models from an SSD. I tried keeping the --help text as close to webui's existing options for consistency.