### PR TITLE
add tile_colorfix+sharp

### DIFF
--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.195'
+version_flag = 'v1.1.196'
 print(f'ControlNet {version_flag}')
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -89,6 +89,7 @@ cn_preprocessor_modules = {
     "reference_adain+attn": identity,
     "inpaint": identity,
     "tile_colorfix": identity,
+    "tile_colorfix+sharp": identity,
 }
 
 cn_preprocessor_unloadable = {

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -769,6 +769,23 @@ preprocessor_sliders_config = {
             "step": 1.0
         }
     ],
+    "tile_colorfix+sharp": [
+        None,
+        {
+            "name": "Variation",
+            "value": 8.0,
+            "min": 3.0,
+            "max": 32.0,
+            "step": 1.0
+        },
+        {
+            "name": "Sharpness",
+            "value": 1.0,
+            "min": 0.0,
+            "max": 2.0,
+            "step": 0.01
+        }
+    ],
     "reference_only": [
         None,
         {


### PR DESCRIPTION
**1.1.196** added "tile_colorfix+sharp"
This method allows you to control the latent sharpness of the outputs of ControlNet tile.
This preprocessor can prevent the Tile model from the tendency to create the somewhat blurred "harmonious atmosphere" in your upscaled images.

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/5fbf68fa-eb8c-483c-b108-9925be1e6036)

# comparison 1

Input image (480x640)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/d61ce438-a0de-4c61-8a6c-3dffafccad75)

Meta (Using T2I or I2I with 100% denoising strength, no extra upscaler/super-resolution, all results use same seed 12345):

1girl, best quality
Negative prompt: lowres, bad anatomy, bad hands, cropped, worst quality
Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 12345, Size: 960x1280, Model hash: 8712e20a5d, Model: Anything-V3.0, Clip skip: 2, Version: v1.2.1, ControlNet 0: "preprocessor: tile_XXXX, model: control_v11f1e_sd15_tile [a371b31b], weight: 1, starting/ending: (0, 1), resize mode: Crop and Resize, pixel perfect: True, control mode: Balanced, preprocessor params: (64, 8, 1)"

**tile_resample**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/fd382840-8b6b-4358-848b-986cfdbd67aa)

**tile_colorfix**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/c701d955-edf3-46b9-be84-8d1d40cbe56a)

**tile_colorfix+sharp (sharpness=0.5)**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/739ac576-f4cb-44f4-b81e-dd733c8d21b6)

**tile_colorfix+sharp (default, sharpness=1.0)**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/ec2356b6-d82f-477e-8ef7-275ee324bf70)


**img2img with 0.25 denoising strength without using any ControlNet**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/c21b3e0e-8d45-4748-afb4-a84523c59949)

# comparison 2 (the difference for realistic image is less obvious)

Input image (480x640)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/c9c4e9a2-f260-48f9-aa6c-436286e005ea)

Meta (Using T2I or I2I with 100% denoising strength, no extra upscaler/super-resolution, all results use same seed 12345):
old man, best quality
Negative prompt: lowres, bad anatomy, bad hands, cropped, worst quality
Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 12345, Size: 960x1280, Model hash: c0d1994c73, Model: realisticVisionV20_v20, Version: v1.2.1, ControlNet 0: "preprocessor: tile_XXXX, model: control_v11f1e_sd15_tile [a371b31b], weight: 1, starting/ending: (0, 1), resize mode: Crop and Resize, pixel perfect: True, control mode: Balanced, preprocessor params: (64, 8, 1)"

**tile_resample**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/88c52bf3-295d-4887-8fd0-939e13728514)

**tile_colorfix**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/47265ec7-eeb4-444c-a2ca-3e79e59a72d1)

**tile_colorfix+sharp (sharpness=0.5)**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/90ed17c1-fe14-40c2-a465-d06d400801f8)

**tile_colorfix+sharp (default, sharpness=1.0)**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/b3d001ab-ada3-4d82-bae1-7ace5b6c32f2)

**img2img with 0.25 denoising strength without using any ControlNet**:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/70b4d9d8-4bb7-4cca-8f81-e17545f2688b)

**Note that all above results in this post are not cherry picked (they all use seed 12345). It is possible to get much better results using these preprocessors in other workflows.**

# version
You need at least **1.1.196** to use it.