### PR TITLE
fix control_scale calculation for adapter with high_res_fix

### DIFF
--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -229,7 +229,7 @@ class UnetHook(nn.Module):
                     # Note that guess_mode is soft weights + cfg masks
                     # only use soft weights will not trigger guess mode
                     if param.is_adapter:
-                        control_scales = param.weight * [0.25, 0.62, 0.825, 1.0]
+                        control_scales = [param.weight * x for x in (0.25, 0.62, 0.825, 1.0)]
                     else:    
                         control_scales = [param.weight * (0.825 ** float(12 - i)) for i in range(13)]
 


### PR DESCRIPTION
Fix mistake in control_scales calculation. This is old bug, but I discovered it when testing new super high quality resampling.