### PR TITLE
:art: Add active units count badge

### DIFF
--- a/style.css
+++ b/style.css
@@ -114,3 +114,19 @@
 .dark .cnet-unit-active {
     color: greenyellow !important;
 }
+
+.cnet-badge {
+    display: inline-block;
+    padding: 0.25em 0.75em;
+    font-size: 0.75em;
+    font-weight: bold;
+    color: white;    
+    border-radius: 0.5em;
+    text-align: center;
+    vertical-align: middle;
+    margin-left: var(--size-2);
+}
+
+.cnet-badge.primary {
+    background-color: green;
+}


### PR DESCRIPTION
This PR adds a total enabled unit count badge besides the ControlNet accordion. 

Light theme:
![Screen Capture 010 - Stable Diffusion - 127 0 0 1](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/15ca9427-3ebf-4165-b075-1966a8953c40)

Dark theme:
![Screen Capture 009 - Stable Diffusion - 127 0 0 1](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/177ae370-00d1-44f0-9502-ed77582b1fbe)
