### PR TITLE
change openpose error icon

### DIFF
--- a/javascript/openpose_editor.js
+++ b/javascript/openpose_editor.js
@@ -92,7 +92,7 @@ function loadPlaceHolder() {
         </div>
         `;
 
-        editButton.innerHTML = editButton.innerHTML + '⚠️';
+        editButton.innerHTML = '<del>' + editButton.innerHTML + '</del>';
     });
 }
 

--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.222'
+version_flag = 'v1.1.223'
 
 from scripts.logging import logger
 


### PR DESCRIPTION
Some users reported that they think openpose is not working when they see ⚠️
so we will change this to \<del\>