### PR TITLE
fix: runtime error for directml in pidinet

### DIFF
--- a/annotator/pidinet/model.py
+++ b/annotator/pidinet/model.py
@@ -306,7 +306,7 @@ def createConvFunc(op_type):
             if weights.is_cuda:
                 buffer = torch.cuda.FloatTensor(shape[0], shape[1], 5 * 5).fill_(0).to(devices.get_device_for("controlnet"))
             else:
-                buffer = torch.zeros(shape[0], shape[1], 5 * 5)
+                buffer = torch.zeros(shape[0], shape[1], 5 * 5).to(devices.get_device_for("controlnet"))
             weights = weights.view(shape[0], shape[1], -1)
             buffer[:, :, [0, 2, 4, 10, 14, 20, 22, 24]] = weights[:, :, 1:]
             buffer[:, :, [6, 7, 8, 11, 13, 16, 17, 18]] = -weights[:, :, 1:]


### PR DESCRIPTION
When I used softedge_pidinet preprocessor, I got a RuntimeError like this
```
Error running process: F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\scripts\controlnet.py
Traceback (most recent call last):
  File "F:\github\stable-diffusion-webui-directml\modules\scripts.py", line 451, in process
    script.process(p, *script_args)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\scripts\controlnet.py", line 805, in process
    detected_map, is_image = preprocessor(input_image, res=preprocessor_resolution, thr_a=unit.threshold_a, thr_b=unit.threshold_b)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\scripts\utils.py", line 76, in decorated_func
    return cached_func(*args, **kwargs)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\scripts\utils.py", line 64, in cached_func
    return func(*args, **kwargs)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\scripts\global_state.py", line 35, in unified_preprocessor
    return preprocessor_modules[preprocessor_name](*args, **kwargs)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\scripts\processor.py", line 295, in pidinet
    result = model_pidinet(img)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\annotator\pidinet\__init__.py", line 38, in apply_pidinet
    edge = netNetwork(image_pidi)[-1]
  File "F:\github\stable-diffusion-webui-directml\venv\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\annotator\pidinet\model.py", line 569, in forward
    x1 = self.block1_2(x1)
  File "F:\github\stable-diffusion-webui-directml\venv\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\annotator\pidinet\model.py", line 431, in forward
    y = self.conv1(x)
  File "F:\github\stable-diffusion-webui-directml\venv\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\annotator\pidinet\model.py", line 353, in forward
    return self.pdc(input, self.weight, self.bias, self.stride, self.padding, self.dilation, self.groups)
  File "F:\github\stable-diffusion-webui-directml\extensions\sd-webui-controlnet\annotator\pidinet\model.py", line 315, in func
    y = F.conv2d(x, buffer, bias, stride=stride, padding=padding, dilation=dilation, groups=groups)
  File "F:\github\stable-diffusion-webui-directml\modules\dml\amp\autocast_mode.py", line 32, in <lambda>
    setattr(resolved_obj, func_path[-1], lambda *args, **kwargs: pre_forward(op, args, kwargs))
  File "F:\github\stable-diffusion-webui-directml\modules\dml\amp\autocast_mode.py", line 9, in pre_forward
    return forward(*args, **kwargs)
RuntimeError: tensor.device().type() == at::DeviceType::PrivateUse1 INTERNAL ASSERT FAILED at "D:\\a\\_work\\1\\s\\pytorch-directml-plugin\\torch_directml\\csrc\\dml\\DMLTensor.cpp":31, please report a bug to PyTorch. unbox expects Dml at::Tensor as inputs
```
my env: **stable-diffusion-webui-directml** + **amd gpu**
similar to https://github.com/Mikubill/sd-webui-controlnet/pull/1635