### PR TITLE
fetch sliders_config by `/controlnet/module_list`

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -9,6 +9,7 @@ from modules.api.models import *
 from modules.api import api
 
 from scripts import external_code, global_state
+from scripts.processor import preprocessor_sliders_config
 
 def encode_to_base64(image):
     if type(image) is str:
@@ -37,9 +38,25 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
 
     @app.get("/controlnet/module_list")
     async def module_list(alias_names: bool = False):
-        _module_list = external_code.get_modules(alias_names)
-        print(_module_list)
-        return {"module_list": _module_list}
+        _module_list = external_code.get_modules(False)
+        _module_list_alias = external_code.get_modules(True)
+        _module_detail = {}
+        
+        _output_list = _module_list if not alias_names else _module_list_alias
+        for index, module in enumerate(_output_list):
+            if _module_list[index] in preprocessor_sliders_config:
+                _module_detail[module] = {
+                    "sliders": preprocessor_sliders_config[_module_list[index]]
+                }
+            else:
+                _module_detail[module] = {
+                    "sliders": []
+                }
+        
+        return {
+            "module_list": _output_list,
+            "module_detail": _module_detail
+        }
 
     @app.post("/controlnet/detect")
     async def detect(

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -38,24 +38,12 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
 
     @app.get("/controlnet/module_list")
     async def module_list(alias_names: bool = False):
-        _module_list = external_code.get_modules(False)
-        _module_list_alias = external_code.get_modules(True)
-        _module_detail = {}
-        
-        _output_list = _module_list if not alias_names else _module_list_alias
-        for index, module in enumerate(_output_list):
-            if _module_list[index] in preprocessor_sliders_config:
-                _module_detail[module] = {
-                    "sliders": preprocessor_sliders_config[_module_list[index]]
-                }
-            else:
-                _module_detail[module] = {
-                    "sliders": []
-                }
+        _module_list = external_code.get_modules(alias_names)
+        print(_module_list)
         
         return {
-            "module_list": _output_list,
-            "module_detail": _module_detail
+            "module_list": _module_list,
+            "module_detail": external_code.get_modules_detail(alias_names)
         }
 
     @app.post("/controlnet/detect")

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -369,7 +369,7 @@ class Script(scripts.Script):
             module = self.get_module_basename(module)
             if (module not in preprocessor_sliders_config): 
                 return [
-                    gr.update(visible=False, interactive=False),
+                    gr.update(label="Preprocessor resolution", value=512, minimum=64, maximum=2048, step=1, visible=not pp, interactive=not pp),
                     gr.update(visible=False, interactive=False),
                     gr.update(visible=False, interactive=False),
                     gr.update(visible=True)
@@ -379,17 +379,17 @@ class Script(scripts.Script):
                 grs = []
                 
                 if (len(slider_config) > 0 and slider_config[0] != 0):
-                    gr.update(label=slider_config[0].name, value=slider_config[0].value, minimum=slider_config[0].min, maximum=slider_config[0].max, step=slider_config[0].step if step in slider_config[0] else 1, visible=True, interactive=True)
+                    grs.append(gr.update(label=slider_config[0]['name'], value=slider_config[0]['value'], minimum=slider_config[0]['min'], maximum=slider_config[0]['max'], step=slider_config[0]['step'] if 'step' in slider_config[0] else 1, visible=not pp, interactive=not pp))
                 else: 
                     grs.append(gr.update(visible=False, interactive=False))
                     
-                if (len(slider_config) > 0 and slider_config[1] != 0):
-                    gr.update(label=slider_config[1].name, value=slider_config[1].value, minimum=slider_config[1].min, maximum=slider_config[1].max, step=slider_config[1].step if step in slider_config[1] else 1, visible=True, interactive=True)
+                if (len(slider_config) > 1 and slider_config[1] != 0):
+                    grs.append(gr.update(label=slider_config[1]['name'], value=slider_config[1]['value'], minimum=slider_config[1]['min'], maximum=slider_config[1]['max'], step=slider_config[1]['step'] if 'step' in slider_config[1] else 1, visible=True, interactive=True))
                 else: 
                     grs.append(gr.update(visible=False, interactive=False))
                     
                 if (len(slider_config) > 2 and slider_config[2] != 0):
-                    gr.update(label=slider_config[2].name, value=slider_config[2].value, minimum=slider_config[2].min, maximum=slider_config[2].max, step=slider_config[2].step if step in slider_config[2] else 1, visible=True, interactive=True)
+                    grs.append(gr.update(label=slider_config[2]['name'], value=slider_config[2]['value'], minimum=slider_config[2]['min'], maximum=slider_config[2]['max'], step=slider_config[2]['step'] if 'step' in slider_config[2] else 1, visible=True, interactive=True))
                 else:
                     grs.append(gr.update(visible=False, interactive=False))
                     

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from PIL import Image, ImageFilter, ImageOps
 from scripts.lvminthin import lvmin_thin, nake_nms
 from torchvision.transforms import Resize, InterpolationMode, CenterCrop, Compose
+from scripts.processor import preprocessor_sliders_config
 
 gradio_compat = True
 try:
@@ -366,104 +367,34 @@ class Script(scripts.Script):
 
         def build_sliders(module, pp):
             module = self.get_module_basename(module)
-            if module == "canny":
+            if (module not in preprocessor_sliders_config): 
                 return [
-                    gr.update(label="Preprocessor resolution", value=512, minimum=64, maximum=2048, step=1, visible=not pp, interactive=not pp),
-                    gr.update(label="Canny low threshold", minimum=1, maximum=255, value=100, step=1, visible=True, interactive=True),
-                    gr.update(label="Canny high threshold", minimum=1, maximum=255, value=200, step=1, visible=True, interactive=True),
-                    gr.update(visible=True)
-                ]
-            elif module == "mlsd": #Hough
-                return [
-                    gr.update(label="Preprocessor Resolution", minimum=64, maximum=2048, value=512, step=1, visible=not pp, interactive=not pp),
-                    gr.update(label="Hough value threshold (MLSD)", minimum=0.01, maximum=2.0, value=0.1, step=0.01, visible=True, interactive=True),
-                    gr.update(label="Hough distance threshold (MLSD)", minimum=0.01, maximum=20.0, value=0.1, step=0.01, visible=True, interactive=True),
-                    gr.update(visible=True)
-                ]
-            elif module in ["hed", "scribble_hed", "hed_safe"]:
-                return [
-                    gr.update(label="Preprocessor Resolution", minimum=64, maximum=2048, value=512, step=1, visible=not pp, interactive=not pp),
+                    gr.update(visible=False, interactive=False),
                     gr.update(visible=False, interactive=False),
                     gr.update(visible=False, interactive=False),
                     gr.update(visible=True)
-                ]
-            elif module in ["openpose", "openpose_full", "segmentation"]:
-                return [
-                    gr.update(label="Preprocessor Resolution", minimum=64, maximum=2048, value=512, step=1, visible=not pp, interactive=not pp),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=True)
-                ]
-            elif module == "depth":
-                return [
-                    gr.update(label="Preprocessor Resolution", minimum=64, maximum=2048, value=512, step=1, visible=not pp, interactive=not pp),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=True)
-                ]
-            elif module in ["depth_leres", "depth_leres++"]:
-                return [
-                    gr.update(label="Preprocessor Resolution", minimum=64, maximum=2048, value=512, step=1, visible=not pp, interactive=not pp),
-                    gr.update(label="Remove Near %", value=0, minimum=0, maximum=100, step=0.1, visible=True, interactive=True),
-                    gr.update(label="Remove Background %", value=0, minimum=0, maximum=100, step=0.1, visible=True, interactive=True),
-                    gr.update(visible=True)
-                ]
-            elif module == "normal_map":
-                return [
-                    gr.update(label="Preprocessor Resolution", minimum=64, maximum=2048, value=512, step=1, visible=not pp, interactive=not pp),
-                    gr.update(label="Normal background threshold", minimum=0.0, maximum=1.0, value=0.4, step=0.01, visible=True, interactive=True),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=True)
-                ]
-            elif module == "threshold":
-                return [
-                    gr.update(label="Preprocessor resolution", value=512, minimum=64, maximum=2048, step=1, visible=not pp, interactive=not pp),
-                    gr.update(label="Binarization Threshold", minimum=0, maximum=255, value=127, step=1, visible=True, interactive=True),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=True)
-                ]
-            elif module == "scribble_xdog":
-                return [
-                    gr.update(label="Preprocessor resolution", value=512, minimum=64, maximum=2048, step=1, visible=not pp, interactive=not pp),
-                    gr.update(label="XDoG Threshold", minimum=1, maximum=64, value=32, step=1, visible=True, interactive=True),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=True)
-                ]
-            elif module == "tile_resample":
-                return [
-                    gr.update(visible=False, interactive=False),
-                    gr.update(label="Down Sampling Rate", value=1.0, minimum=1.0, maximum=8.0, step=0.01, visible=True, interactive=True),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=True)
-                ]
-            elif module == "color":
-                return [
-                    gr.update(label="Preprocessor Resolution", value=512, minimum=64, maximum=2048, step=8, visible=not pp, interactive=not pp),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=True)
-                ]
-            elif module == "mediapipe_face":
-                return [
-                    gr.update(label="Preprocessor Resolution", value=512, minimum=64, maximum=2048, step=8, visible=not pp, interactive=not pp),
-                    gr.update(label="Max Faces", value=1, minimum=1, maximum=10, step=1, visible=True, interactive=True),
-                    gr.update(label="Min Face Confidence", value=0.5, minimum=0.01, maximum=1.0, step=0.01, visible=True, interactive=True),
-                    gr.update(visible=True)
-                ]
-            elif module == "none" or "inpaint" in module:
-                return [
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=False)
                 ]
             else:
-                return [
-                    gr.update(label="Preprocessor resolution", value=512, minimum=64, maximum=2048, step=1, visible=not pp, interactive=not pp),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=True)
-                ]
+                slider_config = preprocessor_sliders_config[module]
+                grs = []
+                
+                if (len(slider_config) > 0 and slider_config[0] != 0):
+                    gr.update(label=slider_config[0].name, value=slider_config[0].value, minimum=slider_config[0].min, maximum=slider_config[0].max, step=slider_config[0].step if step in slider_config[0] else 1, visible=True, interactive=True)
+                else: 
+                    grs.append(gr.update(visible=False, interactive=False))
+                    
+                if (len(slider_config) > 0 and slider_config[1] != 0):
+                    gr.update(label=slider_config[1].name, value=slider_config[1].value, minimum=slider_config[1].min, maximum=slider_config[1].max, step=slider_config[1].step if step in slider_config[1] else 1, visible=True, interactive=True)
+                else: 
+                    grs.append(gr.update(visible=False, interactive=False))
+                    
+                if (len(slider_config) > 2 and slider_config[2] != 0):
+                    gr.update(label=slider_config[2].name, value=slider_config[2].value, minimum=slider_config[2].min, maximum=slider_config[2].max, step=slider_config[2].step if step in slider_config[2] else 1, visible=True, interactive=True)
+                else:
+                    grs.append(gr.update(visible=False, interactive=False))
+                    
+                grs.append(gr.update(visible=True))
+                return grs
 
         # advanced options
         with gr.Column(visible=False) as advanced:

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -287,6 +287,32 @@ def get_modules(alias_names: bool = False) -> List[str]:
 
     return modules
 
+def get_modules_detail(alias_names: bool = False) -> Dict[str, Any]:
+    """
+    get the detail of all preprocessors including
+    sliders: the slider config in Auto1111 webUI
+
+    Keyword arguments:
+    alias_names -- Whether to get the module detail with alias names instead of internal keys
+    """
+
+    _module_detail = {}
+    _module_list = external_code.get_modules(False)
+    _module_list_alias = external_code.get_modules(True)
+    
+    _output_list = _module_list if not alias_names else _module_list_alias
+    for index, module in enumerate(_output_list):
+        if _module_list[index] in preprocessor_sliders_config:
+            _module_detail[module] = {
+                "sliders": preprocessor_sliders_config[_module_list[index]]
+            }
+        else:
+            _module_detail[module] = {
+                "sliders": []
+            }
+            
+    return _module_detail
+
 
 def find_cn_script(script_runner: scripts.ScriptRunner) -> Optional[scripts.Script]:
     """

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -6,6 +6,234 @@ from typing import Callable, Tuple
 
 model_canny = None
 
+preprocessor_sliders_config = {
+    "canny": [
+        {
+            "name": "Preprocessor resolution",
+            "value": 512,
+            "min": 64,
+            "max": 2048
+        },
+        {
+            "name": "Canny low threshold",
+            "value": 100,
+            "min": 1,
+            "max": 255
+        },
+        {
+            "name": "Canny high threshold",
+            "value": 200,
+            "min": 1,
+            "max": 255
+        },
+    ],
+    "mlsd": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        },
+        {
+            "name": "Hough value threshold (MLSD)",
+            "min": 0.01,
+            "max": 2.0,
+            "value": 0.1,
+            "step": 0.01
+        },
+        {
+            "name": "Hough distance threshold (MLSD)",
+            "min": 0.01,
+            "max": 20.0,
+            "value": 0.1,
+            "step": 0.01
+        }
+    ],
+    "hed": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        }
+    ],
+    "scribble_hed": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        }
+    ],
+    "hed_safe": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        }
+    ],
+    "openpose": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        }
+    ],
+    "openpose_full": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        }
+    ],
+    "segmentation": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        }
+    ],
+    "depth": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        }
+    ],
+    "depth_leres": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        },
+        {
+            "name": "Remove Near %",
+            "min": 0,
+            "max": 100,
+            "value": 0,
+            "step": 0.1,
+        },
+        {
+            "name": "Remove Background %",
+            "min": 0,
+            "max": 100,
+            "value": 0,
+            "step": 0.1,
+        }
+    ],
+    "depth_leres++": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        },
+        {
+            "name": "Remove Near %",
+            "min": 0,
+            "max": 100,
+            "value": 0,
+            "step": 0.1,
+        },
+        {
+            "name": "Remove Background %",
+            "min": 0,
+            "max": 100,
+            "value": 0,
+            "step": 0.1,
+        }
+    ],
+    "normal_map": [
+        {
+            "name": "Preprocessor Resolution",
+            "min": 64,
+            "max": 2048,
+            "value": 512
+        },
+        {
+            "name": "Normal background threshold",
+            "min": 0.0,
+            "max": 1.0,
+            "value": 0.4,
+            "step": 0.01
+        }
+    ],
+    "threshold": [
+        {
+            "name": "Preprocessor resolution",
+            "value": 512,
+            "min": 64,
+            "max": 2048
+        },
+        {
+            "name": "Binarization Threshold",
+            "min": 0,
+            "max": 255,
+            "value": 127
+        }
+    ],
+
+    "scribble_xdog": [
+        {
+            "name": "Preprocessor resolution",
+            "value": 512,
+            "min": 64,
+            "max": 2048
+        },
+        {
+            "name": "XDoG Threshold",
+            "min": 1,
+            "max": 64,
+            "value": 32,
+        }
+    ],
+    "tile_resample": [
+        0,
+        {
+            "name": "Down Sampling Rate",
+            "value": 1.0,
+            "min": 1.0,
+            "max": 8.0,
+            "step": 0.01
+        }
+    ],
+    "color": [
+        {
+            "name": "Preprocessor Resolution",
+            "value": 512,
+            "min": 64,
+            "max": 2048,
+        }
+    ],
+    "mediapipe_face": [
+        {
+            "name": "Preprocessor Resolution",
+            "value": 512,
+            "min": 64,
+            "max": 2048,
+        },
+        {
+            "name": "Max Faces",
+            "value": 1,
+            "min": 1,
+            "max": 10,
+            "step": 1
+        },
+        {
+            "name": "Min Face Confidence",
+            "value": 0.5,
+            "min": 0.01,
+            "max": 1.0,
+            "step": 0.01
+        }
+    ],
+}
 
 def canny(img, res=512, thr_a=100, thr_b=200, **kwargs):
     l, h = thr_a, thr_b

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,7 +33,7 @@ def get_model():
 
 
 def get_modules():
-    return requests.get(f"{BASE_URL}/controlnet/module_list").json().get('module_list', [])
+    return requests.get(f"{BASE_URL}/controlnet/module_list").json()
 
 
 def detect(json):

--- a/tests/web_api/txt2img_test.py
+++ b/tests/web_api/txt2img_test.py
@@ -101,9 +101,12 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
         self.assert_status_ok()
 
     def test_call_with_preprocessors(self):
-        avaliable_modules = utils.get_modules()
+        available_modules = utils.get_modules()
+        available_modules_list = available_modules.get('module_list', [])
+        available_modules_detail = available_modules.get('module_detail', {})
         for module in ['depth', 'openpose_full']:
-            assert module in avaliable_modules, f'Failed to find {module}.'
+            assert module in available_modules_list, f'Failed to find {module}.'
+            assert module in available_modules_detail, f"Failed to find {module}'s detail."
             with self.subTest(module=module):
                 self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"] = [
                     {


### PR DESCRIPTION
I'm contributing to the [Auto-Photoshop-StableDiffusion-Plugin](https://github.com/AbdullahAlfaraj/Auto-Photoshop-StableDiffusion-Plugin)
When I was implementing the ThresholdA/B in it, I found that all the sliders config is hardcoded in sd-webui-controlnet.
I think it is better to expose them in the API, so external tools like [Auto-Photoshop-StableDiffusion-Plugin](https://github.com/AbdullahAlfaraj/Auto-Photoshop-StableDiffusion-Plugin) or plugin in Blender etc. could build ThresholdA/B sliders without hardcoding the settings of sliders in their code.
