### PR TITLE
Controlnet batch support

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -574,7 +574,11 @@ class Script(scripts.Script):
             networks.append(model_net)
             self.model_cache[model] = model_net
 
-            if input_image is not None:
+            is_api = getattr(p, 'control_net_api_access', False)
+            is_img2img_batch_tab = not is_api and is_img2img and img2img_tab_tracker.submit_img2img_tab == 'img2img_batch_tab'
+            if is_img2img_batch_tab and p.image_control is not None:
+                input_image = p.image_control 
+            elif input_image is not None:
                 input_image = HWC3(np.asarray(input_image))
             elif image is not None:
                 input_image = HWC3(image['image'])

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -576,8 +576,8 @@ class Script(scripts.Script):
 
             is_api = getattr(p, 'control_net_api_access', False)
             is_img2img_batch_tab = not is_api and is_img2img and img2img_tab_tracker.submit_img2img_tab == 'img2img_batch_tab'
-            if is_img2img_batch_tab and p.image_control is not None:
-                input_image = p.image_control 
+            if is_img2img_batch_tab and hasattr(p, "image_control") and p.image_control is not None:
+                input_image = HWC3(np.asarray(p.image_control)) 
             elif input_image is not None:
                 input_image = HWC3(np.asarray(input_image))
             elif image is not None:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Enable ControlNet extension batch support for control images.

**Additional notes and description of your changes**

Currently there's only batch support for inpainting masks. I simply adapted the following inpainting batch support pull request (https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7295/files), but for ControlNet control images instead.

This enables using 1 control image per 1 img2img input image, which helps to create videos combining different techniques, as can be seen here as a result of this technique with a live background and a live pianist I created using these changes: https://www.youtube.com/watch?v=ciMeSHmq0hg 

This change can only be usable after the following Pull Request is approved in AUTOMATIC1111/stable-diffusion-webui repository: https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/8125

**Environment this was tested in**

 - OS: Linux
 - Browser: chrome
 - Graphics card: NVIDIA RTX 3090 24GB

**Screenshots or videos of your changes**

The following changes were made in AUTOMATIC1111/stable-diffusion-webui, but I'll add the screenshot here for context too:

<img width="871" alt="Screen Shot 2023-02-25 at 22 28 19 1" src="https://user-images.githubusercontent.com/20116813/221388238-66bf1a3a-82ce-4935-8ff3-8c3f072603ea.png">
