### PR TITLE
don't skip img2img when ControlNet is disabled

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -651,7 +651,7 @@ class Script(scripts.Script):
         self.latest_network.notify(forward_params, p.sampler_name in ["DDIM", "PLMS"])
         self.detected_map = detected_maps
             
-        if shared.opts.data.get("control_net_skip_img2img_processing") and hasattr(p, "init_images"):
+        if enabled and shared.opts.data.get("control_net_skip_img2img_processing") and hasattr(p, "init_images"):
             swap_img2img_pipeline(p)
 
     def postprocess(self, p, processed, *args):

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -651,7 +651,7 @@ class Script(scripts.Script):
         self.latest_network.notify(forward_params, p.sampler_name in ["DDIM", "PLMS"])
         self.detected_map = detected_maps
             
-        if enabled and shared.opts.data.get("control_net_skip_img2img_processing") and hasattr(p, "init_images"):
+        if len(control_groups) > 0 and shared.opts.data.get("control_net_skip_img2img_processing") and hasattr(p, "init_images"):
             swap_img2img_pipeline(p)
 
     def postprocess(self, p, processed, *args):


### PR DESCRIPTION
Fixed `Skip img2img processing when using img2img initial image` skipping img2img even when ControlNet is disabled.