### PR TITLE
:bug: Handle unrecogznied resize mode value

### DIFF
--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -53,6 +53,14 @@ def resize_mode_from_value(value: Union[str, int, ResizeMode]) -> ResizeMode:
     if isinstance(value, str):
         return ResizeMode(resize_mode_aliases.get(value, value))
     elif isinstance(value, int):
+        assert value >= 0
+        if value == 3: # 'Just Resize (Latent upscale)'
+            return ResizeMode.RESIZE
+        
+        if value >= len(ResizeMode):
+            print(f'Unrecognized ResizeMode int value {value}. Fall back to RESIZE.')
+            return ResizeMode.RESIZE
+
         return [e for e in ResizeMode][value]
     else:
         return value


### PR DESCRIPTION
A1111 has an extra `ResizeMode` enum value 3 for "Just resize (Latent Upscale)". Make it fall back on ResizeMode.RESIZE.

Also make other unrecognized resize mode value fall back on ResizeMode.RESIZE so that we don't get list out of bound exception. 