### PR TITLE
Improve slider UI performance

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -552,6 +552,8 @@ class Script(scripts.Script):
                 event_subscribers.append(comp.edit)
             elif hasattr(comp, 'click'):
                 event_subscribers.append(comp.click)
+            elif isinstance(comp, gr.Slider) and hasattr(comp, 'release'):
+                event_subscribers.append(comp.release)
             elif hasattr(comp, 'change'):
                 event_subscribers.append(comp.change)
 


### PR DESCRIPTION
Currently, sliders in ControlNet use the `change` event, which is very sluggish when modifying values. This changes it to use `release` instead, resulting in much better visual performance.

<details>
<summary>Current behavior</summary>

![old](https://github.com/Mikubill/sd-webui-controlnet/assets/122327233/969f2aed-988a-4078-919d-22fee00387f6)
</details>

<details>
<summary>New behavior</summary>

![new](https://github.com/Mikubill/sd-webui-controlnet/assets/122327233/69d594ab-78ee-4189-8de6-c3dc37c9e1a0)
</details>

(Ignore offset slider positions, it's due to my txt2img panel size)