### PR TITLE
little bug fix: preprocessor is none but has resolution slider

### DIFF
--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -7,6 +7,9 @@ from typing import Callable, Tuple
 model_canny = None
 
 preprocessor_sliders_config = {
+    "none": [
+        
+    ],
     "canny": [
         {
             "name": "Preprocessor resolution",


### PR DESCRIPTION
Thanks for you patiently correction in #1166

------

here is a liitle bugfix:

when preprocessor is none and keep recheck/uncheck PixelPerfect, the resolution slider will show,

the bug is existed before #1166

![image](https://user-images.githubusercontent.com/5595819/236657626-11c0a275-c267-4be9-93b1-ff3645b44842.png)
