### PR TITLE
Lazy load openpose editor iframe

### DIFF
--- a/javascript/openpose_editor.js
+++ b/javascript/openpose_editor.js
@@ -87,8 +87,6 @@ function loadPlaceHolder() {
                 <li><a href="https://github.com/huchenlei/sd-webui-openpose-editor">
                     huchenlei/sd-webui-openpose-editor</a></li>
             </ul>
-
-
         </div>
         `;
 

--- a/javascript/openpose_editor.js
+++ b/javascript/openpose_editor.js
@@ -15,6 +15,14 @@ function loadOpenposeEditor() {
     }
 
     function navigateIframe(iframe) {
+        function getPathname(rawURL) {
+            try {
+                return new URL(rawURL).pathname;
+            } catch (e) {
+                return rawURL;
+            }
+        }
+
         return new Promise((resolve) => {
             const EDITOR_PATH = '/openpose_editor_index';
             window.addEventListener('message', (event) => {
@@ -22,7 +30,7 @@ function loadOpenposeEditor() {
                 if (message['ready']) resolve();
             }, {once: true});
 
-            if (new URL(iframe.src).pathname !== EDITOR_PATH) {
+            if (getPathname(iframe.src) !== EDITOR_PATH) {
                 iframe.src = EDITOR_PATH;
                 // By default assume 1 second is enough for the openpose editor
                 // to load.

--- a/scripts/controlnet_ui/openpose_editor.py
+++ b/scripts/controlnet_ui/openpose_editor.py
@@ -44,7 +44,11 @@ class OpenposeEditor(object):
         self.pose_input = gr.Textbox(visible=False, elem_classes=["cnet-pose-json"])
 
         self.modal = ModalInterface(
-            f'<iframe src="{OpenposeEditor.editor_url}"></iframe>',
+            # Use about:blank here as placeholder so that the iframe does not
+            # immediately navigate. Most of controlnet units do not need 
+            # openpose editor active. Only navigate when the user first click
+            # 'Edit'. The navigation logic is in `openpose_editor.js`.
+            f'<iframe src="about:blank"></iframe>',
             open_button_text="Edit",
             open_button_classes=["cnet-edit-pose"],
             open_button_extra_attrs=f'title="Send pose to {OpenposeEditor.editor_url} for edit."',


### PR DESCRIPTION
Previously every controlnet unit had an openpose editor iframe embedded invisible. However, the user most likely will only use one controlnet unit for openpose control. Loading the editor in every unit is obviously introducing uncessary work and memory usage (Each Vue app is about 0.5MB size). This become especially true if the user has a lot of controlnet units in the settings. 

This PR makes openpose lazy load on the first click on the edit button.

When navigating the iframe, we wait either 1s or receiving a `ready` frame message from the iframe. The 1s delay should be sufficient under most local setup. Even if the frame message is sent when the iframe is not ready, the user still can close the modal, and reclick the edit button. 