### PR TITLE
:art: Make modal content fit the window size

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,19 +20,16 @@
 .cnet-modal-content {
     position: relative;
     background-color: var(--background-fill-primary);
-    margin: 5% auto;
+    margin: 5vh auto;
     /* 15% from the top and centered */
     padding: 20px;
     border: 1px solid #888;
     width: 80%;
+    height: 90vh;
     /* Could be more or less, depending on screen size */
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
     animation-name: animatetop;
     animation-duration: 0.4s;
-    padding-top: 75%;
-    /* This will give a 4:3 aspect ratio. Adjust as needed */
-    height: 0;
-    /* This is needed for the padding trick to work */
 }
 
 .cnet-modal-content.alert {


### PR DESCRIPTION
Before:
You see there are double scroll bar on the right, even the modal iframe do not need that much space.
![Screenshot (117)](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/b52e9a23-c9ee-40cd-a895-77c91115337b)

After:
The modal does not introduce another scrollbar when it's unnecessary.
![Screenshot (118)](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/844f2a0b-d8eb-423b-a5c8-6e23a564c6a9)
