### PR TITLE
Enable pixel perfect by default

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -818,6 +818,11 @@ class Script(scripts.Script):
                     resize_mode=resize_mode
                 )
 
+            midas_modules = ("depth", "normal_map")
+            if unit.module in midas_modules and preprocessor_resolution > 512:
+                logger.info("Midas models are trained on 384 resolution, which perform bad when using resolution > 512."
+                            "Please consider lower the resolution and/or turn off pixel perfect mode.")
+
             logger.info(f'preprocessor resolution = {preprocessor_resolution}')
             # Preprocessor result may depend on numpy random operations, use the
             # random seed in `StableDiffusionProcessing` to make the 

--- a/scripts/external_code.py
+++ b/scripts/external_code.py
@@ -160,7 +160,7 @@ class ControlNetUnit:
         threshold_b: float=-1,
         guidance_start: float=0.0,
         guidance_end: float=1.0,
-        pixel_perfect: bool=False,
+        pixel_perfect: bool=True,
         control_mode: Union[ControlMode, int, str] = ControlMode.BALANCED,
         **_kwargs,
     ):


### PR DESCRIPTION
This PR enables pixel perfect mode by default for all ControlNet units. 

As far as I know in most situations I need to check pixel perfect checkbox. If there is no downside of using pixel perfect mode, we should make it enabled by default.

Correct me if there is any side effect/downside which makes pixel perfect mode an undesirable option.