### PR TITLE
add tile_colorfix

### DIFF
--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.194'
+version_flag = 'v1.1.195'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -88,6 +88,7 @@ cn_preprocessor_modules = {
     "reference_adain": identity,
     "reference_adain+attn": identity,
     "inpaint": identity,
+    "tile_colorfix": identity,
 }
 
 cn_preprocessor_unloadable = {

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -504,7 +504,11 @@ class UnetHook(nn.Module):
                     continue
                 if param.preprocessor['name'] not in ['tile_colorfix']:
                     continue
+
                 k = int(param.preprocessor['threshold_a'])
+                if is_in_high_res_fix:
+                    k *= 2
+
                 x0_origin = param.used_hint_cond_latent
                 t = torch.round(timesteps.float()).long()
                 x0_prd = predict_start_from_noise(outer.sd_ldm, x, t, h)

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -514,7 +514,9 @@ class UnetHook(nn.Module):
                 x0_prd = predict_start_from_noise(outer.sd_ldm, x, t, h)
                 x0 = x0_prd - blur(x0_prd, k) + blur(x0_origin, k)
                 eps_prd = predict_noise_from_start(outer.sd_ldm, x, t, x0)
-                h = eps_prd
+
+                w = max(0.0, min(1.0, float(param.weight)))
+                h = eps_prd * w + h * (1 - w)
 
             return h
 

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -10,6 +10,7 @@ cond_cast_unet = getattr(devices, 'cond_cast_unet', lambda x: x)
 from ldm.modules.diffusionmodules.util import timestep_embedding
 from ldm.modules.diffusionmodules.openaimodel import UNetModel
 from ldm.modules.attention import BasicTransformerBlock
+from ldm.models.diffusion.ddpm import extract_into_tensor
 
 from modules.prompt_parser import MulticondLearnedConditioning, ComposableScheduledPromptConditioning, ScheduledPromptConditioning
 
@@ -213,6 +214,20 @@ def torch_dfs(model: torch.nn.Module):
     return result
 
 
+def predict_start_from_noise(ldm, x_t, t, noise):
+    return extract_into_tensor(ldm.sqrt_recip_alphas_cumprod, t, x_t.shape) * x_t - extract_into_tensor(ldm.sqrt_recipm1_alphas_cumprod, t, x_t.shape) * noise
+
+
+def predict_noise_from_start(ldm, x_t, t, x0):
+    return (extract_into_tensor(ldm.sqrt_recip_alphas_cumprod, t, x_t.shape) * x_t - x0) / extract_into_tensor(ldm.sqrt_recipm1_alphas_cumprod, t, x_t.shape)
+
+
+def blur(x, k):
+    y = torch.nn.functional.pad(x, (k, k, k, k), mode='replicate')
+    y = torch.nn.functional.avg_pool2d(y, (k*2+1, k*2+1), stride=(1, 1))
+    return y
+
+
 class UnetHook(nn.Module):
     def __init__(self, lowvram=False) -> None:
         super().__init__()
@@ -291,7 +306,7 @@ class UnetHook(nn.Module):
             for param in outer.control_params:
                 if param.used_hint_cond_latent is not None:
                     continue
-                if param.control_model_type not in [ControlModelType.AttentionInjection]:
+                if param.control_model_type not in [ControlModelType.AttentionInjection] and param.preprocessor['name'] not in ['tile_colorfix']:
                     continue
                 try:
                     query_size = int(x.shape[0])
@@ -429,7 +444,7 @@ class UnetHook(nn.Module):
                         param.used_hint_cond_latent
                     ], dim=1)
 
-                outer.current_style_fidelity = float(param.preprocessor.get('threshold_a', 0.5))
+                outer.current_style_fidelity = float(param.preprocessor['threshold_a'])
                 outer.current_style_fidelity = max(0.0, min(1.0, outer.current_style_fidelity))
 
                 if param.cfg_injection:
@@ -437,7 +452,7 @@ class UnetHook(nn.Module):
                 elif param.soft_injection or is_in_high_res_fix:
                     outer.current_style_fidelity = 0.0
 
-                control_name = param.preprocessor.get('name', None)
+                control_name = param.preprocessor['name']
 
                 if control_name in ['reference_only', 'reference_adain+attn']:
                     outer.attention_auto_machine = AutoMachine.Write
@@ -482,6 +497,20 @@ class UnetHook(nn.Module):
             # U-Net Output
             h = h.type(x.dtype)
             h = self.out(h)
+
+            # Post-processing for tile color fix
+            for param in outer.control_params:
+                if param.used_hint_cond_latent is None:
+                    continue
+                if param.preprocessor['name'] not in ['tile_colorfix']:
+                    continue
+                k = int(param.preprocessor['threshold_a'])
+                x0_origin = param.used_hint_cond_latent
+                t = torch.round(timesteps.float()).long()
+                x0_prd = predict_start_from_noise(outer.sd_ldm, x, t, h)
+                x0 = x0_prd - blur(x0_prd, k) + blur(x0_origin, k)
+                eps_prd = predict_noise_from_start(outer.sd_ldm, x, t, x0)
+                h = eps_prd
 
             return h
 

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -759,6 +759,16 @@ preprocessor_sliders_config = {
             "step": 0.01
         }
     ],
+    "tile_colorfix": [
+        None,
+        {
+            "name": "Variation",
+            "value": 8.0,
+            "min": 3.0,
+            "max": 32.0,
+            "step": 1.0
+        }
+    ],
     "reference_only": [
         None,
         {


### PR DESCRIPTION
**1.1.195** added preprocessor tile_colofix.

This preprocessor is mainly targeted to a problem of tile that sometimes it causes color offsets.

### Comparison 1 (strength)

**meta (in txt2img, similar to img2img with denoising strength 1.0)**

1girl, best quality
Negative prompt: lowres, bad anatomy, bad hands, cropped, worst quality
Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 12345, Size: 512x640, Model hash: 8712e20a5d, Model: Anything-V3.0, Clip skip: 2, Version: v1.2.1, ControlNet 0: "preprocessor: tile_XXXX, model: control_v11f1e_sd15_tile [a371b31b], weight: 1, starting/ending: (0, 1), resize mode: Crop and Resize, pixel perfect: True, control mode: Balanced, preprocessor params: (64, 1, 64)"

**input image (64px)**
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/d22866bf-a4dc-4750-a3f4-aeb7ecdc276a)

zoom in view (for visualization, not used)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/6d256d30-aa23-4ffd-b4ac-e13e405b9722)

**tile_resample:**
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/8f22da21-fb89-40ba-a093-e085ab16a7f5)

**tile_colorfix (all parameters same with tile_resample):**
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/3df7cfcb-f70a-4d87-b06a-025702b7f03f)

### Comparison 2 (limitation)

Note that tile_colorfix always lock colors, which means you cannot edit color even in "My prompt is more important" mode

**meta (in txt2img, similar to img2img with denoising strength 1.0)**

1girl, best quality, **in blue dress**
Negative prompt: lowres, bad anatomy, bad hands, cropped, worst quality
Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 12345, Size: 512x640, Model hash: 8712e20a5d, Model: Anything-V3.0, Clip skip: 2, Version: v1.2.1, ControlNet 0: "preprocessor: tile_XXXX, model: control_v11f1e_sd15_tile [a371b31b], weight: 1, starting/ending: (0, 1), resize mode: Crop and Resize, pixel perfect: True, control mode: My prompt is more important, preprocessor params: (64, 1, 64)"

**Note that we have "in blue dress" in the prompt.**

**tile_resample:**
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/09a9ac48-898b-45ba-925b-e89750c9105f)

**tile_colorfix (all parameters same with tile_resample):**
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/20111713-531f-49f0-8769-5882a40d2c15)

### Version

You need at least **1.1.195** to use it.
