### PR TITLE
Add logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ This extension adds these command line arguments to the webui:
     --controlnet-annotator-models-path <path to directory with annotator model directories>    SET the directory for annotator models
     --no-half-controlnet                                                                       load controlnet models in full precision
     --controlnet-preprocessor-cache-size                                                       Cache size for controlnet preprocessor results
+    --controlnet-loglevel                                                                      Log level for the controlnet extension
 ```
 
 # MacOS Support

--- a/preload.py
+++ b/preload.py
@@ -1,12 +1,33 @@
 def preload(parser):
-    parser.add_argument("--controlnet-dir", type=str, help="Path to directory with ControlNet models", default=None)
-    parser.add_argument("--controlnet-annotator-models-path", type=str, help="Path to directory with annotator model directories", default=None)
-    parser.add_argument("--no-half-controlnet", action='store_true', help="do not switch the ControlNet models to 16-bit floats (only needed without --no-half)", default=None)
-    # Setting default max_size=16 as each cache entry contains image as both key 
+    parser.add_argument(
+        "--controlnet-dir",
+        type=str,
+        help="Path to directory with ControlNet models",
+        default=None,
+    )
+    parser.add_argument(
+        "--controlnet-annotator-models-path",
+        type=str,
+        help="Path to directory with annotator model directories",
+        default=None,
+    )
+    parser.add_argument(
+        "--no-half-controlnet",
+        action="store_true",
+        help="do not switch the ControlNet models to 16-bit floats (only needed without --no-half)",
+        default=None,
+    )
+    # Setting default max_size=16 as each cache entry contains image as both key
     # and value (Very costly).
     parser.add_argument(
         "--controlnet-preprocessor-cache-size",
         type=int,
         help="Cache size for controlnet preprocessor results",
         default=16,
+    )
+    parser.add_argument(
+        "--controlnet-loglevel",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
     )

--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,5 +1,8 @@
 version_flag = 'v1.1.214'
-print(f'ControlNet {version_flag}')
+
+from scripts.logging import logger
+
+logger.info(f"ControlNet {version_flag}")
 # A smart trick to know if user has updated as well as if user has restarted terminal.
 # Note that in "controlnet.py" we do NOT use "importlib.reload" to reload this "controlnet_version.py"
 # This means if user did not completely restart terminal, the "version_flag" will be the previous version.

--- a/scripts/logging.py
+++ b/scripts/logging.py
@@ -1,0 +1,23 @@
+import logging
+
+from modules import shared
+
+# Create a new logger
+logger = logging.getLogger("ControlNet")
+
+# Configure logger
+handler = logging.StreamHandler()
+handler.setFormatter(
+    logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+)
+logger.addHandler(handler)
+
+
+if hasattr(shared.cmd_opts, "controlnet_loglevel"):
+    loglevel_string = shared.cmd_opts.controlnet_loglevel
+else:
+    print("Warning: `controlnet_loglevel` not available from A1111")
+    loglevel_string = "DEBUG"
+
+loglevel = getattr(logging, loglevel_string.upper(), None)
+logger.setLevel(loglevel)

--- a/scripts/logging.py
+++ b/scripts/logging.py
@@ -11,13 +11,6 @@ handler.setFormatter(
     logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 )
 logger.addHandler(handler)
-
-
-if hasattr(shared.cmd_opts, "controlnet_loglevel"):
-    loglevel_string = shared.cmd_opts.controlnet_loglevel
-else:
-    print("Warning: `controlnet_loglevel` not available from A1111")
-    loglevel_string = "DEBUG"
-
+loglevel_string = getattr(shared.cmd_opts, "controlnet_loglevel", "INFO")
 loglevel = getattr(logging, loglevel_string.upper(), None)
 logger.setLevel(loglevel)


### PR DESCRIPTION
This PR adds a logger to help distinguish different levels of logs. The default log level is set to `INFO`. 

Example log of ControlNet version:
```
2023-06-02 18:01:51,483 - ControlNet - INFO - ControlNet v1.1.213
```

We should be able to slowly migrate to using the logger from unconditional print. 