### PR TITLE
No autosave if preprocessor is none

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -790,9 +790,10 @@ class Script(scripts.Script):
                 detectmap_dir = os.path.join(shared.opts.data.get("control_net_detectedmap_dir", False), module)
                 if not os.path.isabs(detectmap_dir):
                     detectmap_dir = os.path.join(p.outpath_samples, detectmap_dir)
-                os.makedirs(detectmap_dir, exist_ok=True)
-                img = Image.fromarray(detect_map)
-                save_image(img, detectmap_dir, module)
+                if module != "none":
+                    os.makedirs(detectmap_dir, exist_ok=True)
+                    img = Image.fromarray(detect_map)
+                    save_image(img, detectmap_dir, module)
 
         is_img2img_batch_tab = is_img2img and img2img_tab_tracker.submit_img2img_tab == 'img2img_batch_tab'
         no_detectmap_opt = shared.opts.data.get("control_net_no_detectmap", False)


### PR DESCRIPTION
To solve the problem I described in this question: https://github.com/Mikubill/sd-webui-controlnet/discussions/482

When the option "detect map auto-saving" is activated, it saves the maps generated by the pre-processor in the folder detected_map with the corresponding model name.

When the preprocessor is set to none, ControlNet creates a folder none and keeps copying map provided to the extension in this folder. There is no sense to save those maps.

The typical workflow is to generate a map one time providing an image. And then load this map and set the pre-processor to none. With my fix, no none folder and new image files will be generated at each generation.