### PR TITLE
Fix shuffle preprocessor seed bug & allow modifying seed with subseed

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -733,7 +733,7 @@ class Script(scripts.Script):
                 input_image = images.resize_image(2, input_image, p.width, p.height)
                 input_image = HWC3(np.asarray(input_image))
 
-            np.random.seed(int(p.seed) % 65535)
+            np.random.seed((int(p.seed) + int(p.subseed)) % 65535)
 
             print(f"Loading preprocessor: {unit.module}")
             preprocessor = self.preprocessor[unit.module]

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -733,7 +733,9 @@ class Script(scripts.Script):
                 input_image = images.resize_image(2, input_image, p.width, p.height)
                 input_image = HWC3(np.asarray(input_image))
 
-            np.random.seed((int(p.seed) + max(int(p.subseed),0)) % 65535)
+            tmp_seed = int(p.all_seeds[0] if p.seed == -1 else max(int(p.seed),0))
+            tmp_subseed = int(p.all_seeds[0] if p.subseed == -1 else max(int(p.subseed),0))
+            np.random.seed((tmp_seed + tmp_subseed) & 0xFFFFFFFF)
 
             print(f"Loading preprocessor: {unit.module}")
             preprocessor = self.preprocessor[unit.module]

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -733,7 +733,7 @@ class Script(scripts.Script):
                 input_image = images.resize_image(2, input_image, p.width, p.height)
                 input_image = HWC3(np.asarray(input_image))
 
-            np.random.seed((int(p.seed) + int(p.subseed)) % 65535)
+            np.random.seed((int(p.seed) + max(int(p.subseed),0)) % 65535)
 
             print(f"Loading preprocessor: {unit.module}")
             preprocessor = self.preprocessor[unit.module]


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/811 (see additional comment below regarding this fix)

As discussed in https://github.com/Mikubill/sd-webui-controlnet/pull/742, the shuffle processor seed should be reproducible but also controllable by the user. The implementation in https://github.com/Mikubill/sd-webui-controlnet/commit/fa994bb2ffed7428f07afd423f215609c5794204 isn't ideal because when using txt2img, this means that only one variation is able to be created for a generated image.

This PR changes this to also account for the subseed (what the web UI refers to as the `Variation seed`). This means that a user could use this variation seed, with the `Variation strength` set to `0` (so it doesn't affect the base generated image), but it will affect the Shuffle preprocessor to use a different permutation. This will also work with batch sizes out of the box.

A use case for this would be using the XYZ plot script to show how the Shuffle cnet strength affects the image for multiple different variation seeds at increasing strengths, but all starting from the same generated image.

Might be something to reconsider the implementation for later once paint-with-words and GLIGEN support are added. https://github.com/Mikubill/sd-webui-controlnet/discussions/519#discussioncomment-5225020

**Edit:** [See comment below](https://github.com/Mikubill/sd-webui-controlnet/pull/785#issuecomment-1510425473). This now also fixes a bug in the previous implementation.