### PR TITLE
fix hints (toole tip) for webui when controlnet is enabled

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -1,18 +1,17 @@
-// mouseover tooltips for various UI elements
-titles_controlnet = {
-    '🔄': 'Refresh',
-    '\u2934': 'Send dimensions to stable diffusion',
-    '💥': 'Run preprocessor',
-    '📝': 'Open new canvas',
-    '📷': 'Enable webcam',
-    '⇄': 'Mirror webcam',
-};
-
-onUiUpdate(function(){
-	gradioApp().querySelectorAll('.cnet-toolbutton').forEach(function(button){
-		tooltip = titles_controlnet[button.textContent];
-		if(tooltip){
-			button.title = tooltip;
-		}
-	})
+onUiUpdate(function () {
+    // mouseover tooltips for various UI elements
+    const titles = {
+        '🔄': 'Refresh',
+        '\u2934': 'Send dimensions to stable diffusion',
+        '💥': 'Run preprocessor',
+        '📝': 'Open new canvas',
+        '📷': 'Enable webcam',
+        '⇄': 'Mirror webcam',
+    };
+    gradioApp().querySelectorAll('.cnet-toolbutton').forEach(function (button) {
+        const tooltip = titles[button.textContent];
+        if (tooltip) {
+            button.title = tooltip;
+        }
+    })
 });

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -1,5 +1,5 @@
 // mouseover tooltips for various UI elements
-titles = {
+titles_controlnet = {
     '🔄': 'Refresh',
     '\u2934': 'Send dimensions to stable diffusion',
     '💥': 'Run preprocessor',
@@ -10,7 +10,7 @@ titles = {
 
 onUiUpdate(function(){
 	gradioApp().querySelectorAll('.cnet-toolbutton').forEach(function(button){
-		tooltip = titles[button.textContent];
+		tooltip = titles_controlnet[button.textContent];
 		if(tooltip){
 			button.title = tooltip;
 		}


### PR DESCRIPTION
the hints (toole tip) used in controlnet overrides the hints used in webui
which extension enabled, the [hints in webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/javascript/hints.js) is broken
this fixes it

I'm not a web developer, so I'm not really familiar with JavaScript, I suspect they might be a more elegant way of fixing this.