### PR TITLE
:bug: Remove mandatory mkdir for detected_maps

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -993,7 +993,7 @@ def on_ui_settings():
     shared.opts.add_option("control_net_model_adapter_config", shared.OptionInfo(
         global_state.default_conf_adapter, "Config file for Adapter models", section=section))
     shared.opts.add_option("control_net_detectedmap_dir", shared.OptionInfo(
-        global_state.default_detectedmap_dir, "Directory for detected maps auto saving", section=section))
+        os.path.join("detected_maps"), "Directory for detected maps auto saving", section=section))
     shared.opts.add_option("control_net_models_path", shared.OptionInfo(
         "", "Extra path to scan for ControlNet models (e.g. training output directory)", section=section))
     shared.opts.add_option("control_net_modules_path", shared.OptionInfo(

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -993,7 +993,7 @@ def on_ui_settings():
     shared.opts.add_option("control_net_model_adapter_config", shared.OptionInfo(
         global_state.default_conf_adapter, "Config file for Adapter models", section=section))
     shared.opts.add_option("control_net_detectedmap_dir", shared.OptionInfo(
-        os.path.join("detected_maps"), "Directory for detected maps auto saving", section=section))
+        global_state.default_detectedmap_dir, "Directory for detected maps auto saving", section=section))
     shared.opts.add_option("control_net_models_path", shared.OptionInfo(
         "", "Extra path to scan for ControlNet models (e.g. training output directory)", section=section))
     shared.opts.add_option("control_net_modules_path", shared.OptionInfo(

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -153,13 +153,10 @@ def get_module_basename(module: Optional[str]) -> str:
 
 default_conf = os.path.join("models", "cldm_v15.yaml")
 default_conf_adapter = os.path.join("models", "t2iadapter_sketch_sd14v1.yaml")
-cn_detectedmap_dir = os.path.join("detected_maps")
-default_detectedmap_dir = cn_detectedmap_dir
+default_detectedmap_dir = os.path.join("detected_maps")
 script_dir = scripts.basedir()
 
 os.makedirs(cn_models_dir, exist_ok=True)
-os.makedirs(cn_detectedmap_dir, exist_ok=True)
-
 
 def traverse_all_files(curr_path, model_list):
     f_list = [(os.path.join(curr_path, entry.name), entry.stat())


### PR DESCRIPTION
This PR addresses #1672.

`global_states.cn_detectedmap_dir` is not used anywhere else in the code, thus removed.

https://github.com/Mikubill/sd-webui-controlnet/blob/16805be062f44feee4513a39349a1ed83595279e/scripts/controlnet.py#L929 already does the makedir work so it should be fine to just remove the makedir in global_states.