### PR TITLE
Add back type annotation on BodyResult

### DIFF
--- a/annotator/openpose/body.py
+++ b/annotator/openpose/body.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import matplotlib
 import torch
 from torchvision import transforms
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Union
 
 from . import util
 from .model import bodypose_model
@@ -20,7 +20,12 @@ class Keypoint(NamedTuple):
 
 
 class BodyResult(NamedTuple):
-    keypoints: List[Keypoint | None]
+    # Note: Using `Union` instead of `|` operator as the ladder is a Python
+    # 3.10 feature.
+    # Annotator code should be Python 3.8 Compatible, as controlnet repo uses
+    # Python 3.8 environment.
+    # https://github.com/lllyasviel/ControlNet/blob/d3284fcd0972c510635a4f5abe2eeb71dc0de524/environment.yaml#L6
+    keypoints: List[Union[Keypoint, None]]
     total_score: float
     total_parts: int
 

--- a/annotator/openpose/body.py
+++ b/annotator/openpose/body.py
@@ -20,7 +20,7 @@ class Keypoint(NamedTuple):
 
 
 class BodyResult(NamedTuple):
-    keypoints: List
+    keypoints: List[Keypoint | None]
     total_score: float
     total_parts: int
 


### PR DESCRIPTION
The pipe operation on type annotation is introduced in Python 3.10. See [PEP 604](https://peps.python.org/pep-0604/).

User ran into issue when running with 3.8. 

Add back type annotation as it is a problem with the user's setup. 

Note:
I am not pumping up version in this PR as type annotation does not affect code execution.