### PR TITLE
Add API version getter

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -242,6 +242,10 @@ def warn_deprecated_cn_params():
     print(f"{warning_prefix}consider using the 'control_units' request param instead", file=sys.stderr)
 
 def controlnet_api(_: gr.Blocks, app: FastAPI):
+    @app.get("/controlnet/version")
+    async def version():
+        return {"version": external_code.get_api_version()}
+
     @app.get("/controlnet/model_list")
     async def model_list():
         up_to_date_model_list = external_code.get_models(update=True)

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -4,6 +4,10 @@ from scripts.controlnet import ResizeMode, update_cn_models, cn_models_names, PA
 import numpy as np
 
 
+def get_api_version() -> int:
+    return 1
+
+
 """
 Resize modes for ControlNet input images.
 """


### PR DESCRIPTION
Add a version to the API, to allow developers to support different API versions with breaking changes.

- new `/controlnet/version` route in web API
- new `external_code.get_api_version() -> int` function in code API

Closes #584