### PR TITLE
[UI Improvement] Add hover tooltip for ToolButton

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -5,7 +5,7 @@ titles = {
     '💥': 'Run preprocessor',
     '📝': 'Open new canvas',
     '📷': 'Enable webcam',
-    '⇄': 'Mirrow webcam',
+    '⇄': 'Mirror webcam',
 };
 
 onUiUpdate(function(){

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -1,0 +1,18 @@
+// mouseover tooltips for various UI elements
+titles = {
+    '🔄': 'Refresh',
+    '\u2934': 'Send dimensions to stable diffusion',
+    '💥': 'Run preprocessor',
+    '📝': 'Open new canvas',
+    '📷': 'Enable webcam',
+    '⇄': 'Mirrow webcam',
+};
+
+onUiUpdate(function(){
+	gradioApp().querySelectorAll('.cnet-toolbutton').forEach(function(button){
+		tooltip = titles[button.textContent];
+		if(tooltip){
+			button.title = tooltip;
+		}
+	})
+});

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -55,6 +55,7 @@ try:
 except ImportError:
     pass
 
+# Note: Change symbol hints mapping in `javascript/hints.js` when you change the symbol values.
 refresh_symbol = '\U0001f504'       # 🔄
 switch_values_symbol = '\U000021C5' # ⇅
 camera_symbol = '\U0001F4F7'        # 📷
@@ -85,7 +86,7 @@ class ToolButton(gr.Button, gr.components.FormComponent):
     """Small button with single emoji as text, fits inside gradio forms"""
 
     def __init__(self, **kwargs):
-        super().__init__(variant="tool", **kwargs)
+        super().__init__(variant="tool", elem_classes=['cnet-toolbutton'], **kwargs)
 
     def get_block_name(self):
         return "button"


### PR DESCRIPTION
I found the controlnet emoji buttons a little bit confusing. The user might need to try really hard to guess what each button is for. This PR adds a hover tooltip on each `ToolButton` which appears after the user hovers on the button for a while. 

There is a simpler way to display hover text by adding `title` attribute on `button` element[[link]](https://stackoverflow.com/questions/45456543/make-text-show-up-on-hover-over-button).  However, I did not found a way in Gradio to either directly add a custom attribute on button element, or trigger a piece of JS code that add custom attribute to the element on document load. 

So, I have to take a far route which is pure CSS based implementation.
![Tooltip](https://user-images.githubusercontent.com/20929282/233875299-2c44950a-1c2b-4511-b379-56d30c408d2c.png)

Note:
There is a undesired side-effect on the UI. Gradio has following CSS rule on non-absolute elements. 
```
div.svelte-1oo81b7>*:not(.absolute) {
    border-radius: 0!important;
}
```
This will make the bottom-right and bottom-left coners of the button not rounded. 

If you think this is a big issue, I can workround on CSS to fix this UI side effect. 