### PR TITLE
Req/633

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -733,7 +733,6 @@ class Script(scripts.Script):
                 detected_map = np.ndarray((round(input_image.shape[0]/4),input_image.shape[1]),dtype="float32",buffer=detected_map_bytes)
                 detected_map = torch.Tensor(detected_map).to(devices.get_device_for("controlnet"))
                 is_image = False
-                #fake_detected_map = np.ndarray((detected_map.shape[0]*4, detected_map.shape[1]),dtype="uint8",buffer=detected_map.numpy(force=True).tobytes())
                             
             if is_image:
                 control, detected_map = self.detectmap_proc(detected_map, unit.module, unit.rgbbgr_mode, resize_mode, h, w)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -728,7 +728,7 @@ class Script(scripts.Script):
             else:
                 detected_map, is_image = preprocessor(input_image)
 
-            if model_net.target == "scripts.adapter.StyleAdapter" and unit.module == "none":
+            if unit.module == "none" and "style" in unit.model:
                 detected_map_bytes = detected_map[:,:,0].tobytes()
                 detected_map = np.ndarray((round(input_image.shape[0]/4),input_image.shape[1]),dtype="float32",buffer=detected_map_bytes)
                 detected_map = torch.Tensor(detected_map).to(devices.get_device_for("controlnet"))

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -727,12 +727,22 @@ class Script(scripts.Script):
                 detected_map, is_image = preprocessor(input_image, res=unit.processor_res, thr_a=unit.threshold_a, thr_b=unit.threshold_b)
             else:
                 detected_map, is_image = preprocessor(input_image)
-            
+
+            if model_net.target == "scripts.adapter.StyleAdapter" and unit.module == "none":
+                detected_map_bytes = detected_map[:,:,0].tobytes()
+                detected_map = np.ndarray((round(input_image.shape[0]/4),input_image.shape[1]),dtype="float32",buffer=detected_map_bytes)
+                detected_map = torch.Tensor(detected_map).to(devices.get_device_for("controlnet"))
+                is_image = False
+                #fake_detected_map = np.ndarray((detected_map.shape[0]*4, detected_map.shape[1]),dtype="uint8",buffer=detected_map.numpy(force=True).tobytes())
+                            
             if is_image:
                 control, detected_map = self.detectmap_proc(detected_map, unit.module, unit.rgbbgr_mode, resize_mode, h, w)
                 detected_maps.append((detected_map, unit.module))
             else:
-                control = detected_map  
+                control = detected_map
+                if unit.module == 'clip_vision':
+                    fake_detected_map = np.ndarray((detected_map.shape[0]*4, detected_map.shape[1]),dtype="uint8",buffer=detected_map.numpy(force=True).tobytes())
+                    detected_maps.append((fake_detected_map, unit.module))
 
             forward_param = ControlParams(
                 control_model=model_net,


### PR DESCRIPTION
Convert the output of the clip_vision preprocessor to a fake image (lines 741-744). If that image is fed in, interpret it appropriately (lines 731-735).

It's a bit of a hack - the (x,y) float32 array converted to a (x*4,y) uint8 array via a bytes object, but that can then be saved as an image. 

It comes back as (x*4,y,3) (hence line 732)