### PR TITLE
Fix/skip img2img

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -734,6 +734,10 @@ class Script(scripts.Script):
             enabled, module, model, weight, image, scribble_mode, \
                 resize_mode, rgbbgr_mode, lowvram, pres, pthr_a, pthr_b, guidance_start, guidance_end, guess_mode = params
 
+            if module.lower() == 'none':
+                print('No preprocessor selected, skipping ControlNet')
+                return
+
             resize_mode = resize_mode_from_value(resize_mode)
 
             if lowvram:
@@ -822,9 +826,6 @@ class Script(scripts.Script):
         self.latest_network.hook(unet)
         self.latest_network.notify(forward_params, p.sampler_name in ["DDIM", "PLMS"])
         self.detected_map = detected_maps
-            
-        if len(control_groups) > 0 and shared.opts.data.get("control_net_skip_img2img_processing") and hasattr(p, "init_images"):
-            swap_img2img_pipeline(p)
 
     def postprocess(self, p, processed, is_img2img=False, is_ui=False, *args):
         if shared.opts.data.get("control_net_detectmap_autosaving", False) and self.latest_network is not None:

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -738,9 +738,15 @@ class Script(scripts.Script):
 
             if lowvram:
                 hook_lowvram = True
-                
-            model_net = self.load_control_model(p, unet, model, lowvram)
-            model_net.reset()
+            
+            model_net = None
+            if (is_img2img and shared.opts.data.get("control_net_skip_img2img_processing")) or model is None or model.lower() == 'none':
+                # this will disable img2img processing
+                p.n_iter = 0
+                p.disable_extra_networks = True
+            else:
+                model_net = self.load_control_model(p, unet, model, lowvram)
+                model_net.reset()
 
             is_img2img_batch_tab = is_img2img and img2img_tab_tracker.submit_img2img_tab == 'img2img_batch_tab'
             if is_img2img_batch_tab and hasattr(p, "image_control") and p.image_control is not None:


### PR DESCRIPTION
In settings there's a skip_img2img option but it does not work at all.

This patch makes some small changes:
- Skip img2img when the setting is enabled
  - Also skip img2img if preprocessor selected is "none"
- Skip loading model if "none" is selected (it is not needed when skipping img2img)

Note that regardless of skip img2img you must select some image in the main input image field. That is because the first thing it does is call img2img before any callbacks which tries to convert the image. So be aware of that.
