### PR TITLE
Fetch control_net_max_models_num settings from the api

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -45,6 +45,11 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
             "module_list": _module_list,
             "module_detail": external_code.get_modules_detail(alias_names)
         }
+    
+    @app.get("/controlnet/settings")
+    async def settings():
+        max_models_num = external_code.get_max_models_num()
+        return {"control_net_max_models_num":max_models_num}
 
     cached_cn_preprocessors = global_state.cache_preprocessors(global_state.cn_preprocessor_modules)
     @app.post("/controlnet/detect")

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -168,6 +168,13 @@ def get_single_unit_from(script_args: List[Any], index: int=0) -> Optional[Contr
 
     return None
 
+def get_max_models_num():
+    """
+    Fetch the maximum number of allowed ControlNet models. 
+    """
+
+    max_models_num = shared.opts.data.get("control_net_max_models_num", 1)
+    return max_models_num
 
 def to_processing_unit(unit: Union[Dict[str, Any], ControlNetUnit]) -> ControlNetUnit:
     """


### PR DESCRIPTION
In the Auto-Photoshop plugin, we extract the number of ```control_net_max_models_num``` from the ```/config``` endpoint. However, this doesn’t always work due to user interface localization as in [this]( https://github.com/AbdullahAlfaraj/Auto-Photoshop-StableDiffusion-Plugin/issues/266). 
This pull request makes it easier for third-party tools to get the number of max units from the API.