### PR TITLE
Fix runtime error for multi gpu in pidinet

### DIFF
--- a/annotator/pidinet/model.py
+++ b/annotator/pidinet/model.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from modules import devices
 from basicsr.utils import img2tensor
 
 nets = {
@@ -303,7 +304,7 @@ def createConvFunc(op_type):
 
             shape = weights.shape
             if weights.is_cuda:
-                buffer = torch.cuda.FloatTensor(shape[0], shape[1], 5 * 5).fill_(0)
+                buffer = torch.cuda.FloatTensor(shape[0], shape[1], 5 * 5).fill_(0).to(devices.get_device_for("controlnet"))
             else:
                 buffer = torch.zeros(shape[0], shape[1], 5 * 5)
             weights = weights.view(shape[0], shape[1], -1)


### PR DESCRIPTION
I have two gpus available, and set `CUDA_VISIBLE_DEVICES=0,1` and `--device-id 1` in COMMANDLINE_ARGS:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/55421601/42334d77-b778-4ccd-92ba-2221843e0301)
When I used softedge_pidinet preprocessor, I got a RuntimeError like this
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/55421601/f8d719c6-7e6d-4b09-a7a6-316e2cc5f9ae)
I suppose `.to(devices.get_device_for("controlnet"))` should be added when create `buffer` in `if weights.is_cuda:`.
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/55421601/46b5dede-e1dd-47f6-85c3-8b089e0a2178)

