### PR TITLE
:wrench: Disable ControlNet input in img2img inpaint

### DIFF
--- a/javascript/active_units.js
+++ b/javascript/active_units.js
@@ -18,8 +18,15 @@
             return children.indexOf(element);
         }
 
+        function imageInputDisabledAlert() {
+            alert('Inpaint control type must use a1111 input in img2img mode.');
+        }
+
         class GradioTab {
             constructor(tab) {
+                this.tab = tab;
+                this.isImg2Img = tab.querySelector('.cnet-unit-enabled').id.includes('img2img');
+
                 this.enabledCheckbox = tab.querySelector('.cnet-unit-enabled input');
                 this.inputImage = tab.querySelector('.cnet-input-image-group .cnet-image input[type="file"]');
                 this.controlTypeRadios = tab.querySelectorAll('.controlnet_control_type_filter_group input[type="radio"]');
@@ -79,6 +86,30 @@
                 tabNavButton.appendChild(span);
             }
 
+            /**
+             * When 'Inpaint' control type is selected in img2img:
+             * - Make image input disabled
+             * - Clear existing image input
+             */
+            updateImageInputState() {
+                if (!this.isImg2Img) return;
+
+                const tabNavButton = this.getTabNavButton();
+                if (!tabNavButton) return;
+
+                const controlType = this.getActiveControlType();
+                if (controlType.toLowerCase() === 'inpaint') {
+                    this.inputImage.disabled = true;
+                    this.inputImage.parentNode.addEventListener('click', imageInputDisabledAlert);
+                    const removeButton = this.tab.querySelector(
+                        '.cnet-input-image-group .cnet-image button[aria-label="Remove Image"]');
+                    if (removeButton) removeButton.click();
+                } else {
+                    this.inputImage.disabled = false;
+                    this.inputImage.parentNode.removeEventListener('click', imageInputDisabledAlert);
+                }
+            }
+
             attachEnabledButtonListener() {
                 this.enabledCheckbox.addEventListener('change', () => {
                     this.updateActiveState();
@@ -89,6 +120,7 @@
                 for (const radio of this.controlTypeRadios) {
                     radio.addEventListener('change', () => {
                         this.updateActiveControlType();
+                        this.updateImageInputState();
                     });
                 }
             }

--- a/javascript/active_units.js
+++ b/javascript/active_units.js
@@ -47,7 +47,7 @@
                 return undefined;
             }
 
-            applyActiveState() {
+            updateActiveState() {
                 const tabNavButton = this.getTabNavButton();
                 if (!tabNavButton) return;
 
@@ -61,7 +61,7 @@
             /**
              * Add the active control type to tab displayed text.
              */
-            applyActiveControlType() {
+            updateActiveControlType() {
                 const tabNavButton = this.getTabNavButton();
                 if (!tabNavButton) return;
 
@@ -81,14 +81,14 @@
 
             attachEnabledButtonListener() {
                 this.enabledCheckbox.addEventListener('change', () => {
-                    this.applyActiveState();
+                    this.updateActiveState();
                 });
             }
 
             attachControlTypeRadioListener() {
                 for (const radio of this.controlTypeRadios) {
                     radio.addEventListener('change', () => {
-                        this.applyActiveControlType();
+                        this.updateActiveControlType();
                     });
                 }
             }
@@ -102,8 +102,8 @@
                 new MutationObserver((mutationsList) => {
                     for (const mutation of mutationsList) {
                         if (mutation.type === 'childList') {
-                            this.applyActiveState();
-                            this.applyActiveControlType();
+                            this.updateActiveState();
+                            this.updateActiveControlType();
                         }
                     }
                 }).observe(this.tabNav, { childList: true });


### PR DESCRIPTION
According to https://github.com/Mikubill/sd-webui-controlnet/discussions/1143, when using inpaint, ControlNet input should be left blank, and ControlNet will by default fallback onto the A1111 img2img input. However, our front-end code does not enforce user leave the input blank. User can still upload an irrelevant image as ControlNet input, and apply a mask on that image. This can cause very undefined and controversial behaviours, e.g.
- When both masks exists, current code picks the mask from A1111, but the ControlNet input image is picked.
- https://github.com/Mikubill/sd-webui-controlnet/issues/1743
- The generation result does not make sence when img2img input and ControlNet input are not the same image

For these considerations, this PR disables the ControlNet image input when user selects inpaint as control type in img2img. The backend inpaint logic is untouched. Going to clean it up in a separate PR.