### PR TITLE
fix(uniformer) fix model loading path

### DIFF
--- a/annotator/uniformer/__init__.py
+++ b/annotator/uniformer/__init__.py
@@ -27,7 +27,7 @@ def apply_uniformer(img):
             from basicsr.utils.download_util import load_file_from_url
             load_file_from_url(checkpoint_file, model_dir=modeldir)
             
-        model = init_segmentor(config_file, checkpoint_file)
+        model = init_segmentor(config_file, modelpath)
     model = model.to(devices.get_device_for("controlnet"))
     
     if devices.get_device_for("controlnet").type == 'mps':


### PR DESCRIPTION
Currently, the segmentation preprocessor `upernet_global_small.pth` will be downloaded twice, once by [uniformer/\_\_init\_\_.py#L28](https://github.com/Mikubill/sd-webui-controlnet/blob/d45736038601bf80528d26c7c9dd3ceea13c6842/annotator/uniformer/__init__.py#L28), once by [uniformer/\_\_init\_\_.py#L30](https://github.com/Mikubill/sd-webui-controlnet/blob/d45736038601bf80528d26c7c9dd3ceea13c6842/annotator/uniformer/__init__.py#L30). The one downloaded by L28 was not used.