### PR TITLE
Added support for ControlNet colorization model

### DIFF
--- a/annotator/colorization/__init__.py
+++ b/annotator/colorization/__init__.py
@@ -1,0 +1,8 @@
+import numpy as np
+from PIL import Image, ImageEnhance
+
+def apply_colorization(img, brightness, contrast):
+    pil_img = Image.fromarray(img.astype(np.uint8)).convert('L').convert('RGB')
+    if brightness != 0: pil_img = ImageEnhance.Brightness(pil_img).enhance((brightness+100)/100)
+    if   contrast != 0: pil_img = ImageEnhance.Contrast(pil_img).enhance((contrast+100)/100)
+    return np.array(pil_img)

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -214,7 +214,8 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
             "openpose",
             "segmentation",
             "binary",
-            "color"
+            "color",
+            "colorization"
         ]
 
         if controlnet_module not in available_modules:
@@ -251,6 +252,8 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
                 results.append(binary(img, controlnet_processor_res, controlnet_threshold_a)[0])
             elif controlnet_module == "color":
                 results.append(color(img, controlnet_processor_res)[0])
+            elif controlnet_module == "colorization":
+                results.append(colorization(img, controlnet_processor_res, controlnet_threshold_a, controlnet_threshold_b)[0])
 
         if controlnet_module == "hed":
             unload_hed()

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -24,6 +24,7 @@ cn_preprocessor_modules = {
     "openpose_hand": openpose_hand,
     "clip_vision": clip,
     "color": color,
+    "colorization": colorization,
     "pidinet": pidinet,
     "scribble": simple_scribble,
     "fake_scribble": fake_scribble,

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -215,6 +215,19 @@ def color(img, res=512, **kwargs):
     return result, True
 
 
+model_colorization = None
+
+
+def colorization(img, res=512, thr_a=0, thr_b=0, **kwargs):
+    img = resize_image(HWC3(img), res)
+    global model_colorization
+    if model_colorization is None:
+        from annotator.colorization import apply_colorization
+        model_colorization = apply_colorization
+    result = model_colorization(img, thr_a, thr_b)
+    return result, True
+
+
 model_binary = None
 
 


### PR DESCRIPTION
Added support for a new hint for colorization. [The model](https://huggingface.co/neurallove/controlnet-sd21-colorization/resolve/main/colorization-sd21-safe.safetensors) is trained on the base model Stable-Diffusion 2.1 (512) and is located on HF.

Here's a [Colab](https://colab.research.google.com/drive/1pZW57lNvvdc-YcSKWt3N6dKj3OTFjmgg) for tests