### PR TITLE
refactor: delete flatten_list, using itertools

### DIFF
--- a/scripts/xyz_grid_support.py
+++ b/scripts/xyz_grid_support.py
@@ -1,5 +1,6 @@
 import re
 import numpy as np
+import itertools
 
 from modules import scripts, shared
 
@@ -29,18 +30,9 @@ def find_dict(dict_list, keyword, search_key="name", stop=False):
         raise ValueError(f"Dictionary with value '{keyword}' in key '{search_key}' not found.")
 
 
-def flatten_list(lst):
-    result = []
-    for element in lst:
-        if isinstance(element, list):
-            result.extend(flatten_list(element))
-        else:
-            result.append(element)
-    return result
-
-
 def is_all_included(target_list, check_list, allow_blank=False, stop=False):
-    for element in flatten_list(target_list):
+    flatten_list = list(itertools.chain(target_list))
+    for element in flatten_list:
         if allow_blank and str(element) in ["None", ""]:
             continue
         elif element not in check_list:


### PR DESCRIPTION
A little refactor to simplify the xyz file. Instead of a function looping over a list to flatten it, I propose to use itertools.chain(). The code is shorter and faster.

Example:
```
import itertools
from time import perf_counter

my_list = [[1, 2, 3], [4, 5, 6], [7], [8, 9]]


def flatten_list(lst):
    result = []
    for element in lst:
        if isinstance(element, list):
            result.extend(flatten_list(element))
        else:
            result.append(element)
    return result


time_1 = perf_counter()
merged = list(itertools.chain(*my_list))
time_2 = perf_counter()

time_3 = perf_counter()
merged_2 = flatten_list(my_list)
time_4 = perf_counter()

print(merged)
print(time_2 - time_1)
print(merged_2)
print(time_4 - time_3)
```
output:

> [1, 2, 3, 4, 5, 6, 7, 8, 9]
> 2.200016751885414e-06
> [1, 2, 3, 4, 5, 6, 7, 8, 9]
> 3.200024366378784e-06

flatten_list was only used with string field like Resize Mode. So I tested it generating a x/y/z plot with values "Envelope (Outer Fit),Scale to Fit (Inner Fit)" and it worked like before.

I didn't find test to run in the code, so I don't know what other checks I can do.