### PR TITLE
Logging migration

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -10,6 +10,8 @@ from modules.api import api
 
 from scripts import external_code, global_state
 from scripts.processor import preprocessor_sliders_config
+from scripts.logging import logger
+
 
 def encode_to_base64(image):
     if type(image) is str:
@@ -33,13 +35,13 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
     @app.get("/controlnet/model_list")
     async def model_list():
         up_to_date_model_list = external_code.get_models(update=True)
-        print(up_to_date_model_list)
+        logger.debug(up_to_date_model_list)
         return {"model_list": up_to_date_model_list}
 
     @app.get("/controlnet/module_list")
     async def module_list(alias_names: bool = False):
         _module_list = external_code.get_modules(alias_names)
-        print(_module_list)
+        logger.debug(_module_list)
         
         return {
             "module_list": _module_list,
@@ -70,7 +72,7 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
             raise HTTPException(
                 status_code=422, detail="No image selected")
 
-        print(f"Detecting {str(len(controlnet_input_images))} images with the {controlnet_module} module.")
+        logger.info(f"Detecting {str(len(controlnet_input_images))} images with the {controlnet_module} module.")
 
         results = []
 

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -22,6 +22,7 @@ from scripts.adapter import PlugableAdapter
 from scripts.utils import load_state_dict
 from scripts.hook import ControlParams, UnetHook, ControlModelType
 from scripts.controlnet_ui.controlnet_ui_group import ControlNetUiGroup, UiControlNetUnit
+from scripts.logging import logger
 from modules.processing import StableDiffusionProcessingImg2Img, StableDiffusionProcessingTxt2Img
 from modules.images import save_image
 
@@ -247,7 +248,7 @@ class Script(scripts.Script):
     @staticmethod
     def load_control_model(p, unet, model, lowvram):
         if model in Script.model_cache:
-            print(f"Loading model from cache: {model}")
+            logger.info(f"Loading model from cache: {model}")
             return Script.model_cache[model]
 
         # Remove model from cache to clear space before building another model
@@ -283,7 +284,7 @@ class Script(scripts.Script):
         if not os.path.exists(model_path):
             raise ValueError(f"file not found: {model_path}")
 
-        print(f"Loading model: {model}")
+        logger.info(f"Loading model: {model}")
         state_dict = load_state_dict(model_path)
         network_module = PlugableControlModel
         network_config = shared.opts.data.get("control_net_model_config", global_state.default_conf)
@@ -327,7 +328,7 @@ class Script(scripts.Script):
         if os.path.exists(override_config):
             network_config = override_config
         else:
-            print(f'ERROR: ControlNet cannot find model config [{override_config}] \n'
+            logger.error(f'ERROR: ControlNet cannot find model config [{override_config}] \n'
                   f'ERROR: ControlNet will use a WRONG config [{network_config}] to load your model. \n'
                   f'ERROR: The WRONG config may not match your model. The generated results can be bad. \n'
                   f'ERROR: You are using a ControlNet model [{model_stem}] without correct YAML config file. \n'
@@ -336,7 +337,7 @@ class Script(scripts.Script):
                   f'Solution: Please download YAML file, or ask your model provider to provide [{override_config}] for you to download.\n'
                   f'Hint: You can take a look at [{os.path.join(global_state.script_dir, "models")}] to find many existing YAML files.\n')
 
-        print(f"Loading config: {network_config}")
+        logger.info(f"Loading config: {network_config}")
         network = network_module(
             state_dict=state_dict,
             config_path=network_config,
@@ -344,7 +345,7 @@ class Script(scripts.Script):
             base_model=unet,
         )
         network.to(p.sd_model.device, dtype=p.sd_model.dtype)
-        print(f"ControlNet model {model} loaded.")
+        logger.info(f"ControlNet model {model} loaded.")
         return network
 
     @staticmethod
@@ -570,10 +571,10 @@ class Script(scripts.Script):
         image = image_dict_from_any(unit.image)
 
         if batch_hijack.instance.is_batch and getattr(p, "image_control", None) is not None:
-            print("Warn: Using legacy field 'p.image_control'.")
+            logger.warning("Warn: Using legacy field 'p.image_control'.")
             input_image = HWC3(np.asarray(p.image_control))
         elif p_input_image is not None:
-            print("Warn: Using legacy field 'p.controlnet_input_image'")
+            logger.warning("Warn: Using legacy field 'p.controlnet_input_image'")
             if isinstance(p_input_image, dict) and "mask" in p_input_image and "image" in p_input_image:
                 color = HWC3(np.asarray(p_input_image['image']))
                 alpha = np.asarray(p_input_image['mask'])[..., None]
@@ -594,7 +595,7 @@ class Script(scripts.Script):
             have_mask = 'mask' in image and not ((image['mask'][:, :, 0] == 0).all() or (image['mask'][:, :, 0] == 255).all())
 
             if 'inpaint' in unit.module:
-                print("using inpaint as input")
+                logger.info("using inpaint as input")
                 color = HWC3(image['image'])
                 if have_mask:
                     alpha = image['mask'][:, :, 0:1]
@@ -603,7 +604,7 @@ class Script(scripts.Script):
                 input_image = np.concatenate([color, alpha], axis=2)
             else:
                 if have_mask:
-                    print("using mask as input")
+                    logger.info("using mask as input")
                     input_image = HWC3(image['mask'][:, :, 0])
                     unit.module = 'none'  # Always use black bg and white line
         else:
@@ -715,7 +716,7 @@ class Script(scripts.Script):
 
             if 'inpaint' in unit.module and issubclass(type(p), StableDiffusionProcessingImg2Img) \
                     and p.inpainting_fill and p.image_mask is not None:
-                print('A1111 inpaint and ControlNet inpaint duplicated. ControlNet support enabled.')
+                logger.warning('A1111 inpaint and ControlNet inpaint duplicated. ControlNet support enabled.')
                 unit.module = 'inpaint'
 
             try:
@@ -723,13 +724,13 @@ class Script(scripts.Script):
                 tmp_subseed = int(p.all_seeds[0] if p.subseed == -1 else max(int(p.subseed), 0))
                 np.random.seed((tmp_seed + tmp_subseed) & 0xFFFFFFFF)
             except Exception as e:
-                print(e)
-                print('Warning: Failed to use consistent random seed.')
+                logger.warning(e)
+                logger.warning('Warning: Failed to use consistent random seed.')
 
             # safe numpy
             input_image = np.ascontiguousarray(input_image.copy()).copy()
 
-            print(f"Loading preprocessor: {unit.module}")
+            logger.info(f"Loading preprocessor: {unit.module}")
             preprocessor = self.preprocessor[unit.module]
             h, w, bsz = p.height, p.width, p.batch_size
 
@@ -745,7 +746,7 @@ class Script(scripts.Script):
                     resize_mode=resize_mode
                 )
 
-            print(f'preprocessor resolution = {preprocessor_resolution}')
+            logger.info(f'preprocessor resolution = {preprocessor_resolution}')
             detected_map, is_image = preprocessor(input_image, res=preprocessor_resolution, thr_a=unit.threshold_a, thr_b=unit.threshold_b)
 
             if unit.module == "none" and "style" in unit.model:
@@ -838,7 +839,7 @@ class Script(scripts.Script):
                 def inpaint_only_post_processing(x):
                     _, H, W = x.shape
                     if Hmask != H or Wmask != W:
-                        print('Error: ControlNet find post-processing resolution mismatch. This could be related to other extensions hacked processing.')
+                        logger.error('Error: ControlNet find post-processing resolution mismatch. This could be related to other extensions hacked processing.')
                         return x
                     r = final_inpaint_raw.to(x.dtype).to(x.device)
                     m = final_inpaint_mask.to(x.dtype).to(x.device)
@@ -926,7 +927,7 @@ class Script(scripts.Script):
                 if output_images:
                     unit.image = np.array(output_images[0])
                 else:
-                    print(f'Warning: No loopback image found for controlnet unit {unit_i}. Using control map from last batch iteration instead')
+                    logger.warning(f'Warning: No loopback image found for controlnet unit {unit_i}. Using control map from last batch iteration instead')
 
     def batch_tab_postprocess(self, p, *args, **kwargs):
         self.enabled_units.clear()

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -18,6 +18,7 @@ from scripts.processor import (
     preprocessor_filters,
     HWC3,
 )
+from scripts.logging import logger
 from modules import shared
 from modules.ui_components import FormRow
 
@@ -624,7 +625,7 @@ class ControlNetUiGroup(object):
 
             json_acceptor = JsonAcceptor()
 
-            print(f"Preview Resolution = {pres}")
+            logger.info(f"Preview Resolution = {pres}")
 
             def is_openpose(module: str):
                 return "openpose" in module

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -4,6 +4,7 @@ import numpy as np
 from modules import scripts, processing, shared
 from scripts import global_state
 from scripts.processor import preprocessor_sliders_config, model_free_preprocessors
+from scripts.logging import logger
 
 from modules.api import api
 
@@ -58,7 +59,7 @@ def resize_mode_from_value(value: Union[str, int, ResizeMode]) -> ResizeMode:
             return ResizeMode.RESIZE
         
         if value >= len(ResizeMode):
-            print(f'Unrecognized ResizeMode int value {value}. Fall back to RESIZE.')
+            logger.warning(f'Unrecognized ResizeMode int value {value}. Fall back to RESIZE.')
             return ResizeMode.RESIZE
 
         return [e for e in ResizeMode][value]
@@ -115,13 +116,13 @@ def pixel_perfect_resolution(
     else:
         estimation = max(k0, k1) * float(min(raw_H, raw_W))
     
-    print(f"Pixel Perfect Computation:")
-    print(f"resize_mode = {resize_mode}")
-    print(f"raw_H = {raw_H}")
-    print(f"raw_W = {raw_W}")
-    print(f"target_H = {target_H}")
-    print(f"target_W = {target_W}")
-    print(f"estimation = {estimation}")
+    logger.info(f"Pixel Perfect Computation:")
+    logger.info(f"resize_mode = {resize_mode}")
+    logger.info(f"raw_H = {raw_H}")
+    logger.info(f"raw_W = {raw_W}")
+    logger.info(f"target_H = {target_H}")
+    logger.info(f"target_W = {target_W}")
+    logger.info(f"estimation = {estimation}")
 
     return int(np.round(estimation))
 
@@ -269,7 +270,7 @@ def to_processing_unit(unit: Union[Dict[str, Any], ControlNetUnit]) -> ControlNe
             unit['image'] = {'image': unit['image'], 'mask': mask} if mask is not None else unit['image'] if unit['image'] else None
 
         if 'guess_mode' in unit:
-            print('Guess Mode is removed since 1.1.136. Please use Control Mode instead.')
+            logger.warning('Guess Mode is removed since 1.1.136. Please use Control Mode instead.')
 
         unit = ControlNetUnit(**unit)
 

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -7,6 +7,7 @@ from modules import shared, scripts, sd_models
 from modules.paths import models_path
 from scripts.processor import *
 from scripts.utils import ndarray_lru_cache
+from scripts.logging import logger
 
 from typing import Dict, Callable, Optional
 
@@ -26,12 +27,11 @@ def cache_preprocessors(preprocessor_modules: Dict[str, Callable]) -> Dict[str, 
     if CACHE_SIZE == 0:
         return preprocessor_modules
     
-    print(f'Create LRU cache (max_size={CACHE_SIZE}) for preprocessor results.')
+    logger.debug(f'Create LRU cache (max_size={CACHE_SIZE}) for preprocessor results.')
 
     @ndarray_lru_cache(max_size=CACHE_SIZE)
     def unified_preprocessor(preprocessor_name: str, *args, **kwargs):
-        # TODO: Make this a debug log?
-        print(f'Calling preprocessor {preprocessor_name} outside of cache.')
+        logger.debug(f'Calling preprocessor {preprocessor_name} outside of cache.')
         return preprocessor_modules[preprocessor_name](*args, **kwargs)
     
     # TODO: Introduce a seed parameter for shuffle preprocessor?

--- a/scripts/logging.py
+++ b/scripts/logging.py
@@ -5,12 +5,15 @@ from modules import shared
 # Create a new logger
 logger = logging.getLogger("ControlNet")
 
+# Add handler if we don't have one.
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(handler)
+
 # Configure logger
-handler = logging.StreamHandler()
-handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-)
-logger.addHandler(handler)
 loglevel_string = getattr(shared.cmd_opts, "controlnet_loglevel", "INFO")
 loglevel = getattr(logging, loglevel_string.upper(), None)
 logger.setLevel(loglevel)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -7,6 +7,7 @@ import gradio as gr
 
 from typing import Any, Callable, Dict
 
+from scripts.logging import logger
 
 def load_state_dict(ckpt_path, location="cpu"):
     _, extension = os.path.splitext(ckpt_path)
@@ -19,7 +20,7 @@ def load_state_dict(ckpt_path, location="cpu"):
             torch.load(ckpt_path, map_location=torch.device(location))
         )
     state_dict = get_state_dict(state_dict)
-    print(f"Loaded state_dict from [{ckpt_path}]")
+    logger.info(f"Loaded state_dict from [{ckpt_path}]")
     return state_dict
 
 


### PR DESCRIPTION
This PR migrates most `print` under `scripts/` to corresponding `logger` functions. 

This PR also fixes the issue that a second handler can be added to the logger when module reloaded.
