### PR TITLE
Use image scaled to target resolution for hires fix

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -852,8 +852,6 @@ def on_ui_settings():
         False, "Do not append detectmap to output", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_detectmap_autosaving", shared.OptionInfo(
         False, "Allow detectmap auto saving", gr.Checkbox, {"interactive": True}, section=section))
-    shared.opts.add_option("control_net_only_midctrl_hires", shared.OptionInfo(
-        True, "Use mid-control on highres pass (second pass)", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_allow_script_control", shared.OptionInfo(
         False, "Allow other script to control this extension", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_skip_img2img_processing", shared.OptionInfo(

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -776,8 +776,7 @@ class Script(scripts.Script):
                 advanced_weighting=None,
                 is_adapter=isinstance(model_net, PlugableAdapter),
                 is_extra_cond=getattr(model_net, "target", "") == "scripts.adapter.StyleAdapter",
-                hr_hint_cond = hr_control,
-                hint_cond_check = control
+                hr_hint_cond = hr_control
             )
             forward_params.append(forward_param)
 

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -777,6 +777,7 @@ class Script(scripts.Script):
                 is_adapter=isinstance(model_net, PlugableAdapter),
                 is_extra_cond=getattr(model_net, "target", "") == "scripts.adapter.StyleAdapter",
                 hr_hint_cond = hr_control,
+                hint_cond_check = control
             )
             forward_params.append(forward_param)
 

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -50,7 +50,8 @@ class ControlParams:
         stop_guidance_percent, 
         advanced_weighting, 
         is_adapter,
-        is_extra_cond
+        is_extra_cond,
+        hr_hint_cond
     ):
         self.control_model = control_model
         self.hint_cond = hint_cond
@@ -62,6 +63,7 @@ class ControlParams:
         self.advanced_weighting = advanced_weighting
         self.is_adapter = is_adapter
         self.is_extra_cond = is_extra_cond
+        self.hr_hint_cond = hr_hint_cond
 
 
 class UnetHook(nn.Module):
@@ -160,6 +162,7 @@ class UnetHook(nn.Module):
                 # hires stuffs
                 # note that this method may not works if hr_scale < 1.1
                 if abs(x.shape[-1] - param.hint_cond.shape[-1] // 8) > 8:
+                    param.hint_cond = param.hr_hint_cond
                     only_mid_control = shared.opts.data.get("control_net_only_midctrl_hires", True)
                     # If you want to completely disable control net, uncomment this.
                     # return self._original_forward(x, timesteps=timesteps, context=context, **kwargs)

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -51,7 +51,8 @@ class ControlParams:
         advanced_weighting, 
         is_adapter,
         is_extra_cond,
-        hr_hint_cond
+        hr_hint_cond,
+        hint_cond_check
     ):
         self.control_model = control_model
         self.hint_cond = hint_cond
@@ -64,6 +65,7 @@ class ControlParams:
         self.is_adapter = is_adapter
         self.is_extra_cond = is_extra_cond
         self.hr_hint_cond = hr_hint_cond
+        self.hint_cond_check = hint_cond_check
 
 
 class UnetHook(nn.Module):
@@ -162,7 +164,8 @@ class UnetHook(nn.Module):
                 # hires stuffs
                 # note that this method may not works if hr_scale < 1.1
                 if abs(x.shape[-1] - param.hint_cond.shape[-1] // 8) > 8:
-                    param.hint_cond = param.hr_hint_cond
+                    if (torch.equal(param.hint_cond, param.hint_cond_check)):
+                        param.hint_cond = param.hr_hint_cond
                     only_mid_control = shared.opts.data.get("control_net_only_midctrl_hires", True)
                     # If you want to completely disable control net, uncomment this.
                     # return self._original_forward(x, timesteps=timesteps, context=context, **kwargs)

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -179,13 +179,6 @@ class UnetHook(nn.Module):
                 if outer.lowvram:
                     param.control_model.to(devices.get_device_for("controlnet"))
 
-                # hires stuffs
-                # note that this method may not works if hr_scale < 1.1
-                if abs(x.shape[-1] - param.hint_cond.shape[-1] // 8) > 8:
-                    only_mid_control = shared.opts.data.get("control_net_only_midctrl_hires", True)
-                    # If you want to completely disable control net, uncomment this.
-                    # return self._original_forward(x, timesteps=timesteps, context=context, **kwargs)
-
                 # inpaint model workaround
                 x_in = x
                 control_model = param.control_model.control_model


### PR DESCRIPTION
Probably related to #670 

Previously when using hires fix, the input image would get downscaled to the base resolution, which led to loss in detail and possibly a complete loss of guidance in the hires pass. 

This fixes it by using an image scaled to the hires target resolution for the hires pass.



Here is a very obvious example where the input image gets almost completely ignored:

prompt: 1girl
Negative prompt:  easynegative
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 1649927220, Size: 512x512, Model hash: bd83b90a2e, Model: Counterfeit-V2.5, Denoising strength: 0.55, ControlNet-0 Enabled: True, ControlNet-0 Module: none, ControlNet-0 Model: control_canny-fp16 [e3fe7712], ControlNet-0 Weight: 1, ControlNet-0 Guidance Start: 0, ControlNet-0 Guidance End: 1, Hires upscale: 2, Hires steps: 20, Hires upscaler: Latent (bicubic antialiased)

![Example1](https://user-images.githubusercontent.com/47889291/230788722-d8c9e2ff-8226-451e-956b-40a997e03d6d.png)

Another example when using [the 3d openpose editor](https://zhuyu1997.github.io/open-pose-editor/), where previously there was a loss in quality in the hands:

1girl, school uniform, peace sign, out of frame
Negative prompt:  easynegative, bad-hands-5
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 1649927220, Size: 512x512, Model hash: bd83b90a2e, Model: Counterfeit-V2.5, Denoising strength: 0.5, ControlNet-0 Enabled: True, ControlNet-0 Module: none, ControlNet-0 Model: control_openpose-fp16 [9ca67cc5], ControlNet-0 Weight: 1, ControlNet-0 Guidance Start: 0, ControlNet-0 Guidance End: 1, ControlNet-1 Enabled: True, ControlNet-1 Module: none, ControlNet-1 Model: control_canny-fp16 [e3fe7712], ControlNet-1 Weight: 1, ControlNet-1 Guidance Start: 0, ControlNet-1 Guidance End: 1, ControlNet-2 Enabled: True, ControlNet-2 Module: none, ControlNet-2 Model: control_depth-fp16 [400750f6], ControlNet-2 Weight: 0.7, ControlNet-2 Guidance Start: 0, ControlNet-2 Guidance End: 1, Hires upscale: 2, Hires steps: 20, Hires upscaler: Latent (bicubic antialiased)

![Example2](https://user-images.githubusercontent.com/47889291/230788979-fc5faa3f-8cad-4783-a1ca-172480719d04.png)

