### PR TITLE
Fix an issue with empty mask string.

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -119,9 +119,9 @@ def image_dict_from_unit(unit) -> Optional[Dict[str, np.ndarray]]:
     if isinstance(result['image'], str):
         result['image'] = external_code.to_base64_nparray(result['image'])
 
-    if isinstance(result['mask'], str):
+    if isinstance(result['mask'], str) and result['mask']:
         result['mask'] = external_code.to_base64_nparray(result['mask'])
-    elif result['mask'] is None:
+    else:
         result['mask'] = np.zeros_like(result['image'], dtype=np.uint8)
 
     return result

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -117,7 +117,15 @@ def image_dict_from_unit(unit) -> Optional[Dict[str, np.ndarray]]:
     result = {'image': image['image'], 'mask': image['mask']}
 
     if isinstance(result['image'], str):
-        result['image'] = external_code.to_base64_nparray(result['image'])
+        if result['image']:
+            result['image'] = external_code.to_base64_nparray(result['image'])        
+        else:
+            result['image'] = None
+    
+    # If there is no image, ignore the mask
+    if result['image'] is None:
+        result['mask'] = None
+        return None
 
     if isinstance(result['mask'], str):
         if result['mask']:

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -132,35 +132,26 @@ def image_dict_from_any(image) -> Optional[Dict[str, np.ndarray]]:
         # copy to enable modifying the dict and prevent response serialization error
         image = dict(image)
 
-    # copy to enable modifying the dict and prevent response serialization error
-    result = {'image': image['image'], 'mask': image['mask']}
-
-    if isinstance(result['image'], str):
+    if isinstance(image['image'], str):
         if os.path.exists(image['image']):
             image['image'] = numpy.array(Image.open(image['image'])).astype('uint8')
-        elif result['image']:
-            result['image'] = external_code.to_base64_nparray(result['image'])        
+        elif image['image']:
+            image['image'] = external_code.to_base64_nparray(image['image'])
         else:
-            result['image'] = None
-    
-    # If there is no image, ignore the mask
-    if result['image'] is None:
-        result['mask'] = None
-        return None
+            image['image'] = None            
 
-    if isinstance(result['mask'], str):
-        if result['mask']:
-            result['mask'] = external_code.to_base64_nparray(result['mask'])
-        else:
-            result['mask'] = np.zeros_like(result['image'], dtype=np.uint8)    
-    elif result['mask'] is None:
-        result['mask'] = np.zeros_like(result['image'], dtype=np.uint8)
+    # If there is no image, return image with None image and None mask
+    if image['image'] is None:
+        image['mask'] = None
+        return image
 
     if isinstance(image['mask'], str):
         if os.path.exists(image['mask']):
             image['mask'] = numpy.array(Image.open(image['mask'])).astype('uint8')
-        else:
+        elif image['mask']:
             image['mask'] = external_code.to_base64_nparray(image['mask'])
+        else:
+            image['mask'] = np.zeros_like(image['image'], dtype=np.uint8)
     elif image['mask'] is None:
         image['mask'] = np.zeros_like(image['image'], dtype=np.uint8)
 

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -119,9 +119,12 @@ def image_dict_from_unit(unit) -> Optional[Dict[str, np.ndarray]]:
     if isinstance(result['image'], str):
         result['image'] = external_code.to_base64_nparray(result['image'])
 
-    if isinstance(result['mask'], str) and result['mask']:
-        result['mask'] = external_code.to_base64_nparray(result['mask'])
-    else:
+    if isinstance(result['mask'], str):
+        if result['mask']:
+            result['mask'] = external_code.to_base64_nparray(result['mask'])
+        else:
+            result['mask'] = np.zeros_like(result['image'], dtype=np.uint8)    
+    elif result['mask'] is None:
         result['mask'] = np.zeros_like(result['image'], dtype=np.uint8)
 
     return result


### PR DESCRIPTION
### The Issue
When setting up image and mask into nparray... the mask is typically empty. However, when using the API the mask can be an **empty string**, hence controlnet tries to parse the empty string [and causes exception]... So the solution is to check if the incoming mask is a string and is not empty!

### The Fix

Replace

``` python
    if isinstance(result['mask'], str):
        result['mask'] = external_code.to_base64_nparray(result['mask'])
    elif result['mask'] is None:
        result['mask'] = np.zeros_like(result['image'], dtype=np.uint8)
```

with

``` python
    if isinstance(result['mask'], str) and result['mask']:
        result['mask'] = external_code.to_base64_nparray(result['mask'])
    else:
        result['mask'] = np.zeros_like(result['image'], dtype=np.uint8)
```

EDIT: This was not great... look below! 😄 👇 