### PR TITLE
Reland logging migration

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -10,6 +10,8 @@ from modules.api import api
 
 from scripts import external_code, global_state
 from scripts.processor import preprocessor_sliders_config
+from scripts.logging import logger
+
 
 def encode_to_base64(image):
     if type(image) is str:
@@ -33,13 +35,13 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
     @app.get("/controlnet/model_list")
     async def model_list():
         up_to_date_model_list = external_code.get_models(update=True)
-        print(up_to_date_model_list)
+        logger.debug(up_to_date_model_list)
         return {"model_list": up_to_date_model_list}
 
     @app.get("/controlnet/module_list")
     async def module_list(alias_names: bool = False):
         _module_list = external_code.get_modules(alias_names)
-        print(_module_list)
+        logger.debug(_module_list)
         
         return {
             "module_list": _module_list,
@@ -70,7 +72,7 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
             raise HTTPException(
                 status_code=422, detail="No image selected")
 
-        print(f"Detecting {str(len(controlnet_input_images))} images with the {controlnet_module} module.")
+        logger.info(f"Detecting {str(len(controlnet_input_images))} images with the {controlnet_module} module.")
 
         results = []
 

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -18,6 +18,7 @@ from scripts.processor import (
     preprocessor_filters,
     HWC3,
 )
+from scripts.logging import logger
 from modules import shared
 from modules.ui_components import FormRow
 
@@ -624,7 +625,7 @@ class ControlNetUiGroup(object):
 
             json_acceptor = JsonAcceptor()
 
-            print(f"Preview Resolution = {pres}")
+            logger.info(f"Preview Resolution = {pres}")
 
             def is_openpose(module: str):
                 return "openpose" in module

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -4,6 +4,7 @@ import numpy as np
 from modules import scripts, processing, shared
 from scripts import global_state
 from scripts.processor import preprocessor_sliders_config, model_free_preprocessors
+from scripts.logging import logger
 
 from modules.api import api
 
@@ -58,7 +59,7 @@ def resize_mode_from_value(value: Union[str, int, ResizeMode]) -> ResizeMode:
             return ResizeMode.RESIZE
         
         if value >= len(ResizeMode):
-            print(f'Unrecognized ResizeMode int value {value}. Fall back to RESIZE.')
+            logger.warning(f'Unrecognized ResizeMode int value {value}. Fall back to RESIZE.')
             return ResizeMode.RESIZE
 
         return [e for e in ResizeMode][value]
@@ -115,13 +116,13 @@ def pixel_perfect_resolution(
     else:
         estimation = max(k0, k1) * float(min(raw_H, raw_W))
     
-    print(f"Pixel Perfect Computation:")
-    print(f"resize_mode = {resize_mode}")
-    print(f"raw_H = {raw_H}")
-    print(f"raw_W = {raw_W}")
-    print(f"target_H = {target_H}")
-    print(f"target_W = {target_W}")
-    print(f"estimation = {estimation}")
+    logger.info(f"Pixel Perfect Computation:")
+    logger.info(f"resize_mode = {resize_mode}")
+    logger.info(f"raw_H = {raw_H}")
+    logger.info(f"raw_W = {raw_W}")
+    logger.info(f"target_H = {target_H}")
+    logger.info(f"target_W = {target_W}")
+    logger.info(f"estimation = {estimation}")
 
     return int(np.round(estimation))
 
@@ -269,7 +270,7 @@ def to_processing_unit(unit: Union[Dict[str, Any], ControlNetUnit]) -> ControlNe
             unit['image'] = {'image': unit['image'], 'mask': mask} if mask is not None else unit['image'] if unit['image'] else None
 
         if 'guess_mode' in unit:
-            print('Guess Mode is removed since 1.1.136. Please use Control Mode instead.')
+            logger.warning('Guess Mode is removed since 1.1.136. Please use Control Mode instead.')
 
         unit = ControlNetUnit(**unit)
 

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -7,6 +7,7 @@ from modules import shared, scripts, sd_models
 from modules.paths import models_path
 from scripts.processor import *
 from scripts.utils import ndarray_lru_cache
+from scripts.logging import logger
 
 from typing import Dict, Callable, Optional
 
@@ -26,12 +27,11 @@ def cache_preprocessors(preprocessor_modules: Dict[str, Callable]) -> Dict[str, 
     if CACHE_SIZE == 0:
         return preprocessor_modules
     
-    print(f'Create LRU cache (max_size={CACHE_SIZE}) for preprocessor results.')
+    logger.debug(f'Create LRU cache (max_size={CACHE_SIZE}) for preprocessor results.')
 
     @ndarray_lru_cache(max_size=CACHE_SIZE)
     def unified_preprocessor(preprocessor_name: str, *args, **kwargs):
-        # TODO: Make this a debug log?
-        print(f'Calling preprocessor {preprocessor_name} outside of cache.')
+        logger.debug(f'Calling preprocessor {preprocessor_name} outside of cache.')
         return preprocessor_modules[preprocessor_name](*args, **kwargs)
     
     # TODO: Introduce a seed parameter for shuffle preprocessor?

--- a/scripts/logging.py
+++ b/scripts/logging.py
@@ -5,12 +5,15 @@ from modules import shared
 # Create a new logger
 logger = logging.getLogger("ControlNet")
 
+# Add handler if we don't have one.
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(handler)
+
 # Configure logger
-handler = logging.StreamHandler()
-handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-)
-logger.addHandler(handler)
 loglevel_string = getattr(shared.cmd_opts, "controlnet_loglevel", "INFO")
 loglevel = getattr(logging, loglevel_string.upper(), None)
 logger.setLevel(loglevel)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -7,6 +7,7 @@ import gradio as gr
 
 from typing import Any, Callable, Dict
 
+from scripts.logging import logger
 
 def load_state_dict(ckpt_path, location="cpu"):
     _, extension = os.path.splitext(ckpt_path)
@@ -19,7 +20,7 @@ def load_state_dict(ckpt_path, location="cpu"):
             torch.load(ckpt_path, map_location=torch.device(location))
         )
     state_dict = get_state_dict(state_dict)
-    print(f"Loaded state_dict from [{ckpt_path}]")
+    logger.info(f"Loaded state_dict from [{ckpt_path}]")
     return state_dict
 
 


### PR DESCRIPTION
Previously there was an error output to `stdout` instead of `stderr` in ControlNet code. This caused issue when the logger outputs error message to stderr.

This reland excludes the error code. 

Filed #1541 to track unittest fix.
