### PR TITLE
Updated path mechanism for movie2movie to fix FileNotFoundError

### DIFF
--- a/scripts/movie2movie.py
+++ b/scripts/movie2movie.py
@@ -45,14 +45,12 @@ def save_gif(path, image_list, name, duration):
     if os.path.isdir(tmp_dir):
         shutil.rmtree(tmp_dir)
     os.mkdir(tmp_dir)
-    imgs = []
     for i, image in enumerate(image_list):
         images.save_image(image, tmp_dir, f"output_{i}")
-        imgs.append(image)
 
     os.makedirs(path + "/controlnet-m2m", exist_ok=True)
 
-    imgs[0].save(path + f"/controlnet-m2m/{name}.gif", save_all=True, append_images=imgs[1:], optimize=False, duration=duration, loop=0)
+    image_list[0].save(path + f"/controlnet-m2m/{name}.gif", save_all=True, append_images=image_list[1:], optimize=False, duration=duration, loop=0)
     
 
 class Script(scripts.Script):  

--- a/scripts/movie2movie.py
+++ b/scripts/movie2movie.py
@@ -45,16 +45,14 @@ def save_gif(path, image_list, name, duration):
     if os.path.isdir(tmp_dir):
         shutil.rmtree(tmp_dir)
     os.mkdir(tmp_dir)
-    path_list = []
     imgs = []
     for i, image in enumerate(image_list):
         images.save_image(image, tmp_dir, f"output_{i}")
-        path_list.append(tmp_dir + f"output_{i}-0000.png")
-    for i in range(len(path_list)):
-        img = Image.open(path_list[i])
-        imgs.append(img)
+        imgs.append(image)
 
-    imgs[0].save(path + f"/{name}.gif", save_all=True, append_images=imgs[1:], optimize=False, duration=duration, loop=0)
+    os.makedirs(path + "/controlnet-m2m", exist_ok=True)
+
+    imgs[0].save(path + f"/controlnet-m2m/{name}.gif", save_all=True, append_images=imgs[1:], optimize=False, duration=duration, loop=0)
     
 
 class Script(scripts.Script):  
@@ -93,7 +91,6 @@ class Script(scripts.Script):
         # Custom functions can be defined here, and additional libraries can be imported 
         # to be used in processing. The return value should be a Processed object, which is
         # what is returned by the process_images method.
-
         video_num = opts.data.get("control_net_max_models_num", 1)
         video_list = [get_all_frames(video) for video in args[:video_num]]
         duration, = args[video_num:]
@@ -112,8 +109,9 @@ class Script(scripts.Script):
                 img = proc.images[0]
                 output_image_list.append(img)
                 copy_p.close()
+            # TODO: Generate new name for each movie2movie output
             save_gif(p.outpath_samples, output_image_list, "animation", duration)
-            proc.images = [p.outpath_samples + "/animation.gif"]
+            proc.images = [p.outpath_samples + "/controlnet-m2m/animation.gif"]
 
         else:
             proc = process_images(p)


### PR DESCRIPTION
# Issue
- Currently using movie2movie script fails to create gif after successfully generating all the images.
- This issue is caused by wrong path generation in `save_gif` method.
- It seems to be skipping the `date` directory from the output as shown in following image
![movie2movie_issue](https://user-images.githubusercontent.com/63447220/222947780-253d05c5-c3ca-4d54-b5d4-fb145112c3bd.png)

# Fix
- We can change the logic in save_gif method to not be dependent on path anymore.
- We can skip the `path_list` and `imgs` variables and use `image_list` directly for saving images and also generating gifs.

# Additional changes
- Currently it saves animation.gif in the `txt2img-images` folder directly, I have updated it to be saved in the `txt2iimg-images/controlnet-m2m` folder.
- Added TODO for creating different names for each generation. Let me know if I should remove TODO or complete it.