### PR TITLE
try to fix collapse in ref-only

### DIFF
--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.162'
+version_flag = 'v1.1.163'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -344,14 +344,14 @@ class UnetHook(nn.Module):
 
                 if param.cfg_injection:
                     ref_uncond_xt = x.clone()
-                    print('ontrolNet More Important -  Using standard cfg.')
+                    # print('ontrolNet More Important -  Using standard cfg for reference.')
                 elif param.soft_injection or is_in_high_res_fix:
                     ref_uncond_xt = ref_cond_xt.clone()
-                    print('Prompt More Important -  Using no cfg.')
+                    # print('Prompt More Important -  Using no cfg for reference.')
                 else:
                     time_weight = (timesteps.float() / 1000.0).clip(0, 1)[:, None, None, None]
                     ref_uncond_xt = x * time_weight + ref_cond_xt.clone() * (1.0 - time_weight)
-                    print('Balanced -  Using time-balanced cfg.')
+                    # print('Balanced -  Using time-balanced cfg for reference.')
 
                 ref_xt = ref_cond_xt * uc_mask + ref_uncond_xt * (1 - uc_mask)
 

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -344,7 +344,7 @@ class UnetHook(nn.Module):
 
                 if param.cfg_injection:
                     ref_uncond_xt = x.clone()
-                    # print('ontrolNet More Important -  Using standard cfg for reference.')
+                    # print('ControlNet More Important -  Using standard cfg for reference.')
                 elif param.soft_injection or is_in_high_res_fix:
                     ref_uncond_xt = ref_cond_xt.clone()
                     # print('Prompt More Important -  Using no cfg for reference.')

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -351,7 +351,7 @@ class UnetHook(nn.Module):
                 else:
                     time_weight = (timesteps.float() / 1000.0).clip(0, 1)[:, None, None, None]
                     ref_uncond_xt = x * time_weight + ref_cond_xt.clone() * (1.0 - time_weight)
-                    # print('Balanced -  Using time-balanced cfg for reference.')
+                    # print('Balanced - Using time-balanced cfg for reference.')
 
                 ref_xt = ref_cond_xt * uc_mask + ref_uncond_xt * (1 - uc_mask)
 


### PR DESCRIPTION
It seems work now

this is a midjourney image as input (https://www.reddit.com/r/midjourney/comments/11wsoy8/random_people_on_the_streets/)
<img src="https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/720c5dcd-2961-4bd3-8315-1f7f76a3f083" width="350">

this is before fix (1.1.162)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/7b508518-4a49-427a-ba40-8f4e09b587ef)

this is after fix (1.1.163)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/189a268e-9079-4770-a2dd-a8fce31698b8)

Image is not perfect since I am not using any advanced method - just a low res diffusion pass with 20 Eluar A steps

meta:

handsome man in street, masterpiece, best quality, 4k, 8k, hat

Negative prompt: lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry
Steps: 20, Sampler: Euler a, CFG scale: 5, Seed: 123456, Size: 768x512, Model hash: c0d1994c73, Model: realisticVisionV20_v20, Clip skip: 2, Version: v1.2.0, ControlNet 0: "preprocessor: reference_only, model: None, weight: 1, starting/ending: (0, 1), resize mode: Crop and Resize, pixel perfect: True, control mode: Balanced, preprocessor params: (64, 64, 64)"

Note that sometimes using lower cfg can fix problems (for example cfg=5) but it should be much better than before even if you use 7 or 9 or higher.

I personally prefer "Balanced"

Or we can just use "My prompt is more important"

note that if you want to use the effect before fix, you can select "ControlNet is more important" - it use same method like before the fix.

Well just like all other CNs:

"Balanced" = balanced cfg scale (using whatever method to balance CN and your prompts)
"My prompt is more important" = CN on both sides of cfg scale
"ControlNet is more important" = CN on cond side of cfg scale