### PR TITLE
Fix: AttributeError: module 'numpy' has no attribute 'float' (leres)

### DIFF
--- a/annotator/leres/leres/depthmap.py
+++ b/annotator/leres/leres/depthmap.py
@@ -99,10 +99,10 @@ def calculateprocessingres(img, basesize, confidence=0.1, scale_threshold=3, who
     grad[grad >= middle] = 1
 
     # dilation kernel with size of the receptive field
-    kernel = np.ones((int(basesize/speed_scale), int(basesize/speed_scale)), np.float)
+    kernel = np.ones((int(basesize/speed_scale), int(basesize/speed_scale)), float)
     # dilation kernel with size of the a quarter of receptive field used to compute k
     # as described in section 6 of main paper
-    kernel2 = np.ones((int(basesize / (4*speed_scale)), int(basesize / (4*speed_scale))), np.float)
+    kernel2 = np.ones((int(basesize / (4*speed_scale)), int(basesize / (4*speed_scale))), float)
 
     # Output resolution limit set by the whole_size_threshold and scale_threshold.
     threshold = min(whole_size_threshold, scale_threshold * max(img.shape[:2]))


### PR DESCRIPTION
I'm not sure what versions of numpy everyone has, but as 1.19.5 wouldn't install for python 3.10 I figured this should be ok?
```
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```