### PR TITLE
Use generated im

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import gc
 import os
 import stat
@@ -793,9 +792,9 @@ class Script(scripts.Script):
             if scribble_mode:
                 detected_map = np.zeros_like(input_image, dtype=np.uint8)
                 detected_map[np.min(input_image, axis=2) < 127] = 255
-                input_image = detected_map
-             
+                input_image = detected_map 
                 
+                            
             print(f"Loading preprocessor: {module}")
             preprocessor = self.preprocessor[module]
             h, w, bsz = p.height, p.width, p.batch_size


### PR DESCRIPTION
In response to enhancement request Mikubill/sd-webui-controlnet#549.

I started to add the feature. In txt2img, if you enable ControlNet without image, you check the box "use generated image", you input a prompt and control net will automatically create an image and use it to preprocess/process.

![Animation](https://user-images.githubusercontent.com/66461774/224426537-54be9b43-ae20-4db6-a1b1-2c53e48b2d4a.gif)

What is done so far:
- creation of a checkbox in `uigroup()`
- add an if statement in `process()`

I have to set p.scripts() to None otherwise in `processing.process_images_inner()`, with the check on p.scripts, it kept to sent it back to controlnet.py and I was stuck in an infinite loop.
I do a check on the seed to avoid creating the generated image several times in the case of multicontrolnet.

@djkacevedo , did I understand your request correctly?

Part I am unsure / to do work:

- the cache of models, I don't know how it works for the moment
- the conditions with img2img, if there is an image or not. Not sure at all the way I added mine do not create a bug
- how do you actually mix 2 control net images in txt2img tab? I am aware of the method in img2img, playing with the denoising strenght, not in txt2img