### PR TITLE
Add typecheck on script args

### DIFF
--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -223,7 +223,7 @@ def get_all_units_from(script_args: List[Any]) -> List[ControlNetUnit]:
     all_units = [
         to_processing_unit(script_arg)
         for script_arg in script_args
-        if isinstance(script_arg, ControlNetUnit)
+        if isinstance(script_arg, ControlNetUnit) or isinstance(script_arg, dict)
     ]
     if not all_units:
         logger.warning("No ControlNetUnit detected in args. It is very likely that you are having an extension conflict."

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -220,15 +220,15 @@ def get_all_units_from(script_args: List[Any]) -> List[ControlNetUnit]:
     Fetch ControlNet processing units from ControlNet script arguments.
     Use `external_code.get_all_units` to fetch units from the list of all scripts arguments.
     """
-
-    units = []
-    i = 0
-    while i < len(script_args):
-        if script_args[i] is not None:
-            units.append(to_processing_unit(script_args[i]))
-        i += 1
-
-    return units
+    all_units = [
+        to_processing_unit(script_arg)
+        for script_arg in script_args
+        if isinstance(script_arg, ControlNetUnit)
+    ]
+    if not all_units:
+        logger.warning("No ControlNetUnit detected in args. It is very likely that you are having an extension conflict."
+                       f"Here are args passed to ControlNet: {script_args}.")
+    return all_units
 
 
 def get_single_unit_from(script_args: List[Any], index: int=0) -> Optional[ControlNetUnit]:


### PR DESCRIPTION
We have plenty of issues caused by A1111 screwup the script args parsing due to extension conflicts. This PR adds a typecheck to ensure that a meaningful error message is printed out.
https://github.com/Mikubill/sd-webui-controlnet/issues?q=is%3Aissue+%22has+no+attribute+%27enabled%27%22