### PR TITLE
:loud_sound: Add timing debug logs

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1,5 +1,6 @@
 import gc
 import os
+import logging
 from collections import OrderedDict
 from copy import copy
 from typing import Dict, Optional, Tuple
@@ -7,6 +8,7 @@ import importlib
 import modules.scripts as scripts
 from modules import shared, devices, script_callbacks, processing, masking, images
 import gradio as gr
+
 
 from einops import rearrange
 from scripts import global_state, hook, external_code, processor, batch_hijack, controlnet_version, utils
@@ -206,7 +208,9 @@ def set_numpy_seed(p: processing.StableDiffusionProcessing) -> Optional[int]:
         return None
 
 
-class Script(scripts.Script, metaclass=utils.TimeMeta):
+class Script(scripts.Script, metaclass=(
+    utils.TimeMeta if logger.level == logging.DEBUG else type)):
+
     model_cache = OrderedDict()
 
     def __init__(self) -> None:

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -206,7 +206,7 @@ def set_numpy_seed(p: processing.StableDiffusionProcessing) -> Optional[int]:
         return None
 
 
-class Script(scripts.Script):
+class Script(scripts.Script, metaclass=utils.TimeMeta):
     model_cache = OrderedDict()
 
     def __init__(self) -> None:
@@ -757,7 +757,7 @@ class Script(scripts.Script):
 
             if 'reference' not in unit.module and issubclass(type(p), StableDiffusionProcessingImg2Img) \
                     and p.inpaint_full_res and a1111_mask_image is not None:
-
+                logger.debug("A1111 inpaint mask START")
                 input_image = [input_image[:, :, i] for i in range(input_image.shape[2])]
                 input_image = [Image.fromarray(x) for x in input_image]
 
@@ -779,13 +779,16 @@ class Script(scripts.Script):
 
                 input_image = [np.asarray(x)[:, :, 0] for x in input_image]
                 input_image = np.stack(input_image, axis=2)
+                logger.debug("A1111 inpaint mask END")
 
             if 'inpaint_only' == unit.module and issubclass(type(p), StableDiffusionProcessingImg2Img) and p.image_mask is not None:
                 logger.warning('A1111 inpaint and ControlNet inpaint duplicated. ControlNet support enabled.')
                 unit.module = 'inpaint'
 
             # safe numpy
+            logger.debug("Safe numpy convertion START")
             input_image = np.ascontiguousarray(input_image.copy()).copy()
+            logger.debug("Safe numpy convertion END")
 
             logger.info(f"Loading preprocessor: {unit.module}")
             preprocessor = self.preprocessor[unit.module]

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,13 +1,16 @@
 import torch
 import os
 import functools
+import time
 import base64
 import numpy as np
 import gradio as gr
+import logging
 
 from typing import Any, Callable, Dict
 
 from scripts.logging import logger
+
 
 def load_state_dict(ckpt_path, location="cpu"):
     _, extension = os.path.splitext(ckpt_path)
@@ -80,6 +83,32 @@ def ndarray_lru_cache(max_size: int = 128, typed: bool = False):
     return decorator
 
 
+def timer_decorator(func):
+    """Time the decorated function and output the result to debug logger."""
+    if logger.level != logging.DEBUG:
+        return func
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        start_time = time.time()
+        result = func(*args, **kwargs)
+        end_time = time.time()
+        logger.debug(f"{func.__name__} ran in: {end_time - start_time} sec")
+        return result
+
+    return wrapper
+
+
+class TimeMeta(type):
+    """ Metaclass to record execution time on all methods of the
+    child class. """
+    def __new__(cls, name, bases, attrs):
+        for attr_name, attr_value in attrs.items():
+            if callable(attr_value):
+                attrs[attr_name] = timer_decorator(attr_value)
+        return super().__new__(cls, name, bases, attrs)
+
+
 # svgsupports
 svgsupport = False
 try:
@@ -107,6 +136,7 @@ def svg_preprocess(inputs: Dict, preprocess: Callable):
         base64_str = "data:image/png;base64," + base64_str
         inputs["image"] = base64_str
     return preprocess(inputs)
+
 
 def get_unique_axis0(data):
     arr = np.asanyarray(data)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -93,7 +93,10 @@ def timer_decorator(func):
         start_time = time.time()
         result = func(*args, **kwargs)
         end_time = time.time()
-        logger.debug(f"{func.__name__} ran in: {end_time - start_time} sec")
+        duration = end_time - start_time
+        # Only report function that are significant enough.
+        if duration > 1e-3:
+            logger.debug(f"{func.__name__} ran in: {duration} sec")
         return result
 
     return wrapper


### PR DESCRIPTION
Do not merge until A1111 side [PR on custom metaclass](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11264) landed. 

This PR adds debug timing logs to `Scripts` to better understand performance bottlenecks. 

Source bug: #1648