### PR TITLE
Add str check for image for API compatibility related to #567

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -748,8 +748,15 @@ class Script(scripts.Script):
             elif input_image is not None:
                 input_image = HWC3(np.asarray(input_image))
             elif image is not None:
-                input_image = HWC3(image['image'])
-                if not ((image['mask'][:, :, 0]==0).all() or (image['mask'][:, :, 0]==255).all()):
+                # Need to check the image for API compatibility
+                if isinstance(image['image'], str):
+                    from modules.api.api import decode_base64_to_image
+                    input_image = HWC3(np.asarray(decode_base64_to_image(image['image'])))
+                else:
+                    input_image = HWC3(image['image'])
+
+                # Adding 'mask' check for API compatibility
+                if 'mask' in image and not ((image['mask'][:, :, 0]==0).all() or (image['mask'][:, :, 0]==255).all()):
                     print("using mask as input")
                     input_image = HWC3(image['mask'][:, :, 0])
                     scribble_mode = True


### PR DESCRIPTION
More details regarding this PR is mentioned in #567.

# What has changed
- `scripts/controlnet.process` method has now check for image['image'] being str.
- We will convert it to the np.array if it is string using the `modules.api.api.decode_base64_to_image` method.

Fixes #567 