### PR TITLE
static models cache

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -178,15 +178,14 @@ def create_cn_script_runner(script_runner, control_unit_requests: List[ControlNe
 
     cn_script_runner = copy.copy(script_runner)
 
-    cn_script_args = [False]  # is_img2img
+    cn_script_args: List[Any] = [False]  # is_img2img
     for control_unit_request in control_unit_requests:
         cn_script_args += create_cn_unit_args(control_unit_request)
 
     script_titles = [script.title().lower() for script in script_runner.alwayson_scripts]
     cn_script_id = script_titles.index('controlnet')
-    cn_script = copy.copy(script_runner.alwayson_scripts[cn_script_id])
-    cn_script.args_from = 0
-    cn_script.args_to = len(cn_script_args)
+    cn_script = script_runner.alwayson_scripts[cn_script_id]
+    cn_script_args = ([None] * cn_script.args_from) + cn_script_args
 
     def make_script_runner_f_hijack(fixed_original_f):
         def script_runner_f_hijack(p, *args, **kwargs):

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -167,10 +167,13 @@ def update_cn_models():
 update_cn_models()
 
 
+
+
 class Script(scripts.Script):
+    model_cache = {}
+
     def __init__(self) -> None:
         super().__init__()
-        self.model_cache = {}
         self.latest_network = None
         self.preprocessor = {
             "none": lambda x, *args, **kwargs: x,
@@ -583,15 +586,14 @@ class Script(scripts.Script):
         hook_lowvram = False
         
         # cache stuff
-        models_changed = self.latest_model_hash != p.sd_model.sd_model_hash or self.model_cache == {} or self.model_cache is None
-        if models_changed or len(self.model_cache) >= shared.opts.data.get("control_net_model_cache_size", 2):
-            for key, model in self.model_cache.items():
+        models_changed = self.latest_model_hash != p.sd_model.sd_model_hash or not Script.model_cache or Script.model_cache is None
+        if models_changed or len(Script.model_cache) >= shared.opts.data.get("control_net_model_cache_size", 2):
+            for key, model in Script.model_cache.items():
                 model.to("cpu")
-            del self.model_cache
+            Script.model_cache.clear()
             gc.collect()
             devices.torch_gc()
-            self.model_cache = {}
-            
+
         # unload unused preproc
         module_list = [mod[0] for mod in control_groups]
         for key in self.unloadable:
@@ -608,12 +610,12 @@ class Script(scripts.Script):
             if lowvram:
                 hook_lowvram = True
                 
-            model_net = self.model_cache[model] if model in self.model_cache \
+            model_net = Script.model_cache[model] if model in Script.model_cache \
                 else self.build_control_model(p, unet, model, lowvram) 
  
             model_net.reset()
             networks.append(model_net)
-            self.model_cache[model] = model_net
+            Script.model_cache[model] = model_net
             
             is_img2img_batch_tab = is_img2img and img2img_tab_tracker.submit_img2img_tab == 'img2img_batch_tab'
             if is_img2img_batch_tab and hasattr(p, "image_control") and p.image_control is not None:


### PR DESCRIPTION
Puts the models cache into a static variable. Could move it to globals too. It may also fix img2img and txt2img not having the same models cache.

closes #429