### PR TITLE
:bug: Fix SPACE reload issue on openpose editor

### DIFF
--- a/javascript/openpose_editor.js
+++ b/javascript/openpose_editor.js
@@ -34,6 +34,10 @@ function loadOpenposeEditor() {
                 imageURL: inputImage.src,
                 poseURL: downloadLink.href,
             }, '*');
+            // Focus the iframe so that the focus is no longer on the `Edit` button.
+            // Pressing space when the focus is on `Edit` button will trigger
+            // the click again to resend the frame message.
+            modalIframe.contentWindow.focus();
         });
 
         window.addEventListener('message', (event) => {


### PR DESCRIPTION
Detailed issue:
https://github.com/huchenlei/sd-webui-openpose-editor/issues/7 

This PR autofocus the iframe after the user clicks the edit button, so that press space immedately after click the edit button do not trigger another click event.