### PR TITLE
:wrench: Wait longer for openpose editor iframe to respond

### DIFF
--- a/javascript/openpose_editor.js
+++ b/javascript/openpose_editor.js
@@ -37,9 +37,9 @@
 
                 if (getPathname(iframe.src) !== EDITOR_PATH) {
                     iframe.src = `${EDITOR_PATH}?${darkThemeParam}`;
-                    // By default assume 1 second is enough for the openpose editor
+                    // By default assume 5 second is enough for the openpose editor
                     // to load.
-                    setTimeout(resolve, 1000);
+                    setTimeout(resolve, 5000);
                 } else {
                     // If no navigation is required, immediately return.
                     resolve();


### PR DESCRIPTION
See:
https://github.com/huchenlei/sd-webui-openpose-editor/issues/32

Suspect on slower machines, the initial load of the iframe can take longer than 1 second. If 5s is still giving the error, we should consider introduce a handshake mechanism.