### PR TITLE
Prevent double print of version

### DIFF
--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,5 +1,6 @@
 version_flag = 'v1.1.173'
-print(f'ControlNet {version_flag}')
+if hasattr(__loader__, 'name') and getattr(__loader__, 'name') == 'controlnet_version.py':
+    print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"
 # This means if user did not completely restart terminal, the "version_flag" will be the previous version.


### PR DESCRIPTION
Prevents the version number printing twice in the console (example of current behavior can be seen [here](https://github.com/Mikubill/sd-webui-controlnet/issues/1036)). I don't believe this breaks the other functionality mentioned in the comments in this file.