### PR TITLE
Fix Inpaint with ControlNet for Different Image Resolutions

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -711,6 +711,11 @@ class Script(scripts.Script):
                 crop_region = masking.get_crop_region(np.array(mask), p.inpaint_full_res_padding)
                 crop_region = masking.expand_crop_region(crop_region, p.width, p.height, mask.width, mask.height)
 
+                # scale crop region to the size of our image
+                x1, y1, x2, y2 = crop_region
+                scale_x, scale_y = p.width / float(input_image.width), p.height / float(input_image.height)
+                crop_region = int(x1 / scale_x), int(y1 / scale_y), int(x2 / scale_x), int(y2 / scale_y)
+
                 input_image = input_image.crop(crop_region)
                 input_image = images.resize_image(2, input_image, p.width, p.height)
                 input_image = HWC3(np.asarray(input_image))


### PR DESCRIPTION
This pull request addresses an issue where the inpaint algorithm did not work correctly with controlnet when the resolution of the input image was different from the resolution of the image used in the controlnet. The solution provided in this PR involves resizing the crop zone so that it is consistent for both images, ensuring that the inpaint algorithm functions as expected.

Fixing a bad hand for example:
![image](https://user-images.githubusercontent.com/4660466/229486620-bfbf5faf-b93e-4259-b806-0e5b1373efb0.png)

The resolution of the image used in the inpainting process is 512x512, while the resolution of the image in the controlnet is 1086x1086. This higher resolution in the controlnet allows for the addition of finer details to the image being inpainted, enhancing its quality and appearance.