### PR TITLE
Controllable inpainting Gaussian blur sigma value

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -901,7 +901,7 @@ class Script(scripts.Script, metaclass=(
                 final_inpaint_feed = np.ascontiguousarray(final_inpaint_feed).copy()
                 final_inpaint_mask = final_inpaint_feed[0, 3, :, :].astype(np.float32)
                 final_inpaint_raw = final_inpaint_feed[0, :3].astype(np.float32)
-                sigma = 7
+                sigma = shared.opts.data.get("control_net_inpaint_blur_sigma", 7)
                 final_inpaint_mask = cv2.dilate(final_inpaint_mask, np.ones((sigma, sigma), dtype=np.uint8))
                 final_inpaint_mask = cv2.blur(final_inpaint_mask, (sigma, sigma))[None]
                 _, Hmask, Wmask = final_inpaint_mask.shape
@@ -1031,6 +1031,8 @@ def on_ui_settings():
         3, "Multi ControlNet: Max models amount (requires restart)", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}, section=section))
     shared.opts.add_option("control_net_model_cache_size", shared.OptionInfo(
         1, "Model cache size (requires restart)", gr.Slider, {"minimum": 1, "maximum": 5, "step": 1}, section=section))
+    shared.opts.add_option("control_net_inpaint_blur_sigma", shared.OptionInfo(
+        7, "ControlNet inpainting Gaussian blur sigma", gr.Slider, {"minimum": 0, "maximum": 64, "step": 1}, section=section))
     shared.opts.add_option("control_net_no_detectmap", shared.OptionInfo(
         False, "Do not append detectmap to output", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_detectmap_autosaving", shared.OptionInfo(


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/1811

This exposes the Gaussian blur sigma value used for inpainting (currently hardcoded at an arbitrary value of `7`), which can allow for a more smoother transition in some cases, especially for txt2img outpainting. The default value remains at `7`.

You can see a before/after comparison here: https://imgsli.com/MTkzMzYw
(image from https://github.com/Mikubill/sd-webui-controlnet/discussions/1597#discussioncomment-6401743)

---

I believe this could still be improved but I'm not sure the best way to go about implementing a proper fix. An additional final pass in img2img + manual feathering may be the only way to 100% resolve it for the time being.

cc @wywywywy if you would like to test this out as well.