### PR TITLE
[UI Update] The Control Type Filter is finally implemented

### DIFF
--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.191'
+version_flag = 'v1.1.192'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -820,3 +820,23 @@ preprocessor_sliders_config = {
         }
     ],
 }
+
+preprocessor_filters = {
+    "All": "none",
+    "Invert": "invert (from white bg & black line)",
+    "Canny": "canny",
+    "Depth": "depth_midas",
+    "Normal": "normal_bae",
+    "OpenPose": "openpose_full",
+    "MLSD": "mlsd",
+    "Lineart": "lineart_standard (from white bg & black line)",
+    "SoftEdge": "softedge_pidinet",
+    "Scribble": "scribble_pidinet",
+    "Seg": "seg_ofade20k",
+    "Shuffle": "shuffle",
+    "Tile": "tile_resample",
+    "Inpaint": "inpaint_global_harmonious",
+    "IP2P": "none",
+    "Reference": "reference_only",
+    "T2IA": "none",
+}


### PR DESCRIPTION
Beginning from 1.1.192, we will add a quick shortcut in UI, the Control Type filter.

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/3b258400-25a7-414c-9fa9-2bc0b4cd9961)

You can turn off this quick filter in setting if you prefer not to have it, using the option “Disable control type selection”:

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/6ebbecd5-d5fe-446a-8a6d-48752153d86f)

This filter has two functionalities:

First, if you select one type of control, your preprocessor list and model list will only show items of that type. You can always select “All” to see all preprocessors/models just like before. For example, I select “depth”

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/a5c25cbd-2c0b-4c51-92b4-f865d67c4738)

Then

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/e67c245a-e681-4224-a072-1446b84998d5)

Second, if you select one type of control, it will automatically select a default combination of that control. For example, I select “depth”

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/e619ba74-f4a2-4bae-9a18-28ec3221a6c3)

Then

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/b61e6e11-5edf-4595-9c84-03ebda4cc9f2)

Note that this filter has nothing to do with API and code logics so it will has zero influence to all other extensions.

Now we can swift methods much easier. And we do not need to worry about the list growing longer and longer.

**You need at least 1.1.192 to use it.**
