### PR TITLE
Stop repetitive mediapipe install at webui launch

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,14 +1,20 @@
 import launch
 import os
+import pkg_resources
 
 req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
 
 with open(req_file) as file:
-    for lib in file:
+    for package in file:
         try:
-            lib = lib.strip()
-            if not launch.is_installed(lib):
-                launch.run_pip(f"install {lib}", f"sd-webui-controlnet requirement: {lib}")
+            package = package.strip()
+            if '==' in package:
+                package_name, package_version = package.split('==')
+                installed_version = pkg_resources.get_distribution(package_name).version
+                if installed_version != package_version:
+                    launch.run_pip(f"install {package}", f"sd-webui-controlnet requirement: Changing {package_name} version from {installed_version} to {package_version}")
+            elif not launch.is_installed(package):
+                launch.run_pip(f"install {package}", f"sd-webui-controlnet requirement: {package}")
         except Exception as e:
             print(e)
-            print(f'Warning: Failed to install {lib}, some preprocessors may not work.')
+            print(f'Warning: Failed to install {package}, some preprocessors may not work.')

--- a/install.py
+++ b/install.py
@@ -12,7 +12,7 @@ with open(req_file) as file:
                 package_name, package_version = package.split('==')
                 installed_version = pkg_resources.get_distribution(package_name).version
                 if installed_version != package_version:
-                    launch.run_pip(f"install {package}", f"sd-webui-controlnet requirement: Changing {package_name} version from {installed_version} to {package_version}")
+                    launch.run_pip(f"install {package}", f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}")
             elif not launch.is_installed(package):
                 launch.run_pip(f"install {package}", f"sd-webui-controlnet requirement: {package}")
         except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 mediapipe==0.9.1.0
 svglib
 fvcore
-opencv-python


### PR DESCRIPTION
This PR stops the repetitive mediapipe installation upon each and every webui launch. 

Also removed opencv-python (again), as it comes with 3 of webui's core repos: 
- CodeFormer
- stable-diffusion-stabillity-ai
- taming-transformers