### PR TITLE
skip process if nothing to do

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -709,7 +709,7 @@ class Script(scripts.Script):
                 f"{prefix} Guidance End": guidance_end,
             })
 
-        if len(params_group) == 0:
+        if len(params_group) == 0 or len(control_groups) == 0:
            self.latest_network = None
            return 
 


### PR DESCRIPTION
latest version of controlnet does not perform correct checks if its enabled, so if txt2img is triggered via api call, it will attempt processing even if its disabled.
