### PR TITLE
fix: calculate size to fit output image

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -582,11 +582,19 @@ class Script(scripts.Script):
             
             control = rearrange(control, 'h w c -> c h w')
             detected_map = rearrange(torch.from_numpy(detected_map), 'h w c -> c h w')
+
+            _, old_h, old_w = detected_map.shape
+
             if resize_mode == "Scale to Fit (Inner Fit)":
+                if old_h / old_w > h / w:
+                    scale = h / old_h
+                else:
+                    scale = w / old_w
+
                 transform = Compose([
-                    Resize(h if h<w else w, interpolation=InterpolationMode.BICUBIC),
+                    Resize(int(old_h*scale) if old_h < old_w else int(old_w *scale), interpolation=InterpolationMode.BICUBIC),
                     CenterCrop(size=(h, w))
-                ]) 
+                ])
                 control = transform(control)
                 detected_map = transform(detected_map)
             elif resize_mode == "Envelope (Outer Fit)":


### PR DESCRIPTION
It is incorrect to scale to fit image. I add more calculations to fix it

|   Input Image  | Output Size    |  Output: AS-IS |  Output: TO-BE |
| :-----| ----: | :----: | :----: |
|  192x264 ![download](https://user-images.githubusercontent.com/18410894/221294989-c3f5a204-d53c-4cb1-81c5-bc2a89b568f3.jpg) | 192x264 | ![00127-1486389336](https://user-images.githubusercontent.com/18410894/221295346-8f74b42b-61a2-4987-b48c-42bf5294a980.png) | ![00131-1486389336](https://user-images.githubusercontent.com/18410894/221296236-7dec15b7-d0a1-4438-860a-fd3dfa63d5c8.png)
| 192x264 ![download](https://user-images.githubusercontent.com/18410894/221294989-c3f5a204-d53c-4cb1-81c5-bc2a89b568f3.jpg) | 264x192 |  ![00119-1486389336](https://user-images.githubusercontent.com/18410894/221295428-9920b7ba-2122-4b1a-adf9-5c5b7743224f.png) | ![00121-1486389336](https://user-images.githubusercontent.com/18410894/221295459-e7b8fad7-67bd-465b-baa9-963b39a69041.png)|