### PR TITLE
[Enhancement] Cache preprocessor results

### DIFF
--- a/preload.py
+++ b/preload.py
@@ -1,4 +1,7 @@
 def preload(parser):
+    parser.add_argument("--controlnet-dir", type=str, help="Path to directory with ControlNet models", default=None)
+    parser.add_argument("--controlnet-annotator-models-path", type=str, help="Path to directory with annotator model directories", default=None)
+    parser.add_argument("--no-half-controlnet", action='store_true', help="do not switch the ControlNet models to 16-bit floats (only needed without --no-half)", default=None)
     # Setting default max_size=16 as each cache entry contains image as both key 
     # and value (Very costly).
     parser.add_argument(

--- a/preload.py
+++ b/preload.py
@@ -1,4 +1,9 @@
 def preload(parser):
-    parser.add_argument("--controlnet-dir", type=str, help="Path to directory with ControlNet models", default=None)
-    parser.add_argument("--controlnet-annotator-models-path", type=str, help="Path to directory with annotator model directories", default=None)
-    parser.add_argument("--no-half-controlnet", action='store_true', help="do not switch the ControlNet models to 16-bit floats (only needed without --no-half)", default=None)
+    # Setting default max_size=16 as each cache entry contains image as both key 
+    # and value (Very costly).
+    parser.add_argument(
+        "--controlnet-preprocessor-cache-size",
+        type=int,
+        help="Cache size for controlnet preprocessor",
+        default=16,
+    )

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -46,6 +46,7 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
             "module_detail": external_code.get_modules_detail(alias_names)
         }
 
+    cached_cn_preprocessors = global_state.cache_preprocessors(global_state.cn_preprocessor_modules)
     @app.post("/controlnet/detect")
     async def detect(
         controlnet_module: str = Body("none", title='Controlnet Module'),
@@ -56,7 +57,7 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
     ):
         controlnet_module = global_state.reverse_preprocessor_aliases.get(controlnet_module, controlnet_module)
 
-        if controlnet_module not in global_state.cn_preprocessor_modules:
+        if controlnet_module not in cached_cn_preprocessors:
             raise HTTPException(
                 status_code=422, detail="Module not available")
 
@@ -68,7 +69,7 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
 
         results = []
 
-        processor_module = global_state.cn_preprocessor_modules[controlnet_module]
+        processor_module = cached_cn_preprocessors[controlnet_module]
 
         for input_image in controlnet_input_images:
             img = external_code.to_base64_nparray(input_image)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -471,7 +471,19 @@ class Script(scripts.Script):
             json_acceptor = JsonAcceptor()
 
             print(f'Preview Resolution = {pres}')
-            result, is_image = preprocessor(img, res=pres, thr_a=pthr_a, thr_b=pthr_b, json_pose_callback=json_acceptor.accept)
+
+            def is_openpose(module: str):
+                return 'openpose' in module
+            
+            # Only openpose preprocessor returns a JSON output, pass json_acceptor
+            # only when a JSON output is expected. This will make preprocessor cache
+            # work for all other preprocessors other than openpose ones. JSON acceptor
+            # instance are different every call, which means cache will never take 
+            # effect.
+            # TODO: Maybe we should let `preprocessor` return a Dict to alleviate this issue?
+            # This requires changing all callsites though.
+            result, is_image = preprocessor(img, res=pres, thr_a=pthr_a, thr_b=pthr_b,
+                                            json_pose_callback=json_acceptor.accept if is_openpose(module) else None)
 
             if preprocessor is processor.clip:
                 result = processor.clip_vision_visualization(result)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -206,7 +206,7 @@ class Script(scripts.Script):
     def __init__(self) -> None:
         super().__init__()
         self.latest_network = None
-        self.preprocessor = global_state.cn_preprocessor_modules
+        self.preprocessor = global_state.cache_preprocessors(global_state.cn_preprocessor_modules)
         self.unloadable = global_state.cn_preprocessor_unloadable
         self.input_image = None
         self.latest_model_hash = ""

--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.185'
+version_flag = 'v1.1.186'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,6 +1,9 @@
 import torch
 import os
+import functools
+import numpy as np
 
+from typing import Any, Callable
 
 def load_state_dict(ckpt_path, location='cpu'):
     _, extension = os.path.splitext(ckpt_path)
@@ -17,3 +20,46 @@ def load_state_dict(ckpt_path, location='cpu'):
 
 def get_state_dict(d):
     return d.get('state_dict', d)
+
+
+def ndarray_lru_cache(max_size: int = 128, typed: bool = False):
+    """
+    Decorator to enable caching for functions with numpy array arguments.
+    Numpy arrays are mutable, and thus not directly usable as hash keys.
+    """
+
+    def decorator(func: Callable):
+        """The actual decorator that accept function as input."""
+
+        class HashableNpArray(np.ndarray):
+            def __new__(cls, input_array):
+                # Input array is an instance of ndarray.
+                # The view makes the input array and returned array share the same data.
+                obj = np.asarray(input_array).view(cls)
+                return obj
+
+            def __eq__(self, other) -> bool:
+                return np.array_equal(self, other)
+
+            def __hash__(self):
+                # Hash the bytes representing the data of the array.
+                return hash(self.tobytes())
+
+        @functools.lru_cache(maxsize=max_size, typed=typed)
+        def cached_func(*args, **kwargs):
+            """This function only accepts `HashableNpArray` as input params."""
+            return func(*args, **kwargs)
+
+        def decorated_func(*args, **kwargs):
+            """The decorated function that delegates the original function."""
+
+            def convert_item(item: Any):
+                return HashableNpArray(item) if isinstance(item, np.ndarray) else item
+
+            args = [convert_item(arg) for arg in args]
+            kwargs = {k: convert_item(arg) for k, arg in kwargs.items()}
+            return cached_func(*args, **kwargs)
+
+        return decorated_func
+
+    return decorator

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -26,6 +26,13 @@ def ndarray_lru_cache(max_size: int = 128, typed: bool = False):
     """
     Decorator to enable caching for functions with numpy array arguments.
     Numpy arrays are mutable, and thus not directly usable as hash keys.
+
+    The idea here is to wrap the incoming arguments with type `np.ndarray`
+    as `HashableNpArray` so that `lru_cache` can correctly handles `np.ndarray`
+    arguments.
+
+    `HashableNpArray` functions exactly the same way as `np.ndarray` except
+    having `__hash__` and `__eq__` overriden.
     """
 
     def decorator(func: Callable):
@@ -50,6 +57,8 @@ def ndarray_lru_cache(max_size: int = 128, typed: bool = False):
             """This function only accepts `HashableNpArray` as input params."""
             return func(*args, **kwargs)
 
+        # Preserves original function.__name__ and __doc__.
+        @functools.wraps(func)
         def decorated_func(*args, **kwargs):
             """The decorated function that delegates the original function."""
 

--- a/tests/cn_script/utils_test.py
+++ b/tests/cn_script/utils_test.py
@@ -1,0 +1,65 @@
+import importlib
+utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
+utils.setup_test_env()
+
+from scripts.utils import ndarray_lru_cache
+
+import unittest
+import numpy as np
+
+class TestNumpyLruCache(unittest.TestCase):
+
+    def setUp(self):
+        self.arr1 = np.array([1, 2, 3, 4, 5])
+        self.arr2 = np.array([1, 2, 3, 4, 5])
+
+    @ndarray_lru_cache(max_size=128)
+    def add_one(self, arr):
+        return arr + 1
+
+    def test_same_array(self):
+        # Test that the decorator works with numpy arrays.
+        result1 = self.add_one(self.arr1)
+        result2 = self.add_one(self.arr1)
+
+        # If caching is working correctly, these should be the same object.
+        self.assertIs(result1, result2)
+
+    def test_different_array_same_data(self):
+        # Test that the decorator works with different numpy arrays with the same data.
+        result1 = self.add_one(self.arr1)
+        result2 = self.add_one(self.arr2)
+
+        # If caching is working correctly, these should be the same object.
+        self.assertIs(result1, result2)
+
+    def test_cache_size(self):
+        # Test that the cache size limit is respected.
+        arrs = [np.array([i]) for i in range(150)]
+
+        # Add all arrays to the cache.
+        
+        result1 = self.add_one(arrs[0])
+        for arr in arrs[1:]:
+            self.add_one(arr)
+
+        # Check that the first array is no longer in the cache.
+        result2 = self.add_one(arrs[0])
+
+        # If the cache size limit is working correctly, these should not be the same object.
+        self.assertIsNot(result1, result2)
+
+    def test_large_array(self):
+        # Create two large arrays with the same elements in the beginning and end, but one different element in the middle.
+        arr1 = np.ones(10000)
+        arr2 = np.ones(10000)
+        arr2[len(arr2)//2] = 0
+
+        result1 = self.add_one(arr1)
+        result2 = self.add_one(arr2)
+
+        # If hashing is working correctly, these should not be the same object because the input arrays are not equal.
+        self.assertIsNot(result1, result2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#807 attempts to add a cache for preprocessor, but using an inefficient way:
- Use str(ndarray) as hash will make array with same start & end return same hash
- Each time the preprocessor is called, the caching decorator is reapplied

#1238 also requests us adding cache for preprocessor.

This PR adds an shared LRU cache of size 16 for all preprocessor functions. We can debate the cache size later. I set it to 16 as I feel like I often don't need longer history of preprocessor results.

Currently openpose preprocessor will not be cached when called with trigger button in preview, as each time the preprocessor receives a new instance of `JsonAcceptor`. We probably will want to rework the function signature of preprocessor later so that openpose preprocessor can be cached as well.