### PR TITLE
add settings for annotator models path

### DIFF
--- a/annotator/annotator_path.py
+++ b/annotator/annotator_path.py
@@ -1,4 +1,11 @@
 import os
+from modules import shared
 
-models_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'downloads')
+models_path = shared.opts.data.get('control_net_modules_path', None)
+if not models_path:
+    models_path = getattr(shared.cmd_opts, 'controlnet_annotator_models_path', None)
+if not models_path:
+    models_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'downloads')
+
+models_path = os.path.realpath(models_path)
 os.makedirs(models_path, exist_ok=True)

--- a/preload.py
+++ b/preload.py
@@ -1,3 +1,4 @@
 def preload(parser):
     parser.add_argument("--controlnet-dir", type=str, help="Path to directory with ControlNet models", default=None)
+    parser.add_argument("--controlnet-annotator-models-path", type=str, help="Path to directory with annotator model directories", default=None)
     parser.add_argument("--no-half-controlnet", action='store_true', help="do not switch the ControlNet models to 16-bit floats (only needed without --no-half)", default=None)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -931,7 +931,7 @@ def on_ui_settings():
     shared.opts.add_option("control_net_models_path", shared.OptionInfo(
         "", "Extra path to scan for ControlNet models (e.g. training output directory)", section=section))
     shared.opts.add_option("control_net_modules_path", shared.OptionInfo(
-        "", "Path to directory containing annotator model directories (overrides command line flag for annotators path)", section=section))
+        "", "Path to directory containing annotator model directories (requires restart, overrides corresponding command line flag)", section=section))
     shared.opts.add_option("control_net_max_models_num", shared.OptionInfo(
         1, "Multi ControlNet: Max models amount (requires restart)", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}, section=section))
     shared.opts.add_option("control_net_model_cache_size", shared.OptionInfo(

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -12,10 +12,13 @@ import gradio as gr
 import numpy as np
 
 from einops import rearrange
-from scripts import global_state, hook, external_code
+import annotator
+from scripts import global_state, hook, external_code, processor
 importlib.reload(global_state)
 importlib.reload(hook)
 importlib.reload(external_code)
+importlib.reload(annotator)
+importlib.reload(processor)
 from scripts.cldm import PlugableControlModel
 from scripts.processor import *
 from scripts.adapter import PlugableAdapter
@@ -927,6 +930,8 @@ def on_ui_settings():
         global_state.default_detectedmap_dir, "Directory for detected maps auto saving", section=section))
     shared.opts.add_option("control_net_models_path", shared.OptionInfo(
         "", "Extra path to scan for ControlNet models (e.g. training output directory)", section=section))
+    shared.opts.add_option("control_net_modules_path", shared.OptionInfo(
+        "", "Path to directory containing annotator model directories (overrides command line flag for annotators path)", section=section))
     shared.opts.add_option("control_net_max_models_num", shared.OptionInfo(
         1, "Multi ControlNet: Max models amount (requires restart)", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}, section=section))
     shared.opts.add_option("control_net_model_cache_size", shared.OptionInfo(


### PR DESCRIPTION
Now we can put the models where we want. There are 2 ways to specify the preprocessor directories path:

- by command line, using `--controlnet-annotator-models-path <models-directory>`
- by setting the value of the textbox in the controlnet settings: "Path to directory containing annotator model directories (overrides command line flag for annotators path)"
- by not doing anything. default value is `extensions/sd-webui-controlnet/annotator/downloads`

I think the default value should be under `<webui>/models` and users should delete corrupted models manually instead. What do you think @lllyasviel, is that a bad idea? See message here for the rationale behind this: https://github.com/Mikubill/sd-webui-controlnet/pull/881#issuecomment-1512665611

I will update this PR according to the outcome of the discussions.

Closes #890