### PR TITLE
use relative path for download directory

### DIFF
--- a/annotator/hed/__init__.py
+++ b/annotator/hed/__init__.py
@@ -97,7 +97,7 @@ class Network(torch.nn.Module):
 
 netNetwork = None
 remote_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/network-bsds500.pth"
-modeldir = os.path.join(extensions.extensions_dir, "sd-webui-controlnet", "annotator", "hed")
+modeldir = os.path.join(__file__, "..")
 
 def apply_hed(input_image):
     global netNetwork

--- a/annotator/midas/api.py
+++ b/annotator/midas/api.py
@@ -13,7 +13,7 @@ from .midas.midas_net import MidasNet
 from .midas.midas_net_custom import MidasNet_small
 from .midas.transforms import Resize, NormalizeImage, PrepareForNet
 
-base_model_path = os.path.join(extensions.extensions_dir, "sd-webui-controlnet", "annotator", "midas")
+base_model_path = os.path.join(__file__, "..")
 remote_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/dpt_hybrid-midas-501f0c75.pt"
 
 ISL_PATHS = {

--- a/annotator/mlsd/__init__.py
+++ b/annotator/mlsd/__init__.py
@@ -11,7 +11,7 @@ from modules import extensions, devices
 
 mlsdmodel = None
 remote_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/mlsd_large_512_fp32.pth"
-modeldir = os.path.join(extensions.extensions_dir, "sd-webui-controlnet", "annotator", "mlsd")
+modeldir = os.path.join(__file__, "..")
 
 def unload_mlsd_model():
     global mlsdmodel

--- a/annotator/openpose/__init__.py
+++ b/annotator/openpose/__init__.py
@@ -13,7 +13,7 @@ hand_estimation = None
 
 body_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/body_pose_model.pth"
 hand_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/hand_pose_model.pth"
-modeldir = os.path.join(extensions.extensions_dir, "sd-webui-controlnet", "annotator", "openpose")
+modeldir = os.path.join(__file__, "..")
 
 def unload_openpose_model():
     global body_estimation, hand_estimation

--- a/annotator/uniformer/__init__.py
+++ b/annotator/uniformer/__init__.py
@@ -4,9 +4,9 @@ from modules.shared import extensions
 from modules import devices
 import os
 
-modeldir = os.path.join(extensions.extensions_dir, "sd-webui-controlnet", "annotator", "uniformer")
+modeldir = os.path.join(__file__, "..")
 checkpoint_file = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/upernet_global_small.pth"
-config_file = os.path.join(extensions.extensions_dir, "sd-webui-controlnet", "annotator", "uniformer", "exp", "upernet_global_small", "config.py")
+config_file = os.path.join(__file__, "..", "exp", "upernet_global_small", "config.py")
 model = None
 
 def unload_uniformer_model():


### PR DESCRIPTION
The directory for downloading models are currently hardcoded.
It would be messy when we use a different name for repository directory.

To prevent this, these paths should be expressed as relative path.