### PR TITLE
Add resize preprocessor

### DIFF
--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -51,6 +51,7 @@ cn_preprocessor_modules = {
     "tile_gaussian": tile_gaussian,
     "inpaint": inpaint,
     "invert": invert,
+    "resize": resize,
 }
 
 cn_preprocessor_unloadable = {

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -498,3 +498,7 @@ def shuffle(img, res=512, **kwargs):
         model_shuffle = ContentShuffleDetector()
     result = model_shuffle(img)
     return result, True
+
+def resize(img, res=512, **kwargs):
+    img = resize_image(HWC3(img), res)
+    return img, True


### PR DESCRIPTION
The reason why this preprocessor need to exist is that some people may want to use 3rd-party preprocessor, but they may not benefit from the new pixel-perfect feature if this preprocessor does not exist. 

For example, some people may use posex to generate pose and choose None as preprocessor, which might be suboptimal. An incoming new feature of my SAM extension is to use SAM to enhance semantic segmentation, and people may want to use this preprocessor to process the input semantic segmentation image.