### PR TITLE
:bug: Disable logging propagate

### DIFF
--- a/scripts/logging.py
+++ b/scripts/logging.py
@@ -4,6 +4,7 @@ from modules import shared
 
 # Create a new logger
 logger = logging.getLogger("ControlNet")
+logger.propagate = False
 
 # Add handler if we don't have one.
 if not logger.handlers:


### PR DESCRIPTION
This PR disables propagate of the controlnet logger so that log messages do not appear again in the root logger. 