### PR TITLE
Multiple control units in API

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -197,7 +197,7 @@ class Script(scripts.Script):
         self.latest_model_hash = ""
 
     def title(self):
-        return "ControlNet for generating"
+        return "ControlNet"
 
     def show(self, is_img2img):
         # if is_img2img:


### PR DESCRIPTION
I got arbitrary multi-controlnet processing units to work through the api. You can now even use a 100 processing units if you have the resources 😄
But I haven't implemented it in the img2img route yet, and some corner cases are not accounted for yet.

What I did here so far is, monkey patch the existing `/sdapi/v1/txt2img` to include an additional optional field `controlnet_units` that expects a list of control processing unit parameters. (which is mapped to the 14*n args packs the script expects as input)

<details><summary>Example request:</summary>
<p>

POST on route `/sdapi/v1/txt2img`:

```
{
  "enable_hr": false,
  "denoising_strength": 0,
  "firstphase_width": 0,
  "firstphase_height": 0,
  "hr_scale": 2,
  "hr_upscaler": "string",
  "hr_second_pass_steps": 0,
  "hr_resize_x": 0,
  "hr_resize_y": 0,
  "prompt": "",
  "styles": [],
  "seed": -1,
  "subseed": -1,
  "subseed_strength": 0,
  "seed_resize_from_h": -1,
  "seed_resize_from_w": -1,
  "sampler_name": "Euler",
  "batch_size": 1,
  "n_iter": 1,
  "steps": 50,
  "cfg_scale": 7,
  "width": 512,
  "height": 512,
  "restore_faces": false,
  "tiling": false,
  "negative_prompt": "",
  "eta": 0,
  "s_churn": 0,
  "s_tmax": 0,
  "s_tmin": 0,
  "s_noise": 1,
  "override_settings": {},
  "override_settings_restore_afterwards": true,
  "script_args": [],
  "sampler_index": "Euler",
  "controlnet_units": [
    {
      "input_image": "...", // <-
      "module": "depth",
      "model": "diff_control_sd15_depth_fp16 [978ef0a1]"
    },
    {
      "input_image": "...", // <-
      "module": "canny",
      "model": "diff_control_sd15_canny_fp16 [ea6e3b9c]"
    }
  ]
}
```

Response:

```json
{
  "images": [...], // <-
  "parameters": {
    "enable_hr": false,
    "denoising_strength": 0,
    "firstphase_width": 0,
    "firstphase_height": 0,
    "hr_scale": 2,
    "hr_upscaler": "string",
    "hr_second_pass_steps": 0,
    "hr_resize_x": 0,
    "hr_resize_y": 0,
    "prompt": "",
    "styles": [],
    "seed": -1,
    "subseed": -1,
    "subseed_strength": 0,
    "seed_resize_from_h": -1,
    "seed_resize_from_w": -1,
    "sampler_name": "Euler",
    "batch_size": 1,
    "n_iter": 1,
    "steps": 50,
    "cfg_scale": 7,
    "width": 512,
    "height": 512,
    "restore_faces": false,
    "tiling": false,
    "negative_prompt": "",
    "eta": 0,
    "s_churn": 0,
    "s_tmax": 0,
    "s_tmin": 0,
    "s_noise": 1,
    "override_settings": {},
    "override_settings_restore_afterwards": true,
    "script_args": [],
    "sampler_index": "Euler",
    "script_name": null,
    "controlnet_units": [
      {
        "input_image": "...", // <-
        "mask": "",
        "module": "depth",
        "model": "diff_control_sd15_depth_fp16 [978ef0a1]",
        "weight": 1,
        "resize_mode": "Scale to Fit (Inner Fit)",
        "lowvram": false,
        "processor_res": 64,
        "threshold_a": 64,
        "threshold_b": 64,
        "guidance": 1,
        "guessmode": true
      }
    ]
  },
  "info": "{\"prompt\": \"\", \"all_prompts\": [\"\"], \"negative_prompt\": \"\", \"all_negative_prompts\": [\"\"], \"seed\": 2134127272, \"all_seeds\": [2134127272], \"subseed\": 2639399611, \"all_subseeds\": [2639399611], \"subseed_strength\": 0.0, \"width\": 512, \"height\": 512, \"sampler_name\": \"Euler\", \"cfg_scale\": 7.0, \"steps\": 50, \"batch_size\": 1, \"restore_faces\": false, \"face_restoration_model\": null, \"sd_model_hash\": \"0fc198c490\", \"seed_resize_from_w\": -1, \"seed_resize_from_h\": -1, \"denoising_strength\": 0.0, \"extra_generation_params\": {\"ControlNet Enabled\": true, \"ControlNet Module\": \"depth\", \"ControlNet Model\": \"diff_control_sd15_depth_fp16 [978ef0a1]\", \"ControlNet Weight\": 1.0, \"ControlNet Guidance Strength\": 1.0}, \"index_of_first_image\": 0, \"infotexts\": [\"Steps: 50, Sampler: Euler, CFG scale: 7.0, Seed: 2134127272, Size: 512x512, Model hash: 0fc198c490, Seed resize from: -1x-1, Denoising strength: 0.0, ENSD: 31337, ControlNet Enabled: True, ControlNet Module: depth, ControlNet Model: diff_control_sd15_depth_fp16 [978ef0a1], ControlNet Weight: 1.0, ControlNet Guidance Strength: 1.0\"], \"styles\": [], \"job_timestamp\": \"20230225223609\", \"clip_skip\": 1, \"is_using_inpainting_conditioning\": false}"
}
```

</p>
</details>

A few questions I have:

- is monkey patching the existing webui routes a bad idea? is there a risk these routes get updated and the extension stops working because of that?

Updating the `/controlnet/*2img` routes by removing the spliced `controlnet_*` fields (except for `controlnet_units`) will break existing code. I think the best way to introduce this feature smoothly would be to deprecate the existing `control_*` fields with a warning and implement both the `controlnet_units` and `controlnet_*` fields simultaneously.

Closes #314 and #371