### PR TITLE
shift to cfg-scale based style fidelity

### DIFF
--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.173'
+version_flag = 'v1.1.174'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"


### PR DESCRIPTION
This is an attempt to address most collapse problems of the reference preprocessor.
Now we are using time step to guide the scale, but it is wrong from a mathematic perspective - this commit brings a real cfg-like guidance, which leads to significantly fewer artifacts.
