### PR TITLE
:wrench: Disable resize mode selection when using A1111 input

### DIFF
--- a/javascript/active_units.js
+++ b/javascript/active_units.js
@@ -5,7 +5,7 @@
  * Append control type to tab name.
  */
 (function () {
-    const cnetAllUnits = new Map/* <Element, GradioTab> */();
+    const cnetAllUnits = new Map/* <Element, ControlNetUnitTab> */();
     const cnetAllAccordions = new Set();
     onUiUpdate(() => {
         function childIndex(element) {
@@ -22,7 +22,7 @@
             alert('Inpaint control type must use a1111 input in img2img mode.');
         }
 
-        class GradioTab {
+        class ControlNetUnitTab {
             constructor(tab) {
                 this.tab = tab;
                 this.isImg2Img = tab.querySelector('.cnet-unit-enabled').id.includes('img2img');
@@ -153,7 +153,7 @@
 
         gradioApp().querySelectorAll('.cnet-unit-tab').forEach(tab => {
             if (cnetAllUnits.has(tab)) return;
-            cnetAllUnits.set(tab, new GradioTab(tab));
+            cnetAllUnits.set(tab, new ControlNetUnitTab(tab));
         });
 
         function getActiveUnitCount(checkboxes) {

--- a/style.css
+++ b/style.css
@@ -129,3 +129,7 @@
     bottom: 0px;
     right: 0px;
 }
+
+.cnet-disabled-radio {
+    opacity: 50%;
+}


### PR DESCRIPTION
In img2img when using A1111 input, the resize mode from A1111 will be used. The resize mode set in ControlNet UI will be ignored.

This PR disables the resize mode selection when using A1111 input in img2img mode so that it is clear that the value is not being used by the backend. 