### PR TITLE
remove unnecessary copying

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -658,7 +658,6 @@ class Script(scripts.Script):
                     if a1111_mask.shape[0] == input_image.shape[0]:
                         if a1111_mask.shape[1] == input_image.shape[1]:
                             input_image = np.concatenate([input_image[:, :, 0:3], a1111_mask[:, :, None]], axis=2)
-                            input_image = np.ascontiguousarray(input_image.copy()).copy()
                             a1111_i2i_resize_mode = getattr(p, "resize_mode", None)
                             if a1111_i2i_resize_mode is not None:
                                 resize_mode = external_code.resize_mode_from_value(a1111_i2i_resize_mode)


### PR DESCRIPTION
Remove the unnecessary copying of `input_image` as it will be done again later

```
            try:
                tmp_seed = int(p.all_seeds[0] if p.seed == -1 else max(int(p.seed), 0))
                tmp_subseed = int(p.all_seeds[0] if p.subseed == -1 else max(int(p.subseed), 0))
                np.random.seed((tmp_seed + tmp_subseed) & 0xFFFFFFFF)
            except Exception as e:
                print(e)
                print('Warning: Failed to use consistent random seed.')

            # safe numpy
            input_image = np.ascontiguousarray(input_image.copy()).copy() <<<<<

            print(f"Loading preprocessor: {unit.module}")
            preprocessor = self.preprocessor[unit.module]
            h, w, bsz = p.height, p.width, p.batch_size
```