### PR TITLE
[Reland] Extract Prepare Mask logic

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -677,7 +677,7 @@ class Script(scripts.Script):
             if resize_mode_overwrite is not None:
                 resize_mode = resize_mode_overwrite
             
-            a1111_mask_image : Image.Image = getattr(p, "image_mask", None)
+            a1111_mask_image : Optional[Image.Image] = getattr(p, "image_mask", None)
             if 'inpaint' in unit.module and not image_has_mask(input_image) and a1111_mask_image is not None:
                 a1111_mask = np.array(prepare_mask(a1111_mask_image, p))
                 if a1111_mask.ndim == 2:

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -133,6 +133,39 @@ def image_has_mask(input_image: np.ndarray) -> bool:
     )
 
 
+def prepare_mask(
+    mask: Image.Image, p: processing.StableDiffusionProcessing
+) -> np.ndarray:
+    """
+    Prepare an image mask for the inpainting process.
+
+    This function takes as input a PIL Image object and an instance of the 
+    StableDiffusionProcessing class, and performs the following steps to prepare the mask:
+
+    1. Convert the mask to grayscale (mode "L").
+    2. If the 'inpainting_mask_invert' attribute of the processing instance is True,
+       invert the mask colors.
+    3. If the 'mask_blur' attribute of the processing instance is greater than 0,
+       apply a Gaussian blur to the mask with a radius equal to 'mask_blur'.
+    4. Convert the mask to a numpy array for further processing.
+
+    Args:
+        mask (Image.Image): The input mask as a PIL Image object.
+        p (processing.StableDiffusionProcessing): An instance of the StableDiffusionProcessing class 
+                                                   containing the processing parameters.
+
+    Returns:
+        mask (np.ndarray): The prepared mask as a numpy array.
+    """
+    mask = mask.convert("L")
+    if getattr(p, "inpainting_mask_invert", False):
+        mask = ImageOps.invert(mask)
+    if getattr(p, "mask_blur", 0) > 0:
+        mask = mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
+    mask = np.asarray(mask)
+    return mask
+
+
 class Script(scripts.Script):
     model_cache = OrderedDict()
 
@@ -648,12 +681,7 @@ class Script(scripts.Script):
             
             a1111_mask = getattr(p, "image_mask", None)
             if 'inpaint' in unit.module and not image_has_mask(input_image) and a1111_mask is not None:
-                a1111_mask = a1111_mask.convert('L')
-                if getattr(p, "inpainting_mask_invert", False):
-                    a1111_mask = ImageOps.invert(a1111_mask)
-                if getattr(p, "mask_blur", 0) > 0:
-                    a1111_mask = a1111_mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
-                a1111_mask = np.asarray(a1111_mask)
+                a1111_mask = prepare_mask(a1111_mask, p)
                 if a1111_mask.ndim == 2:
                     if a1111_mask.shape[0] == input_image.shape[0]:
                         if a1111_mask.shape[1] == input_image.shape[1]:
@@ -663,16 +691,12 @@ class Script(scripts.Script):
                                 resize_mode = external_code.resize_mode_from_value(a1111_i2i_resize_mode)
 
             if 'reference' not in unit.module and issubclass(type(p), StableDiffusionProcessingImg2Img) \
-                    and p.inpaint_full_res and p.image_mask is not None:
+                    and p.inpaint_full_res and a1111_mask is not None:
 
                 input_image = [input_image[:, :, i] for i in range(input_image.shape[2])]
                 input_image = [Image.fromarray(x) for x in input_image]
 
-                mask = p.image_mask.convert('L')
-                if p.inpainting_mask_invert:
-                    mask = ImageOps.invert(mask)
-                if p.mask_blur > 0:
-                    mask = mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
+                mask = prepare_mask(a1111_mask, p)
 
                 crop_region = masking.get_crop_region(np.array(mask), p.inpaint_full_res_padding)
                 crop_region = masking.expand_crop_region(crop_region, p.width, p.height, mask.width, mask.height)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -677,9 +677,9 @@ class Script(scripts.Script):
             if resize_mode_overwrite is not None:
                 resize_mode = resize_mode_overwrite
             
-            a1111_mask = getattr(p, "image_mask", None)
-            if 'inpaint' in unit.module and not image_has_mask(input_image) and a1111_mask is not None:
-                a1111_mask = np.array(prepare_mask(a1111_mask, p))
+            a1111_mask_image : Image.Image = getattr(p, "image_mask", None)
+            if 'inpaint' in unit.module and not image_has_mask(input_image) and a1111_mask_image is not None:
+                a1111_mask = np.array(prepare_mask(a1111_mask_image, p))
                 if a1111_mask.ndim == 2:
                     if a1111_mask.shape[0] == input_image.shape[0]:
                         if a1111_mask.shape[1] == input_image.shape[1]:
@@ -689,12 +689,12 @@ class Script(scripts.Script):
                                 resize_mode = external_code.resize_mode_from_value(a1111_i2i_resize_mode)
 
             if 'reference' not in unit.module and issubclass(type(p), StableDiffusionProcessingImg2Img) \
-                    and p.inpaint_full_res and a1111_mask is not None:
+                    and p.inpaint_full_res and a1111_mask_image is not None:
 
                 input_image = [input_image[:, :, i] for i in range(input_image.shape[2])]
                 input_image = [Image.fromarray(x) for x in input_image]
 
-                mask = prepare_mask(a1111_mask, p)
+                mask = prepare_mask(a1111_mask_image, p)
 
                 crop_region = masking.get_crop_region(np.array(mask), p.inpaint_full_res_padding)
                 crop_region = masking.expand_crop_region(crop_region, p.width, p.height, mask.width, mask.height)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -135,7 +135,7 @@ def image_has_mask(input_image: np.ndarray) -> bool:
 
 def prepare_mask(
     mask: Image.Image, p: processing.StableDiffusionProcessing
-) -> np.ndarray:
+) -> Image.Image:
     """
     Prepare an image mask for the inpainting process.
 
@@ -147,7 +147,6 @@ def prepare_mask(
        invert the mask colors.
     3. If the 'mask_blur' attribute of the processing instance is greater than 0,
        apply a Gaussian blur to the mask with a radius equal to 'mask_blur'.
-    4. Convert the mask to a numpy array for further processing.
 
     Args:
         mask (Image.Image): The input mask as a PIL Image object.
@@ -155,14 +154,13 @@ def prepare_mask(
                                                    containing the processing parameters.
 
     Returns:
-        mask (np.ndarray): The prepared mask as a numpy array.
+        mask (Image.Image): The prepared mask as a PIL Image object.
     """
     mask = mask.convert("L")
     if getattr(p, "inpainting_mask_invert", False):
         mask = ImageOps.invert(mask)
     if getattr(p, "mask_blur", 0) > 0:
         mask = mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
-    mask = np.asarray(mask)
     return mask
 
 
@@ -681,7 +679,7 @@ class Script(scripts.Script):
             
             a1111_mask = getattr(p, "image_mask", None)
             if 'inpaint' in unit.module and not image_has_mask(input_image) and a1111_mask is not None:
-                a1111_mask = prepare_mask(a1111_mask, p)
+                a1111_mask = np.array(prepare_mask(a1111_mask, p))
                 if a1111_mask.ndim == 2:
                     if a1111_mask.shape[0] == input_image.shape[0]:
                         if a1111_mask.shape[1] == input_image.shape[1]:

--- a/tests/cn_script/cn_script_test.py
+++ b/tests/cn_script/cn_script_test.py
@@ -1,0 +1,44 @@
+import unittest
+from PIL import Image
+import numpy as np
+
+import importlib
+utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
+utils.setup_test_env()
+
+from scripts.controlnet import prepare_mask
+from modules import processing
+
+
+class TestPrepareMask(unittest.TestCase):
+    def test_prepare_mask(self):
+        p = processing.StableDiffusionProcessing()
+        p.inpainting_mask_invert = True
+        p.mask_blur = 5
+
+        mask = Image.new("RGB", (10, 10), color="white")
+
+        processed_mask = prepare_mask(mask, p)
+
+        # Check that mask is correctly converted to grayscale and then to numpy array
+        self.assertEqual(processed_mask.shape, (10, 10))
+
+        # Check that mask colors are correctly inverted
+        self.assertEqual(processed_mask[0, 0], 0)  # inverted white should be black
+
+        p.inpainting_mask_invert = False
+        processed_mask = prepare_mask(mask, p)
+
+        # Check that mask colors are not inverted when 'inpainting_mask_invert' is False
+        self.assertEqual(processed_mask[0, 0], 255)  # white should remain white
+
+        p.mask_blur = 0
+        mask = Image.new("RGB", (10, 10), color="black")
+        processed_mask = prepare_mask(mask, p)
+
+        # Check that mask is not blurred when 'mask_blur' is 0
+        self.assertEqual(processed_mask[0, 0], 0)  # black should remain black
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cn_script/cn_script_test.py
+++ b/tests/cn_script/cn_script_test.py
@@ -16,28 +16,28 @@ class TestPrepareMask(unittest.TestCase):
         p.inpainting_mask_invert = True
         p.mask_blur = 5
 
-        mask = Image.new("RGB", (10, 10), color="white")
+        mask = Image.new('RGB', (10, 10), color='white')
 
         processed_mask = prepare_mask(mask, p)
 
-        # Check that mask is correctly converted to grayscale and then to numpy array
-        self.assertEqual(processed_mask.shape, (10, 10))
+        # Check that mask is correctly converted to grayscale
+        self.assertTrue(processed_mask.mode, "L")
 
         # Check that mask colors are correctly inverted
-        self.assertEqual(processed_mask[0, 0], 0)  # inverted white should be black
+        self.assertEqual(processed_mask.getpixel((0, 0)), 0)  # inverted white should be black
 
         p.inpainting_mask_invert = False
         processed_mask = prepare_mask(mask, p)
 
         # Check that mask colors are not inverted when 'inpainting_mask_invert' is False
-        self.assertEqual(processed_mask[0, 0], 255)  # white should remain white
+        self.assertEqual(processed_mask.getpixel((0, 0)), 255)  # white should remain white
 
         p.mask_blur = 0
-        mask = Image.new("RGB", (10, 10), color="black")
+        mask = Image.new('RGB', (10, 10), color='black')
         processed_mask = prepare_mask(mask, p)
 
         # Check that mask is not blurred when 'mask_blur' is 0
-        self.assertEqual(processed_mask[0, 0], 0)  # black should remain black
+        self.assertEqual(processed_mask.getpixel((0, 0)), 0)  # black should remain black
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously `a1111_mask` variable was reassigned to hold value of different type, which caused crashes. This reland fixes this by rename the `a1111_mask` with `PIL.Image.Image` type as `a1111_mask_image` so that variable types are stable. 

Verified locally that the issue is fixed in inpaint mode.