### PR TITLE
Improvement of xyz_grid_support.py

### DIFF
--- a/scripts/xyz_grid_support.py
+++ b/scripts/xyz_grid_support.py
@@ -11,12 +11,60 @@ def find_xyz_grid():
 
 
 def add_axis_options(xyz_grid):
+    class AxisOption(xyz_grid.AxisOption):
+        """This class returns an instance of the xyz_grid.AxisOption class.
+
+        If clone is not specified, a single instance is returned.
+        If clone is True, the number of copies is
+        obtained from control_net_max_models_num and a list is returned.
+        If clone is an integer greater than 1,
+        that number of copies is made and returned as a list.
+        """
+        def __new__(cls, *args, clone=None, **kwargs):
+            def init():
+                # Compatible with older WebUI
+                try:
+                    cls.__init__(this, *args, **kwargs)
+                except:
+                    kwargs.pop("choices", None)
+                    cls.__init__(this, *args, **kwargs)
+
+            if clone:
+                this = super().__new__(cls)
+                init()
+                return this._clone(clone)
+            else:
+                this = super().__new__(xyz_grid.AxisOption)
+                init()
+                return this
+
+        def _clone(self, num=True):
+            if num is True:
+                num = shared.opts.data.get("control_net_max_models_num", 1)
+
+            def copy():
+                return self.__class__(**self.__dict__)
+
+            instance_list = [copy()]
+
+            for i in range(1, num):
+                instance = copy()
+                instance.label = f"{self.label} - {i}"
+
+                apply_func = self.apply.__kwdefaults__["enclosure"]
+                apply_arg = f"{self.apply.__kwdefaults__['field']}_{i}"
+                instance.apply = apply_func(apply_arg)
+
+                instance_list.append(instance)
+
+            return instance_list
+
     def enable_control_net(p):
         shared.opts.data["control_net_allow_script_control"] = True
         setattr(p, "control_net_enabled", True)
 
     def apply_field(field):
-        def core(p, x, xs):
+        def core(p, x, xs, *, field=field, enclosure=apply_field):
             enable_control_net(p)
             setattr(p, field, x)
 
@@ -51,14 +99,14 @@ def add_axis_options(xyz_grid):
                 raise RuntimeError(f"Unknown Preprocessor: {x}")
 
     extra_axis_options = [
-        xyz_grid.AxisOption("[ControlNet] Model", str, apply_field("control_net_model"), choices=choices_model, confirm=confirm_model, cost=0.9),
-        xyz_grid.AxisOption("[ControlNet] Weight", float, apply_field("control_net_weight")),
-        xyz_grid.AxisOption("[ControlNet] Guidance Strength", float, apply_field("control_net_guidance_strength")),
-        xyz_grid.AxisOption("[ControlNet] Resize Mode", str, apply_field("control_net_resize_mode"), choices=choices_resize_mode),
-        xyz_grid.AxisOption("[ControlNet] Preprocessor", str, apply_field("control_net_module"), choices=choices_preprocessor, confirm=confirm_preprocessor),
-        xyz_grid.AxisOption("[ControlNet] Pre Resolution", int, apply_field("control_net_pres")),
-        xyz_grid.AxisOption("[ControlNet] Pre Threshold A", float, apply_field("control_net_pthr_a")),
-        xyz_grid.AxisOption("[ControlNet] Pre Threshold B", float, apply_field("control_net_pthr_b")),
+        AxisOption("[ControlNet] Model", str, apply_field("control_net_model"), choices=choices_model, confirm=confirm_model, cost=0.9),
+        AxisOption("[ControlNet] Weight", float, apply_field("control_net_weight")),
+        AxisOption("[ControlNet] Guidance Strength", float, apply_field("control_net_guidance_strength")),
+        AxisOption("[ControlNet] Resize Mode", str, apply_field("control_net_resize_mode"), choices=choices_resize_mode, confirm=confirm_resize_mode),
+        AxisOption("[ControlNet] Preprocessor", str, apply_field("control_net_module"), choices=choices_preprocessor, confirm=confirm_preprocessor),
+        AxisOption("[ControlNet] Pre Resolution", int, apply_field("control_net_pres")),
+        AxisOption("[ControlNet] Pre Threshold A", float, apply_field("control_net_pthr_a")),
+        AxisOption("[ControlNet] Pre Threshold B", float, apply_field("control_net_pthr_b")),
     ]
 
     xyz_grid.axis_options.extend(extra_axis_options)


### PR DESCRIPTION
### Fixed error with the 'choices' keyword argument
not sure if it's effective🤔
### Added confirm to Resize Mode
forgot to include it😅
### Other changes
I've made some modifications so that it's easier to add new items to the list. By changing the 'AxisOption(foo)' notation in extra_axis_options list to '*AxisOption(foo, clone=True)', new items will be replicated based on the control_net_max_models_num. However, changes to controlnet.py are required to make these replicated items work.