### PR TITLE
:art: colorize loglevel

### DIFF
--- a/scripts/logging.py
+++ b/scripts/logging.py
@@ -1,6 +1,27 @@
 import logging
+import copy
+import sys
 
 from modules import shared
+
+
+class ColoredFormatter(logging.Formatter):
+    COLORS = {
+        "DEBUG": "\033[0;36m",  # CYAN
+        "INFO": "\033[0;32m",  # GREEN
+        "WARNING": "\033[0;33m",  # YELLOW
+        "ERROR": "\033[0;31m",  # RED
+        "CRITICAL": "\033[0;37;41m",  # WHITE ON RED
+        "RESET": "\033[0m",  # RESET COLOR
+    }
+
+    def format(self, record):
+        colored_record = copy.copy(record)
+        levelname = colored_record.levelname
+        seq = self.COLORS.get(levelname, self.COLORS["RESET"])
+        colored_record.levelname = f"{seq}{levelname}{self.COLORS['RESET']}"
+        return super().format(colored_record)
+
 
 # Create a new logger
 logger = logging.getLogger("ControlNet")
@@ -8,9 +29,9 @@ logger.propagate = False
 
 # Add handler if we don't have one.
 if not logger.handlers:
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(
-        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        ColoredFormatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     )
     logger.addHandler(handler)
 


### PR DESCRIPTION
This PR also moves log output from `stderr` to `stdout`. 

`stderr` appears red by default in PyCharm.