### PR TITLE
add settings for annotator models path (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ To use the API: start WebUI with argument `--api` and go to `http://webui-addres
 
 To use external call: Checkout [Wiki](https://github.com/Mikubill/sd-webui-controlnet/wiki/API)
 
+### Command Line Arguments
+
+This extension adds these command line arguments to the webui:
+
+```
+    --controlnet-dir <path to directory with controlnet models>                                ADD a controlnet models directory
+    --controlnet-annotator-models-path <path to directory with annotator model directories>    SET the directory for annotator models
+    --no-half-controlnet                                                                       load controlnet models in full precision
+```
+
 ### MacOS Support
 
 Tested with pytorch nightly: https://github.com/Mikubill/sd-webui-controlnet/pull/143#issuecomment-1435058285

--- a/annotator/annotator_path.py
+++ b/annotator/annotator_path.py
@@ -7,5 +7,8 @@ if not models_path:
 if not models_path:
     models_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'downloads')
 
+if not os.path.isabs(models_path):
+    models_path = os.path.join(shared.data_path, models_path)
+
 models_path = os.path.realpath(models_path)
 os.makedirs(models_path, exist_ok=True)

--- a/annotator/annotator_path.py
+++ b/annotator/annotator_path.py
@@ -5,7 +5,7 @@ models_path = shared.opts.data.get('control_net_modules_path', None)
 if not models_path:
     models_path = getattr(shared.cmd_opts, 'controlnet_annotator_models_path', None)
 if not models_path:
-    models_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'downloads')
+    models_path = shared.models_path
 
 if not os.path.isabs(models_path):
     models_path = os.path.join(shared.data_path, models_path)


### PR DESCRIPTION
Follow up of #891 

Because of https://github.com/Mikubill/sd-webui-controlnet/pull/881#issuecomment-1512665611, I am also changing the default path back to `<webui>/models`.

Related discussion: #45, #127

Controlnet is not the only extension using the models, IIUC it is a bad idea to locate them inside the extension directory.