### PR TITLE
[Reland] 🔨 Refactor bound check for threshold and resolution

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -645,17 +645,16 @@ class Script(scripts.Script):
         """
         cfg = preprocessor_sliders_config.get(
             global_state.get_module_basename(unit.module), [])
-        
-        defaults = tuple(
-            cfg[i]['value'] if i < len(cfg) else default
-            for i, default in enumerate((512, 0, 0))
-        )
-        assert len(defaults) >= 3
-        for param, default in zip(('processor_res', 'threshold_a', 'threshold_b'), defaults):
-            param_value = getattr(unit, param)
-            if param_value < 0:
-                setattr(unit, param, default)
-                logger.warning(f'Invalid value({param_value}) for {param}, using default value {default}.')
+        defaults = {
+            param: cfg_default['value']
+            for param, cfg_default in zip(
+                ("processor_res", 'threshold_a', 'threshold_b'), cfg)
+            if cfg_default is not None
+        }
+        for param, default_value in defaults.items():
+            if getattr(unit, param) < 0:
+                setattr(unit, param, default_value)
+                logger.warning(f'Invalid value({getattr(unit, param)}) for {param}, using default value {default_value}.')
                 
     def process(self, p, *args):
         """

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -633,13 +633,36 @@ class Script(scripts.Script):
         assert isinstance(input_image, np.ndarray)
         return input_image, resize_mode
     
+    @staticmethod
+    def bound_check_params(unit: external_code.ControlNetUnit) -> None:
+        """
+        Checks and corrects negative parameters in ControlNetUnit 'unit'.
+        Parameters 'processor_res', 'threshold_a', 'threshold_b' are reset to 
+        their default values if negative.
+        
+        Args:
+            unit (external_code.ControlNetUnit): The ControlNetUnit instance to check.
+        """
+        cfg = preprocessor_sliders_config.get(
+            global_state.get_module_basename(unit.module), [])
+        
+        defaults = tuple(
+            cfg[i]['value'] if i < len(cfg) else default
+            for i, default in enumerate((512, 0, 0))
+        )
+        assert len(defaults) >= 3
+        for param, default in zip(('processor_res', 'threshold_a', 'threshold_b'), defaults):
+            param_value = getattr(unit, param)
+            if param_value < 0:
+                setattr(unit, param, default)
+                logger.warning(f'Invalid value({param_value}) for {param}, using default value {default}.')
+                
     def process(self, p, *args):
         """
         This function is called before processing begins for AlwaysVisible scripts.
         You can modify the processing object (p) here, inject hooks, etc.
         args contains all values returned by components from ui()
         """
-
         sd_ldm = p.sd_model
         unet = sd_ldm.model.diffusion_model
 
@@ -673,6 +696,8 @@ class Script(scripts.Script):
 
         self.latest_model_hash = p.sd_model.sd_model_hash
         for idx, unit in enumerate(self.enabled_units):
+            Script.bound_check_params(unit)
+
             unit.module = global_state.get_module_basename(unit.module)
             resize_mode = external_code.resize_mode_from_value(unit.resize_mode)
             control_mode = external_code.control_mode_from_value(unit.control_mode)
@@ -740,33 +765,6 @@ class Script(scripts.Script):
 
             # safe numpy
             input_image = np.ascontiguousarray(input_image.copy()).copy()
-
-            if unit.processor_res < 0:
-                try:
-                    cfg = preprocessor_sliders_config[global_state.get_module_basename(unit.module)]
-                    unit.processor_res = int(cfg[0]['value'])
-                    logger.info(f'API used default config: unit.processor_res = {unit.processor_res}')
-                except:
-                    unit.processor_res = 512
-                    logger.info(f'API used default value: unit.processor_res = {unit.processor_res}')
-
-            if unit.threshold_a < 0:
-                try:
-                    cfg = preprocessor_sliders_config[global_state.get_module_basename(unit.module)]
-                    unit.threshold_a = float(cfg[1]['value'])
-                    logger.info(f'API used default config: unit.threshold_a = {unit.threshold_a}')
-                except:
-                    unit.threshold_a = 0
-                    logger.info(f'API used default value: unit.threshold_a = {unit.threshold_a}')
-
-            if unit.threshold_b < 0:
-                try:
-                    cfg = preprocessor_sliders_config[global_state.get_module_basename(unit.module)]
-                    unit.threshold_b = float(cfg[2]['value'])
-                    logger.info(f'API used default config: unit.threshold_b = {unit.threshold_b}')
-                except:
-                    unit.threshold_b = 0
-                    logger.info(f'API used default value: unit.threshold_b = {unit.threshold_b}')
 
             logger.info(f"Loading preprocessor: {unit.module}")
             preprocessor = self.preprocessor[unit.module]

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -652,9 +652,10 @@ class Script(scripts.Script):
             if cfg_default is not None
         }
         for param, default_value in defaults.items():
-            if getattr(unit, param) < 0:
+            value = getattr(unit, param)
+            if value < 0:
                 setattr(unit, param, default_value)
-                logger.warning(f'Invalid value({getattr(unit, param)}) for {param}, using default value {default_value}.')
+                logger.warning(f'Invalid value({value}) for {param}, using default value {default_value}.')
                 
     def process(self, p, *args):
         """

--- a/tests/cn_script/cn_script_test.py
+++ b/tests/cn_script/cn_script_test.py
@@ -6,7 +6,8 @@ import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
 utils.setup_test_env()
 
-from scripts.controlnet import prepare_mask
+from scripts import external_code, processor
+from scripts.controlnet import prepare_mask, Script
 from modules import processing
 
 
@@ -38,6 +39,27 @@ class TestPrepareMask(unittest.TestCase):
 
         # Check that mask is not blurred when 'mask_blur' is 0
         self.assertEqual(processed_mask.getpixel((0, 0)), 0)  # black should remain black
+
+
+class TestScript(unittest.TestCase):
+    def test_bound_check_params(self):
+        def param_required(module: str, param: str) -> bool:
+            configs = processor.preprocessor_sliders_config[module]
+            config_index = ('processor_res', 'threshold_a', 'threshold_b').index(param)
+            return config_index < len(configs) and configs[config_index] is not None
+
+        for module in processor.preprocessor_sliders_config.keys():
+            for param in ('processor_res', 'threshold_a', 'threshold_b'):
+                with self.subTest(param=param, module=module):
+                    unit = external_code.ControlNetUnit(
+                        module=module,
+                        **{param: -100},
+                    )
+                    Script.bound_check_params(unit)
+                    if param_required(module, param):
+                        self.assertGreaterEqual(getattr(unit, param), 0)
+                    else:
+                        self.assertEqual(getattr(unit, param), -100)
 
 
 if __name__ == "__main__":

--- a/tests/web_api/txt2img_test.py
+++ b/tests/web_api/txt2img_test.py
@@ -129,6 +129,17 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
                 ]
                 self.assert_status_ok(f'Running preprocessor module: {module}')
 
+    def test_call_invalid_params(self):
+        for param in ('processor_res', 'threshold_a', 'threshold_b'):
+            with self.subTest(param=param):
+                self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"] = [
+                    {
+                        "input_image": utils.readImage("test/test_files/img2img_basic.png"),
+                        "model": utils.get_model(),
+                        param: -1,
+                    }
+                ]
+                self.assert_status_ok(f'Run with {param} = -1.')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR refactors the logic of bound check parameters for API calls.
- Removes the try-catch default value check, as it might hide underlying issues, such as no `"value"` present in config.
- Only use default value and print warning when a required value is invalid. 