### PR TITLE
fix: Raise 500 exception instead of returning an error on `detect` API call

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -209,53 +209,7 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
             raise HTTPException(
                 status_code=500, detail="Module not available")
         
-        available_modules = [
-            "none",
-
-            "canny",
-
-            "depth_midas",                  # Unload
-            "depth_leres",                  # Unload
-            "depth_zoe",                    # Unload
-
-            "lineart",                      # Unload
-            "lineart_coarse",               # Unload
-            "lineart_anime",                # Unload
-
-            "mediapipe_face",
-
-            "mlsd",                         # Unload
-
-            "normal_midas",                 # Unload
-            "normal_bae",                   # Unload
-
-            "openpose",                     # Unload
-            "openpose_face",                # Unload
-            "openpose_faceonly",            # Unload
-            "openpose_hand",                # Unload
-            "openpose_full",                # Unload
-
-            "scribble_hed",
-            "scribble_pidinet",
-            "scribble_xdog",
-
-            "seg_ofcoco",                   # Unload
-            "seg_ofade20k",                 # Unload
-            "seg_ufade20k",                 # Unload
-
-            "shuffle",
-
-            "softedge_hed",                 # Unload
-            "softedge_hedsafe",             # Unload
-            "softedge_pidinet",             # Unload
-            "softedge_pidisafe",            # Unload
-
-            "t2ia_color_grid",
-            "t2ia_sketch_pidi",
-
-            "threshold"
-        ]
-
+       
         if len(controlnet_input_images) == 0:
             raise HTTPException(
                 status_code=500, detail="No image selected")

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -2,6 +2,7 @@ from typing import Union
 
 import numpy as np
 from fastapi import FastAPI, Body
+from fastapi.exceptions import HTTPException
 from PIL import Image
 import copy
 import pydantic
@@ -205,9 +206,59 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
         controlnet_module = global_state.reverse_preprocessor_aliases.get(controlnet_module, controlnet_module)
 
         if controlnet_module not in global_state.cn_preprocessor_modules:
-            return {"images": [], "info": "Module not available"}
+            raise HTTPException(
+                status_code=500, detail="Module not available")
+        
+        available_modules = [
+            "none",
+
+            "canny",
+
+            "depth_midas",                  # Unload
+            "depth_leres",                  # Unload
+            "depth_zoe",                    # Unload
+
+            "lineart",                      # Unload
+            "lineart_coarse",               # Unload
+            "lineart_anime",                # Unload
+
+            "mediapipe_face",
+
+            "mlsd",                         # Unload
+
+            "normal_midas",                 # Unload
+            "normal_bae",                   # Unload
+
+            "openpose",                     # Unload
+            "openpose_face",                # Unload
+            "openpose_faceonly",            # Unload
+            "openpose_hand",                # Unload
+            "openpose_full",                # Unload
+
+            "scribble_hed",
+            "scribble_pidinet",
+            "scribble_xdog",
+
+            "seg_ofcoco",                   # Unload
+            "seg_ofade20k",                 # Unload
+            "seg_ufade20k",                 # Unload
+
+            "shuffle",
+
+            "softedge_hed",                 # Unload
+            "softedge_hedsafe",             # Unload
+            "softedge_pidinet",             # Unload
+            "softedge_pidisafe",            # Unload
+
+            "t2ia_color_grid",
+            "t2ia_sketch_pidi",
+
+            "threshold"
+        ]
+
         if len(controlnet_input_images) == 0:
-            return {"images": [], "info": "No image selected"}
+            raise HTTPException(
+                status_code=500, detail="No image selected")
         
         print(f"Detecting {str(len(controlnet_input_images))} images with the {controlnet_module} module.")
 

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -207,12 +207,12 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
 
         if controlnet_module not in global_state.cn_preprocessor_modules:
             raise HTTPException(
-                status_code=500, detail="Module not available")
+                status_code=422, detail="Module not available")
         
        
         if len(controlnet_input_images) == 0:
             raise HTTPException(
-                status_code=500, detail="No image selected")
+                status_code=422, detail="No image selected")
         
         print(f"Detecting {str(len(controlnet_input_images))} images with the {controlnet_module} module.")
 

--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.132'
+version_flag = 'v1.1.133'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.133'
+version_flag = 'v1.1.134'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,10 +6,6 @@ from base64 import b64encode
 import requests
 
 BASE_URL = "http://localhost:7860"
-<< << << < HEAD
-== == == =
-
->>>>>> > c0726ca(chore: add tests for detect endpoint)
 
 
 def setup_test_env():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,16 @@
-import os, sys, cv2
+import os
+import sys
+import cv2
 from base64 import b64encode
 
 import requests
 
 BASE_URL = "http://localhost:7860"
+<< << << < HEAD
+== == == =
+
+>>>>>> > c0726ca(chore: add tests for detect endpoint)
+
 
 def setup_test_env():
     ext_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -19,7 +26,7 @@ def readImage(path):
 
 
 def get_model():
-    r = requests.get("http://localhost:7860/controlnet/model_list")
+    r = requests.get(BASE_URL+"/controlnet/model_list")
     result = r.json()
     if "model_list" in result:
         result = result["model_list"]
@@ -31,4 +38,7 @@ def get_model():
 
 def get_modules():
     return requests.get(f"{BASE_URL}/controlnet/module_list").json().get('module_list', [])
-    
+
+
+def detect(json):
+    return requests.post(BASE_URL+"/controlnet/detect", json=json)

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -17,15 +17,15 @@ class TestDetectEndpointWorking(unittest.TestCase):
         }
 
     def test_detect_with_invalid_module_performed(self):
-        detect_args = self.base_detect_args | {
+        detect_args = self.base_detect_args.copy().update({
             "controlnet_module": "INVALID",
-        }
+        })
         self.assertEqual(utils.detect(detect_args).status_code, 500)
 
     def test_detect_with_no_input_images_performed(self):
-        detect_args = self.base_detect_args | {
+        detect_args = self.base_detect_args.copy().update({
             "controlnet_input_images": [],
-        }
+        })
         self.assertEqual(utils.detect(detect_args).status_code, 500)
 
     def test_detect_with_valid_args_performed(self):

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -21,14 +21,14 @@ class TestDetectEndpointWorking(unittest.TestCase):
         detect_args.update({
             "controlnet_module": "INVALID",
         })
-        self.assertEqual(utils.detect(detect_args).status_code, 500)
+        self.assertEqual(utils.detect(detect_args).status_code, 422)
 
     def test_detect_with_no_input_images_performed(self):
         detect_args = self.base_detect_args.copy()
         detect_args.update({
             "controlnet_input_images": [],
         })
-        self.assertEqual(utils.detect(detect_args).status_code, 500)
+        self.assertEqual(utils.detect(detect_args).status_code, 422)
 
     def test_detect_with_valid_args_performed(self):
         detect_args = self.base_detect_args

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -6,9 +6,9 @@ utils = importlib.import_module(
 utils.setup_test_env()
 
 
-class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
+class TestDetectTxt2ImgWorking(unittest.TestCase):
     def setUp(self):
-        base_detect_args = {
+        self.base_detect_args = {
             "controlnet_module": "canny",
             "controlnet_input_images": [utils.readImage("test/test_files/img2img_basic.png")],
             "controlnet_processor_res": 512,
@@ -17,15 +17,15 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
         }
 
     def test_detect_with_invalid_module_performed(self):
-        detect_args = self.base_detect_args ** {
+        detect_args = self.base_detect_args.update({
             "controlnet_module": "INVALID",
-        }
+        })
         self.assertEqual(utils.detect(detect_args).status_code, 500)
 
     def test_detect_with_no_input_images_performed(self):
-        detect_args = self.base_detect_args ** {
+        detect_args = self.base_detect_args.update({
             "controlnet_input_images": [],
-        }
+        })
         self.assertEqual(utils.detect(detect_args).status_code, 500)
 
     def test_detect_with_valid_args_performed(self):

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -24,7 +24,8 @@ class TestDetectEndpointWorking(unittest.TestCase):
         self.assertEqual(utils.detect(detect_args).status_code, 500)
 
     def test_detect_with_no_input_images_performed(self):
-        detect_args = self.base_detect_args.copy().update({
+        detect_args = self.base_detect_args.copy()
+        detect_args.update({
             "controlnet_input_images": [],
         })
         self.assertEqual(utils.detect(detect_args).status_code, 500)

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -1,0 +1,39 @@
+import requests
+import unittest
+import importlib
+utils = importlib.import_module(
+    'extensions.sd-webui-controlnet.tests.utils', 'utils')
+utils.setup_test_env()
+
+
+class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
+    def setUp(self):
+        base_detect_args = {
+            "controlnet_module": "canny",
+            "controlnet_input_images": [utils.readImage("test/test_files/img2img_basic.png")],
+            "controlnet_processor_res": 512,
+            "controlnet_threshold_a": 0,
+            "controlnet_threshold_b": 0,
+        }
+
+    def test_detect_with_invalid_module_performed(self):
+        detect_args = self.base_detect_args ** {
+            "controlnet_module": "INVALID",
+        }
+        self.assertEqual(utils.detect(detect_args).status_code, 500)
+
+    def test_detect_with_no_input_images_performed(self):
+        detect_args = {
+            "controlnet_input_images": [],
+        }
+        self.assertEqual(utils.detect(detect_args).status_code, 500)
+
+    def test_detect_with_valid_args_performed(self):
+        detect_args = self.base_detect_args
+        response = utils.detect(detect_args)
+
+        self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -17,15 +17,15 @@ class TestDetectEndpointWorking(unittest.TestCase):
         }
 
     def test_detect_with_invalid_module_performed(self):
-        detect_args = self.base_detect_args.update({
+        detect_args = self.base_detect_args | {
             "controlnet_module": "INVALID",
-        })
+        }
         self.assertEqual(utils.detect(detect_args).status_code, 500)
 
     def test_detect_with_no_input_images_performed(self):
-        detect_args = self.base_detect_args.update({
+        detect_args = self.base_detect_args | {
             "controlnet_input_images": [],
-        })
+        }
         self.assertEqual(utils.detect(detect_args).status_code, 500)
 
     def test_detect_with_valid_args_performed(self):

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -17,7 +17,8 @@ class TestDetectEndpointWorking(unittest.TestCase):
         }
 
     def test_detect_with_invalid_module_performed(self):
-        detect_args = self.base_detect_args.copy().update({
+        detect_args = self.base_detect_args.copy()
+        detect_args.update({
             "controlnet_module": "INVALID",
         })
         self.assertEqual(utils.detect(detect_args).status_code, 500)

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -23,7 +23,7 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
         self.assertEqual(utils.detect(detect_args).status_code, 500)
 
     def test_detect_with_no_input_images_performed(self):
-        detect_args = {
+        detect_args = self.base_detect_args ** {
             "controlnet_input_images": [],
         }
         self.assertEqual(utils.detect(detect_args).status_code, 500)

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -6,7 +6,7 @@ utils = importlib.import_module(
 utils.setup_test_env()
 
 
-class TestDetectTxt2ImgWorking(unittest.TestCase):
+class TestDetectEndpointWorking(unittest.TestCase):
     def setUp(self):
         self.base_detect_args = {
             "controlnet_module": "canny",


### PR DESCRIPTION
I noticed that the `detect` API call returns with a `200` status code when the selected module is not implemented/available or no when no input image is provided.
This PR raises an 500 status code HTTP exception for better integration with 3rd party implementations.

Note: I couldn't find a PEP formatting guide on the repo, so I didn't format the file on saving to avoid having unrelated changes on the PR.