### PR TITLE
feat: use the closest model if model is not found

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -476,6 +476,10 @@ class Script(scripts.Script):
 
         model_path = global_state.cn_models.get(model, None)
         if model_path is None:
+            model = find_closest_lora_model_name(model)
+            model_path = global_state.cn_models.get(model, None)
+
+        if model_path is None:
             raise RuntimeError(f"model not found: {model}")
 
         # trim '"' at start/end


### PR DESCRIPTION
Since the `build_control_model` function does not try to find other models, we have to fill this `model` field in API with the exact name and hash code as below:
```json
{
    // ... other parameters of txt2img/img2img
    "alwayson_scripts": {
        "ControlNet": {
            "args": [
                {
                    "input_image": "input_img",
                    "mask": null,
                    "module": "canny",
                    "model": "control_sd15_canny [fef5e48e]",  // we have to fill this field with the exact name and hash code 
                    "resize_mode": "Scale to Fit (Inner Fit)",
                    "lowvram": false,
                    "processor_res": 512,
                    "threshold_a": 100,
                    "threshold_b": 200,
                    "guidance": 1,
                    "guidance_start": 0,
                    "guidance_end": 1,
                    "guessmode": false
                }
            ]
        }
    }
}
```

Now we can use a more concise name to do so.

```json
{
    // ... other parameters of txt2img/img2img
    "alwayson_scripts": {
        "ControlNet": {
            "args": [
                {
                    // ... other parameters of control net
                    "model": "control_sd15_canny",  // now we can use a concise name
                }
            ]
        }
    }
}
```