### PR TITLE
Fixed issue where Nontype causes a crash

### DIFF
--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -277,6 +277,9 @@ def find_cn_script(script_runner: scripts.ScriptRunner) -> Optional[scripts.Scri
     Find the ControlNet script in `script_runner`. Returns `None` if `script_runner` does not contain a ControlNet script.
     """
 
+    if script_runner is None:
+        return None:
+    
     for script in script_runner.alwayson_scripts:
         if is_cn_script(script):
             return script


### PR DESCRIPTION
On some plugins this crashes on object type Nonetype. Figured because the function can return type none it would be a good idea to return type none if we have a variable of type none. There are a lot of nones in this post. Does that make it holly? (sorry for the poor joke, I have been starring at python code all day)

![image](https://user-images.githubusercontent.com/5393103/233884629-91c191e1-0ce1-44fa-b69c-50634d7f9931.png)
