### PR TITLE
Deprecate `/controlnet/*2img` web API in favor of new alwayson_scripts support

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -121,8 +121,12 @@ class ApiHijack(api.Api):
     def controlnet_any2img(self, any2img_request, original_callback, is_img2img):
         any2img_request = nest_deprecated_cn_fields(any2img_request)
         any2img_request.alwayson_scripts.update({'ControlNet': {'args': [is_img2img, False, *[to_api_cn_unit(unit) for unit in any2img_request.controlnet_units]]}})
+        controlnet_units = any2img_request.controlnet_units
         delattr(any2img_request, 'controlnet_units')
-        return original_callback(self, any2img_request)
+        result = original_callback(self, any2img_request)
+        result.parameters['controlnet_units'] = controlnet_units
+        result.parameters['alwayson_scripts'].clear()
+        return result
 
 api.Api = ApiHijack
 

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -120,7 +120,7 @@ class ApiHijack(api.Api):
 
     def controlnet_any2img(self, any2img_request, original_callback, is_img2img):
         any2img_request = nest_deprecated_cn_fields(any2img_request)
-        any2img_request.alwayson_scripts.update('ControlNet', {'args': [is_img2img, False, *[vars(unit) for unit in any2img_request.controlnet_units]]})
+        any2img_request.alwayson_scripts.update('ControlNet', {'args': [is_img2img, False, *[to_api_cn_unit(unit) for unit in any2img_request.controlnet_units]]})
         delattr(any2img_request, 'controlnet_units')
         return original_callback(self, any2img_request)
 

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -120,7 +120,7 @@ class ApiHijack(api.Api):
 
     def controlnet_any2img(self, any2img_request, original_callback, is_img2img):
         any2img_request = nest_deprecated_cn_fields(any2img_request)
-        any2img_request.alwayson_scripts.update('ControlNet', {'args': [is_img2img, False, *[to_api_cn_unit(unit) for unit in any2img_request.controlnet_units]]})
+        any2img_request.alwayson_scripts.update({'ControlNet': {'args': [is_img2img, False, *[to_api_cn_unit(unit) for unit in any2img_request.controlnet_units]]}})
         delattr(any2img_request, 'controlnet_units')
         return original_callback(self, any2img_request)
 

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -120,12 +120,13 @@ class ApiHijack(api.Api):
 
     def controlnet_any2img(self, any2img_request, original_callback, is_img2img):
         any2img_request = nest_deprecated_cn_fields(any2img_request)
+        alwayson_scripts = dict(any2img_request.alwayson_scripts)
         any2img_request.alwayson_scripts.update({'ControlNet': {'args': [is_img2img, False, *[to_api_cn_unit(unit) for unit in any2img_request.controlnet_units]]}})
         controlnet_units = any2img_request.controlnet_units
         delattr(any2img_request, 'controlnet_units')
         result = original_callback(self, any2img_request)
         result.parameters['controlnet_units'] = controlnet_units
-        result.parameters['alwayson_scripts'].clear()
+        result.parameters['alwayson_scripts'] = alwayson_scripts
         return result
 
 api.Api = ApiHijack

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -738,7 +738,7 @@ class Script(scripts.Script):
         units = []
         i = 0
         while i < len(args):
-            if type(args[0]) is bool:
+            if type(args[i]) is bool:
                 units.append(ControlNetUnit(*args[i:i + PARAM_COUNT]))
                 i += PARAM_COUNT
 

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -1,65 +1,13 @@
-from typing import List, Any, Optional, Union, Tuple, Dict
+from typing import List, Any, Optional
 from modules import scripts, processing, shared
-from scripts.controlnet import ResizeMode, update_cn_models, cn_models_names, PARAM_COUNT
-import numpy as np
+from scripts.controlnet import ControlNetUnit, ResizeMode, update_cn_models, cn_models_names, PARAM_COUNT
 
 
-"""
-Resize modes for ControlNet input images.
-"""
 ResizeMode = ResizeMode
 
 
-class ControlNetUnit:
-    """
-    Represents an entire ControlNet processing unit.
-    """
+ControlNetUnit = ControlNetUnit
 
-    def __init__(
-        self,
-        enabled: bool=True,
-        module: Optional[str]=None,
-        model: Optional[str]=None,
-        weight: float=1.0,
-        image: Optional[Union[Dict[str, np.ndarray], Tuple[np.ndarray, np.ndarray], np.ndarray]]=None,
-        invert_image: bool=False,
-        resize_mode: Union[ResizeMode, int, str]=ResizeMode.INNER_FIT,
-        rgbbgr_mode: bool=False,
-        low_vram: bool=False,
-        processor_res: int=64,
-        threshold_a: float=64,
-        threshold_b: float=64,
-        guidance_start: float=0.0,
-        guidance_end: float=1.0,
-        guess_mode: bool=True,
-    ):
-        self.enabled = enabled
-        self.module = module
-        self.model = model
-        self.weight = weight
-        self.image = image
-        self.invert_image = invert_image
-        self.resize_mode = resize_mode
-        self.rgbbgr_mode = rgbbgr_mode
-        self.low_vram = low_vram
-        self.processor_res = processor_res
-        self.threshold_a = threshold_a
-        self.threshold_b = threshold_b
-        self.guidance_start = guidance_start
-        self.guidance_end = guidance_end
-        self.guess_mode = guess_mode
-
-    def get_image_dict(self) -> Dict[str, np.ndarray]:
-        image = self.image
-        if image is not None:
-            if isinstance(image, (tuple, list)):
-                image = {'image': image[0], 'mask': image[1]}
-            elif isinstance(image, np.ndarray):
-                image = {'image': image, 'mask': np.zeros_like(image, dtype=np.uint8)}
-
-            image = dict(image)
-
-        return image
 
 def get_all_units_in_processing(p: processing.StableDiffusionProcessing) -> List[ControlNetUnit]:
     """

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -1,12 +1,82 @@
-from typing import List, Any, Optional
+from enum import Enum
+from typing import List, Any, Optional, Union, Tuple, Dict
+import numpy as np
 from modules import scripts, processing, shared
-from scripts.controlnet import ControlNetUnit, ResizeMode, update_cn_models, cn_models_names, PARAM_COUNT
+from scripts.global_state import update_cn_models, cn_models_names
 
 
-ResizeMode = ResizeMode
+PARAM_COUNT = 15
 
 
-ControlNetUnit = ControlNetUnit
+class ResizeMode(Enum):
+    """
+    Resize modes for ControlNet input images.
+    """
+
+    RESIZE = "Just Resize"
+    INNER_FIT = "Scale to Fit (Inner Fit)"
+    OUTER_FIT = "Envelope (Outer Fit)"
+
+
+def resize_mode_from_value(value: Union[str, int, ResizeMode]) -> ResizeMode:
+    if isinstance(value, str):
+        return ResizeMode(value)
+    elif isinstance(value, int):
+        return [e for e in ResizeMode][value]
+    else:
+        return value
+
+
+class ControlNetUnit:
+    """
+    Represents an entire ControlNet processing unit.
+    """
+
+    def __init__(
+        self,
+        enabled: bool=True,
+        module: Optional[str]=None,
+        model: Optional[str]=None,
+        weight: float=1.0,
+        image: Optional[Union[Dict[str, np.ndarray], Tuple[np.ndarray, np.ndarray], np.ndarray]]=None,
+        invert_image: bool=False,
+        resize_mode: Union[ResizeMode, int, str]=ResizeMode.INNER_FIT,
+        rgbbgr_mode: bool=False,
+        low_vram: bool=False,
+        processor_res: int=64,
+        threshold_a: float=64,
+        threshold_b: float=64,
+        guidance_start: float=0.0,
+        guidance_end: float=1.0,
+        guess_mode: bool=True,
+    ):
+        self.enabled = enabled
+        self.module = module
+        self.model = model
+        self.weight = weight
+        self.image = image
+        self.invert_image = invert_image
+        self.resize_mode = resize_mode
+        self.rgbbgr_mode = rgbbgr_mode
+        self.low_vram = low_vram
+        self.processor_res = processor_res
+        self.threshold_a = threshold_a
+        self.threshold_b = threshold_b
+        self.guidance_start = guidance_start
+        self.guidance_end = guidance_end
+        self.guess_mode = guess_mode
+
+    def get_image_dict(self) -> Dict[str, np.ndarray]:
+        image = self.image
+        if image is not None:
+            if isinstance(image, (tuple, list)):
+                image = {'image': image[0], 'mask': image[1]}
+            elif isinstance(image, np.ndarray):
+                image = {'image': image, 'mask': np.zeros_like(image, dtype=np.uint8)}
+
+            image = dict(image)
+
+        return image
 
 
 def get_all_units_in_processing(p: processing.StableDiffusionProcessing) -> List[ControlNetUnit]:

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -1,0 +1,85 @@
+import os.path
+import stat
+from collections import OrderedDict
+
+from modules import shared, scripts, sd_models
+from modules.paths import models_path
+
+
+CN_MODEL_EXTS = [".pt", ".pth", ".ckpt", ".safetensors"]
+cn_models_dir = os.path.join(models_path, "ControlNet")
+cn_models_dir_old = os.path.join(scripts.basedir(), "models")
+cn_models = OrderedDict()      # "My_Lora(abcd1234)" -> C:/path/to/model.safetensors
+cn_models_names = {}  # "my_lora" -> "My_Lora(abcd1234)"
+
+default_conf = os.path.join("models", "cldm_v15.yaml")
+default_conf_adapter = os.path.join("models", "sketch_adapter_v14.yaml")
+cn_detectedmap_dir = os.path.join("detected_maps")
+default_detectedmap_dir = cn_detectedmap_dir
+script_dir = scripts.basedir()
+
+os.makedirs(cn_models_dir, exist_ok=True)
+os.makedirs(cn_detectedmap_dir, exist_ok=True)
+
+
+def traverse_all_files(curr_path, model_list):
+    f_list = [(os.path.join(curr_path, entry.name), entry.stat())
+              for entry in os.scandir(curr_path)]
+    for f_info in f_list:
+        fname, fstat = f_info
+        if os.path.splitext(fname)[1] in CN_MODEL_EXTS:
+            model_list.append(f_info)
+        elif stat.S_ISDIR(fstat.st_mode):
+            model_list = traverse_all_files(fname, model_list)
+    return model_list
+
+
+def get_all_models(sort_by, filter_by, path):
+    res = OrderedDict()
+    fileinfos = traverse_all_files(path, [])
+    filter_by = filter_by.strip(" ")
+    if len(filter_by) != 0:
+        fileinfos = [x for x in fileinfos if filter_by.lower()
+                     in os.path.basename(x[0]).lower()]
+    if sort_by == "name":
+        fileinfos = sorted(fileinfos, key=lambda x: os.path.basename(x[0]))
+    elif sort_by == "date":
+        fileinfos = sorted(fileinfos, key=lambda x: -x[1].st_mtime)
+    elif sort_by == "path name":
+        fileinfos = sorted(fileinfos)
+
+    for finfo in fileinfos:
+        filename = finfo[0]
+        name = os.path.splitext(os.path.basename(filename))[0]
+        # Prevent a hypothetical "None.pt" from being listed.
+        if name != "None":
+            res[name + f" [{sd_models.model_hash(filename)}]"] = filename
+
+    return res
+
+
+def update_cn_models():
+    cn_models.clear()
+    ext_dirs = (shared.opts.data.get("control_net_models_path", None), getattr(shared.cmd_opts, 'controlnet_dir', None))
+    extra_lora_paths = (extra_lora_path for extra_lora_path in ext_dirs
+                if extra_lora_path is not None and os.path.exists(extra_lora_path))
+    paths = [cn_models_dir, cn_models_dir_old, *extra_lora_paths]
+
+    for path in paths:
+        sort_by = shared.opts.data.get(
+            "control_net_models_sort_models_by", "name")
+        filter_by = shared.opts.data.get("control_net_models_name_filter", "")
+        found = get_all_models(sort_by, filter_by, path)
+        cn_models.update({**found, **cn_models})
+
+    # insert "None" at the beginning of `cn_models` in-place
+    cn_models_copy = OrderedDict(cn_models)
+    cn_models.clear()
+    cn_models.update({**{"None": None}, **cn_models_copy})
+
+    cn_models_names.clear()
+    for name_and_hash, filename in cn_models.items():
+        if filename is None:
+            continue
+        name = os.path.splitext(os.path.basename(filename))[0].lower()
+        cn_models_names[name] = name_and_hash


### PR DESCRIPTION
Closes #571, closes #567

This combines the 2 argument passing strategies we use in `processing` and `postprocessing` into a single strategy. (using an array of structures) I find that code readability increases with this.

As I am not sure whether this really is a good idea, I created a companion discussion: #528. This changes a lot of code, risks breaking something as there are no tests. Feel free to close if it is not welcome.