### PR TITLE
Add enabled extension list requirement to bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -70,6 +70,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: extensions
+    attributes:
+      label: List of enabled extensions
+      description: Please provide a **full** list of **enabled** extensions. This list can found on the "Extensions" tab.
+    validations:
+      required: true
+  - type: textarea
     id: logs
     attributes:
       label: Console logs


### PR DESCRIPTION
More and more issues are being opened that are caused by other 3rd party extensions that should be reported upstream but are not (https://github.com/Mikubill/sd-webui-controlnet/issues/1301, https://github.com/Mikubill/sd-webui-controlnet/issues/1284, https://github.com/Mikubill/sd-webui-controlnet/issues/1239, https://github.com/Mikubill/sd-webui-controlnet/issues/1296, https://github.com/Mikubill/sd-webui-controlnet/issues/1265). This PR adds a new requirement to creating bug reports that asks for a list of all enabled extensions.

I'm going to open a PR in the main web UI repo soon to add a button or similar to copy the list of enabled extensions for easy pasting, but hopefully we could add this now to narrow down the amount of bogus reports we're receiving.