### PR TITLE
fix: subscribe gr.Slider's change event, not release event

### DIFF
--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -834,8 +834,6 @@ class ControlNetUiGroup(object):
                 event_subscribers.append(comp.edit)
             elif hasattr(comp, "click"):
                 event_subscribers.append(comp.click)
-            elif isinstance(comp, gr.Slider) and hasattr(comp, "release"):
-                event_subscribers.append(comp.release)
             elif hasattr(comp, "change"):
                 event_subscribers.append(comp.change)
 


### PR DESCRIPTION
If only subscribe gr.Slider's release event, when change value directly, no event will be triggered. But if  subscribe gr.Slider's change event, both release even and  change event will be triggerd.

Test code below:

```
import gradio as gr

with gr.Blocks() as demo:
    s = gr.Slider(2, 20, value=4, label="Count", info="Choose betwen 2 and 20", interactive=True)
    s.change(lambda : print("change"))
    # s.release(lambda: print("release"))
demo.launch()
```