### PR TITLE
add preprocessor reference_adain and adain_attn

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1214,9 +1214,10 @@ class Script(scripts.Script):
             if model_net is not None:
                 if model_net.config.model.params.get("global_average_pooling", False):
                     global_average_pooling = True
-            else:
+            elif unit.module in model_free_preprocessors:
                 # Pass preprocessor parameters to model-free control
                 model_net = dict(
+                    name=unit.module,
                     preprocessor_resolution=preprocessor_resolution,
                     threshold_a=unit.threshold_a,
                     threshold_b=unit.threshold_b

--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.170'
+version_flag = 'v1.1.171'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -52,6 +52,8 @@ cn_preprocessor_modules = {
     "invert": invert,
     "lineart_anime_denoise": lineart_anime_denoise,
     "reference_only": identity,
+    "reference_adain": identity,
+    "reference_adain+attn": identity,
     "inpaint": identity,
 }
 

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -553,7 +553,12 @@ def shuffle(img, res=512, **kwargs):
     return result, True
 
 
-model_free_preprocessors = ["reference_only"]
+model_free_preprocessors = [
+    "reference_only",
+    "reference_adain",
+    "reference_adain+attn"
+]
+
 flag_preprocessor_resolution = "Preprocessor Resolution"
 preprocessor_sliders_config = {
     "none": [],
@@ -755,6 +760,26 @@ preprocessor_sliders_config = {
         }
     ],
     "reference_only": [
+        None,
+        {
+            "name": r'Style Fidelity (only for "Balanced" mode)',
+            "value": 0.5,
+            "min": 0.0,
+            "max": 1.0,
+            "step": 0.01
+        }
+    ],
+    "reference_adain": [
+        None,
+        {
+            "name": r'Style Fidelity (only for "Balanced" mode)',
+            "value": 0.5,
+            "min": 0.0,
+            "max": 1.0,
+            "step": 0.01
+        }
+    ],
+    "reference_adain+attn": [
         None,
         {
             "name": r'Style Fidelity (only for "Balanced" mode)',


### PR DESCRIPTION
V1.1.171 adds two new reference preprocessors:

**reference_adain**
AdaIn (Adaptive Instance Normalization) from
Arbitrary Style Transfer in Real-time with Adaptive Instance Normalization
https://arxiv.org/abs/1703.06868

**reference_adain+attn**
AdaIn (Adaptive Instance Normalization) + Attention link same as "reference_only"

### Comparison
source (midjourney v5, https://twitter.com/kajikent/status/1654409097041817601)

<img src="https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/4df7ec51-6a7f-4766-a0df-9b8153dc33d4" width="350">

meta

woman in street, masterpiece, best quality,
Negative prompt: lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry
Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 12345, Size: 768x512, Model hash: c0d1994c73, Model: realisticVisionV20_v20, Version: v1.2.0, ControlNet 0: "preprocessor: reference_????, model: None, weight: 1, starting/ending: (0, 1), resize mode: Crop and Resize, pixel perfect: True, control mode: Balanced, preprocessor params: (64, 0.5, 64)"

reference_only:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/d26e684c-cc8b-44cb-9829-3b836093ad05)

reference_adain:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/0283658f-f613-4f3d-91af-85c12e49e487)

reference_adain+attn:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/506fa282-48d3-4223-b61f-4af4b621522f)

without CN (all controlnets disabled):
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/45159c36-1f56-4744-b58b-c54f2600f30d)

