### PR TITLE
Added str check in get_*_unit_from functions

### DIFF
--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -120,6 +120,9 @@ def get_all_units_from(script_args: List[Any]) -> List[ControlNetUnit]:
             units.append(ControlNetUnit(*script_args[i:i + PARAM_COUNT]))
             i += PARAM_COUNT
 
+        elif type(script_args[i]) is str:
+            i += 1
+
         else:
             if script_args[i] is not None:
                 units.append(to_processing_unit(script_args[i]))
@@ -140,6 +143,9 @@ def get_single_unit_from(script_args: List[Any], index: int=0) -> Optional[Contr
             if index == 0:
                 return ControlNetUnit(*script_args[i:i + PARAM_COUNT])
             i += PARAM_COUNT
+
+        elif type(script_args[i]) is str:
+            i += 1
 
         else:
             if index == 0 and script_args[i] is not None:


### PR DESCRIPTION
Added check for str when fetching ControlNetUnits to avoid having problems with the new default values created in [PR #8669](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/8669) of the webui. The Gradio State objects returned by the ui function used when initializing the default arg list give strings. If you have a more elegant way of doing it either here or in the webui feel free to suggest it.

closes #675 