### PR TITLE
[New Feature] Allow user to download openpose preprocessor result as JSON file

### DIFF
--- a/annotator/openpose/__init__.py
+++ b/annotator/openpose/__init__.py
@@ -11,7 +11,7 @@ from .face import Face
 from modules import devices
 from annotator.annotator_path import models_path
 
-from typing import NamedTuple, Tuple, List
+from typing import NamedTuple, Tuple, List, Callable
 
 body_model_path = "https://huggingface.co/lllyasviel/Annotators/resolve/main/body_pose_model.pth"
 hand_model_path = "https://huggingface.co/lllyasviel/Annotators/resolve/main/hand_pose_model.pth"
@@ -228,7 +228,10 @@ class OpenposeDetector:
             
             return results
         
-    def __call__(self, oriImg, include_body=True, include_hand=False, include_face=False):
+    def __call__(
+            self, oriImg, include_body=True, include_hand=False, include_face=False,
+            json_pose_callback: Callable[[str], None] = None,
+        ):
         """
         Detect and draw poses in the given image.
 
@@ -237,11 +240,14 @@ class OpenposeDetector:
             include_body (bool, optional): Whether to include body keypoints. Defaults to True.
             include_hand (bool, optional): Whether to include hand keypoints. Defaults to False.
             include_face (bool, optional): Whether to include face keypoints. Defaults to False.
+            json_pose_callback (Callable, optional): A callback that accepts the pose JSON string.
 
         Returns:
             numpy.ndarray: The image with detected and drawn poses.
         """
         H, W, _ = oriImg.shape
         poses = self.detect_poses(oriImg, include_hand, include_face)
+        if json_pose_callback:
+            json_pose_callback(encode_poses_as_json(poses, H, W))
         return draw_poses(poses, H, W, draw_body=include_body, draw_hand=include_hand, draw_face=include_face) 
                      

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -543,12 +543,19 @@ class Script(scripts.Script):
             )
 
         def shift_preview(is_on):
-            if is_on:
-                return gr.update(visible=True), gr.update(value=None), gr.update(visible=True)
-            else:
-                return gr.update(visible=False), gr.update(), gr.update(visible=False)
+            return (
+                # trigger_preprocessor
+                gr.update(visible=is_on),
+                # generated_image
+                gr.update(value=None) if is_on else gr.update(),
+                # generated_image_group
+                gr.update(visible=is_on),
+                # download_pose_link
+                gr.update(value=None) if is_on else gr.update(),
+            )
 
-        preprocessor_preview.change(fn=shift_preview, inputs=[preprocessor_preview], outputs=[trigger_preprocessor, generated_image, generated_image_group])
+        preprocessor_preview.change(fn=shift_preview, inputs=[preprocessor_preview], 
+                                    outputs=[trigger_preprocessor, generated_image, generated_image_group, download_pose_link])
 
         if is_img2img:
             send_dimen_button.click(fn=send_dimensions, inputs=[input_image], outputs=[self.img2img_w_slider, self.img2img_h_slider])

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -123,12 +123,22 @@ def update_json_download_link(json_string: str, file_name: str) -> Dict:
     data_uri = f'data:application/json;base64,{base64_encoded_json}'
     style = """ 
     position: absolute;
-    right: 10%;
+    right: var(--size-2);
+    bottom: var(--size-2);
     font-size: x-small;
+    font-weight: bold;
+    padding: 2px;
+
+    box-shadow: var(--shadow-drop);
+    border: 1px solid var(--button-secondary-border-color);
+    border-radius: var(--radius-sm);
+    background: var(--background-fill-primary);
+    height: var(--size-5);
+    color: var(--block-label-text-color);
     """
     hint = "Download the pose as .json file"
     html = f"""<a href='{data_uri}' download='{file_name}' style="{style}" title="{hint}">
-                Download JSON</a>"""
+                {{JSON}}</a>"""
     return gr.update(
         value=html,
         visible=(json_string != '')

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -126,7 +126,8 @@ def update_json_download_link(json_string: str, file_name: str) -> Dict:
     right: 10%;
     font-size: x-small;
     """
-    html = f"""<a href='{data_uri}' download='{file_name}' class='cnet-download-json' style="{style}">
+    hint = "Download the pose as .json file"
+    html = f"""<a href='{data_uri}' download='{file_name}' style="{style}" title="{hint}">
                 Download JSON</a>"""
     return gr.update(
         value=html,

--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.119'
+version_flag = 'v1.1.120'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -189,13 +189,16 @@ class OpenposeModel(object):
             img: np.ndarray, 
             include_body: bool, 
             include_hand: bool, 
-            include_face: bool, 
+            include_face: bool,
+            json_pose_callback: Callable[[str], None],
             res: int = 512, 
             **kwargs  # Ignore rest of kwargs
         ) -> Tuple[np.ndarray, bool]:
         """Run the openpose model. Returns a tuple of
         - result image
         - is_image flag
+
+        The JSON format pose string is passed to `json_pose_callback`.
         """
         img = resize_image(HWC3(img), res)
         if self.model_openpose is None:
@@ -206,7 +209,8 @@ class OpenposeModel(object):
             img, 
             include_body=include_body, 
             include_hand=include_hand, 
-            include_face=include_face
+            include_face=include_face,
+            json_pose_callback=json_pose_callback
         ), True
     
     def unload(self):


### PR DESCRIPTION
This PR adds a link on the page to allow user to download openpose preprocessor result as JSON file.

The link only appears when:
- `Allow Preview` option is checked
- An openpose related model is selected
- Trigger button on preprocessor is clicked

The link will not disappear unless the preprocess is clicked again and another preprocessor is selected.

The JSON file format follows [openpose repo's output format](https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/doc/02_output.md).

![demo](https://user-images.githubusercontent.com/20929282/235280437-3666ae58-e4e3-4351-adf4-7f8561e3b886.png)

This is the first step to build an seamless integrated openpose editor(#1012). I will do some research on how to send the JSON to another extension and how to set the preprocessor image in controlnet.

