### PR TITLE
Added support for Multi-ControlNet (list notation).

### DIFF
--- a/scripts/xyz_grid_support.py
+++ b/scripts/xyz_grid_support.py
@@ -135,7 +135,7 @@ def add_axis_options(xyz_grid):
                     valslist[i] = sub_list + [None] * (max_length-len(sub_list))
 
         if not any(search_bracket(s) for s in valslist):  # There is no list inside
-            type_convert(valslist, type_func)  # Type conv
+            type_convert(valslist, type_func, allow_blank=True)  # Type conv
             return
         else:                            # There is a list inside
             fix(valslist, type_func)  # Fix & Type conv

--- a/scripts/xyz_grid_support.py
+++ b/scripts/xyz_grid_support.py
@@ -169,7 +169,7 @@ def add_axis_options(xyz_grid):
     def identity(x):
         return x
 
-    # The confirm_foo function defined in this module
+    # The confirm function defined in this module
     # enables list notation and performs type conversion.
     #
     # Example:
@@ -206,8 +206,9 @@ def add_axis_options(xyz_grid):
 
                 normalize_list(xs, valid_data["type"])
 
+                confirm_list = valid_data["element"]()
                 for x in flatten_list(xs):
-                    if x is not None and x not in valid_data["element"]():
+                    if x is not None and x not in confirm_list:
                         raise RuntimeError(f"Unknown {valid_data['label']}: {x}")
                 return
 

--- a/scripts/xyz_grid_support.py
+++ b/scripts/xyz_grid_support.py
@@ -35,11 +35,9 @@ def flatten_list(lst):
 def find_module(module_names):
     if isinstance(module_names, str):
         module_names = [s.strip() for s in module_names.split(",")]
-
     for data in scripts.scripts_data:
         if data.script_class.__module__ in module_names and hasattr(data, "module"):
             return data.module
-
     return None
 
 
@@ -263,9 +261,7 @@ def add_axis_options(xyz_grid):
 
 
 def run():
-    xyz_grid = find_module("xyz_grid.py, xy_grid.py")
-
-    if xyz_grid:
+    if xyz_grid := find_module("xyz_grid.py, xy_grid.py"):
         add_axis_options(xyz_grid)
 
 

--- a/scripts/xyz_grid_support.py
+++ b/scripts/xyz_grid_support.py
@@ -1,5 +1,23 @@
+import re
+
 from modules import scripts, shared
-from scripts import controlnet
+
+try:
+    from scripts import controlnet
+except ImportError:
+    import_error = True
+else:
+    import_error = False
+
+DEBUG_MODE = False
+
+
+def debug_info(func):
+    def debug_info_(*args, **kwargs):
+        if DEBUG_MODE:
+            print(f"Debug info: {func.__name__}, {args}")
+        return func(*args, **kwargs)
+    return debug_info_
 
 
 def find_xyz_grid():
@@ -11,6 +29,7 @@ def find_xyz_grid():
 
 
 def add_axis_options(xyz_grid):
+    # This class is currently meaningless.
     class AxisOption(xyz_grid.AxisOption):
         """This class returns an instance of the xyz_grid.AxisOption class.
 
@@ -21,99 +40,235 @@ def add_axis_options(xyz_grid):
         that number of copies is made and returned as a list.
         """
         def __new__(cls, *args, clone=None, **kwargs):
-            def init():
-                # Compatible with older WebUI
-                try:
-                    cls.__init__(this, *args, **kwargs)
-                except:
-                    kwargs.pop("choices", None)
-                    cls.__init__(this, *args, **kwargs)
-
+            def init(this):
+                cls.__init__(this, *args, **kwargs)
             if clone:
                 this = super().__new__(cls)
-                init()
+                init(this)
                 return this._clone(clone)
             else:
                 this = super().__new__(xyz_grid.AxisOption)
-                init()
+                init(this)
                 return this
 
         def _clone(self, num=True):
+            def copy(self):
+                return self.__class__(**self.__dict__)
             if num is True:
                 num = shared.opts.data.get("control_net_max_models_num", 1)
 
-            def copy():
-                return self.__class__(**self.__dict__)
-
-            instance_list = [copy()]
-
+            instance_list = [copy(self)]
             for i in range(1, num):
-                instance = copy()
+                instance = copy(self)
                 instance.label = f"{self.label} - {i}"
-
                 apply_func = self.apply.__kwdefaults__["enclosure"]
                 apply_arg = f"{self.apply.__kwdefaults__['field']}_{i}"
                 instance.apply = apply_func(apply_arg)
-
                 instance_list.append(instance)
 
             return instance_list
 
-    def enable_control_net(p):
+    def normalize_list(valslist, type_func=None):
+        """This function restores a broken list caused by the following process
+        in the xyz_grid module.
+            -> valslist = [x.strip() for x in chain.from_iterable(
+                                                csv.reader(StringIO(vals)))]
+        It also performs type conversion,
+        adjusts the number of elements in the list, and other operations.
+        """
+        def search_bracket(string, bracket="[", replace=None):
+            if bracket == "[":
+                pattern = r"^\[(?![a-z0-9]{8}\])"
+            elif bracket == "]":
+                pattern = r"(?<!\[[a-z0-9]{8})\]$"
+            else:
+                raise ValueError(f"Invalid argument provided. (bracket: {bracket})")
+
+            if replace is None:
+                return re.search(pattern, string)
+            else:
+                return re.sub(pattern, replace, string)
+
+        def type_convert(valslist, type_func, allow_blank=False):
+            valslist_copy = valslist.copy()
+            valslist.clear()
+            for s in valslist_copy:
+                if allow_blank and (s is None or s in ["None", ""]):
+                    valslist.append(None)
+                elif type_func:
+                    valslist.append(type_func(s))
+                else:
+                    valslist.append(s)
+
+        def fix(valslist, type_func):
+            def is_same_length(list1, list2):
+                return len(list1) == len(list2)
+
+            fixing_list = []
+            start_indices = []
+            end_indices = []
+            for i, s in enumerate(valslist):
+                if is_same_length(start_indices, end_indices):
+                    if search_bracket(s, "["):
+                        s = search_bracket(s, "[", replace="")
+                        start_indices.append(i)
+                if not is_same_length(start_indices, end_indices):
+                    if search_bracket(s, "]"):
+                        s = search_bracket(s, "]", replace="")
+                        end_indices.append(i + 1)
+                fixing_list.append(s)
+
+            if not is_same_length(start_indices, end_indices):
+                raise ValueError(f"Lengths of {start_indices} and {end_indices} are different.")
+
+            valslist[:] = fixing_list
+            type_convert(valslist, type_func, allow_blank=True)
+
+            # Restore the structure of a list.
+            for i, j in zip(reversed(start_indices), reversed(end_indices)):
+                valslist[i:j] = [valslist[i:j]]
+
+        def padding(valslist):
+            max_length = max(len(sub_list) for sub_list in valslist if isinstance(sub_list, list))
+            for i, sub_list in enumerate(valslist):
+                if isinstance(sub_list, list):
+                    valslist[i] = sub_list + [None] * (max_length-len(sub_list))
+
+        if not any(search_bracket(s) for s in valslist):  # There is no list inside
+            type_convert(valslist, type_func)  # Type conv
+            return
+        else:                            # There is a list inside
+            fix(valslist, type_func)  # Fix & Type conv
+            padding(valslist)  # Fill sublist with None
+            return
+
+    ################################################
+    ################################################
+    #
+    # Define a function to pass to the AxisOption class from here.
+    #
+    ################################################
+    ################################################
+
+    # Set this function as the type attribute of the AxisOption class.
+    # To skip the following processing of xyz_grid module.
+    #   -> valslist = [opt.type(x) for x in valslist]
+    # Perform type conversion using the function
+    # set to the confirm attribute instead.
+    def identity(x):
+        return x
+
+    # The confirm_foo function defined in this module
+    # enables list notation and performs type conversion.
+    #
+    # Example:
+    #     any = [any, any, any, ...]
+    #     [any] = [any, None, None, ...]
+    #     [None, None, any] = [None, None, any]
+    #     [,,any] = [None, None, any]
+    #     any, [,any,] = [any, any, any, ...], [None, any, None]
+    #
+    #     Enabled Only:
+    #         any = [any] = [any, None, None, ...]
+    #         (any and [any] are considered equivalent)
+    def bool_(string):
+        string = str(string)
+        if string in ["None", ""]:
+            return None
+        elif string.lower() in ["true", "1"]:
+            return True
+        elif string.lower() in ["false", "0"]:
+            return False
+        else:
+            raise ValueError(f"invalid literal for to_bool(): {string}")
+
+    def confirm(func_or_str):
+        def find_dict(dict_name):
+            return next((d for d in validation_data if d["name"] == dict_name), None)
+
+        def flatten_list(lst):
+            for element in lst:
+                if isinstance(element, list):
+                    yield from flatten_list(element)
+                else:
+                    yield element
+
+        @debug_info
+        def confirm_(p, xs):
+            if callable(func_or_str):  # func_or_str is type_func
+                normalize_list(xs, func_or_str)
+                return
+
+            elif isinstance(func_or_str, str):  # func_or_str is dict_name
+                valid_data = find_dict(func_or_str)
+                if valid_data is None:
+                    return
+
+                normalize_list(xs, valid_data["type"])
+
+                valslist_flat = list(flatten_list(xs))
+                for x in valslist_flat:
+                    if x is not None and x not in valid_data["element"]:
+                        raise RuntimeError(f"Unknown {valid_data['label']}: {x}")
+                return
+
+            else:
+                return
+
+        return confirm_
+
+    def enable_script_control():
         shared.opts.data["control_net_allow_script_control"] = True
-        setattr(p, "control_net_enabled", True)
 
     def apply_field(field):
-        def core(p, x, xs, *, field=field, enclosure=apply_field):
-            enable_control_net(p)
+        @debug_info
+        def apply_field_(p, x, xs, *, field=field, enclosure=apply_field):
+            enable_script_control()
             setattr(p, field, x)
 
-        return core
+        return apply_field_
+
+    def choices_bool():
+        return ["False", "True"]
 
     def choices_model():
         controlnet.update_cn_models()
         return list(controlnet.cn_models_names.values())
 
-    def confirm_model(p, xs):
-        confirm_list = choices_model()
-        for x in xs:
-            if x not in confirm_list:
-                raise RuntimeError(f"Unknown ControlNet Model: {x}")
+    def choices_preprocessor():
+        return list(controlnet.Script().preprocessor)
 
     def choices_resize_mode():
         return ["Envelope (Outer Fit)", "Scale to Fit (Inner Fit)", "Just Resize"]
 
-    def confirm_resize_mode(p, xs):
-        confirm_list = choices_resize_mode()
-        for x in xs:
-            if x not in confirm_list:
-                raise RuntimeError(f"Unknown Resize Mode: {x}")
-
-    def choices_preprocessor():
-        return list(controlnet.Script().preprocessor)
-
-    def confirm_preprocessor(p, xs):
-        confirm_list = choices_preprocessor()
-        for x in xs:
-            if x not in confirm_list:
-                raise RuntimeError(f"Unknown Preprocessor: {x}")
+    validation_data = [
+        {"name": "model", "type": str, "element": choices_model(), "label": "ControlNet Model"},
+        {"name": "preprocessor", "type": str, "element": choices_preprocessor(), "label": "Preprocessor"},
+        {"name": "resize_mode", "type": str, "element": choices_resize_mode(), "label": "Resize Mode"},
+    ]
 
     extra_axis_options = [
-        AxisOption("[ControlNet] Model", str, apply_field("control_net_model"), choices=choices_model, confirm=confirm_model, cost=0.9),
-        AxisOption("[ControlNet] Weight", float, apply_field("control_net_weight")),
-        AxisOption("[ControlNet] Guidance Start", float, apply_field("control_net_guidance_start")),
-        AxisOption("[ControlNet] Guidance End", float, apply_field("control_net_guidance_end")),
-        AxisOption("[ControlNet] Resize Mode", str, apply_field("control_net_resize_mode"), choices=choices_resize_mode, confirm=confirm_resize_mode),
-        AxisOption("[ControlNet] Preprocessor", str, apply_field("control_net_module"), choices=choices_preprocessor, confirm=confirm_preprocessor),
-        AxisOption("[ControlNet] Pre Resolution", int, apply_field("control_net_pres")),
-        AxisOption("[ControlNet] Pre Threshold A", float, apply_field("control_net_pthr_a")),
-        AxisOption("[ControlNet] Pre Threshold B", float, apply_field("control_net_pthr_b")),
+        AxisOption("[ControlNet] Enabled", identity, apply_field("control_net_enabled"), confirm=confirm(bool_), choices=choices_bool),
+        AxisOption("[ControlNet] Model", identity, apply_field("control_net_model"), confirm=confirm("model"), choices=choices_model, cost=0.9),
+        AxisOption("[ControlNet] Weight", identity, apply_field("control_net_weight"), confirm=confirm(float)),
+        AxisOption("[ControlNet] Guidance Start", identity, apply_field("control_net_guidance_start"), confirm=confirm(float)),
+        AxisOption("[ControlNet] Guidance End", identity, apply_field("control_net_guidance_end"), confirm=confirm(float)),
+        AxisOption("[ControlNet] Resize Mode", identity, apply_field("control_net_resize_mode"), confirm=confirm("resize_mode"), choices=choices_resize_mode),
+        AxisOption("[ControlNet] Preprocessor", identity, apply_field("control_net_module"), confirm=confirm("preprocessor"), choices=choices_preprocessor),
+        AxisOption("[ControlNet] Pre Resolution", identity, apply_field("control_net_pres"), confirm=confirm(int)),
+        AxisOption("[ControlNet] Pre Threshold A", identity, apply_field("control_net_pthr_a"), confirm=confirm(float)),
+        AxisOption("[ControlNet] Pre Threshold B", identity, apply_field("control_net_pthr_b"), confirm=confirm(float)),
     ]
 
     xyz_grid.axis_options.extend(extra_axis_options)
 
 
-xyz_grid = find_xyz_grid()
+def run():
+    xyz_grid = find_xyz_grid()
 
-if xyz_grid:
-    add_axis_options(xyz_grid)
+    if xyz_grid:
+        add_axis_options(xyz_grid)
+
+
+if not import_error:
+    run()


### PR DESCRIPTION
### Example:
- any = [any, any, any, ...]
- [any] = [any, None, None, ...]
- [None, None, any] = [None, None, any]
- [,,any] = [None, None, any]
- any, [,any,] = [any, any, any, ...], [None, any, None]

> Enabled Only:

- any = [any] = [any, None, None, ...]

### Note:

- Whitespace characters are replaced with None.
- The configuration values that correspond to the None index are used from GradioUI.
- There is a difference in behavior between 'Enabled' items and non-'Enabled' items when using 'any' (not in a list).
- Using [] in the filename will cause it to malfunction. Only the [hash value] is allowed.
