### PR TITLE
Add setting to disable ControlNet in highres fix pass

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1033,6 +1033,8 @@ def on_ui_settings():
         1, "Model cache size (requires restart)", gr.Slider, {"minimum": 1, "maximum": 5, "step": 1}, section=section))
     shared.opts.add_option("control_net_inpaint_blur_sigma", shared.OptionInfo(
         7, "ControlNet inpainting Gaussian blur sigma", gr.Slider, {"minimum": 0, "maximum": 64, "step": 1}, section=section))
+    shared.opts.add_option("control_net_no_high_res_fix", shared.OptionInfo(
+        False, "Do not apply ControlNet during highres fix", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_no_detectmap", shared.OptionInfo(
         False, "Do not append detectmap to output", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_detectmap_autosaving", shared.OptionInfo(

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -387,6 +387,8 @@ class UnetHook(nn.Module):
                             param.used_hint_cond_latent = None
                             param.used_hint_inpaint_hijack = None
 
+            no_high_res_control = is_in_high_res_fix and shared.opts.data.get("control_net_no_high_res_fix", False)
+
             # Convert control image to latent
             for param in outer.control_params:
                 if param.used_hint_cond_latent is not None:
@@ -399,6 +401,9 @@ class UnetHook(nn.Module):
 
             # handle prompt token control
             for param in outer.control_params:
+                if no_high_res_control:
+                    continue
+
                 if param.guidance_stopped:
                     continue
 
@@ -414,6 +419,9 @@ class UnetHook(nn.Module):
 
             # handle ControlNet / T2I_Adapter
             for param in outer.control_params:
+                if no_high_res_control:
+                    continue
+
                 if param.guidance_stopped:
                     continue
 
@@ -524,6 +532,9 @@ class UnetHook(nn.Module):
 
             # Handle attention and AdaIn control
             for param in outer.control_params:
+                if no_high_res_control:
+                    continue
+
                 if param.guidance_stopped:
                     continue
 
@@ -605,7 +616,7 @@ class UnetHook(nn.Module):
                     continue
 
                 k = int(param.preprocessor['threshold_a'])
-                if is_in_high_res_fix:
+                if is_in_high_res_fix and not no_high_res_control:
                     k *= 2
 
                 # Inpaint hijack


### PR DESCRIPTION
Closes #1826

Adds an option in settings to disable ControlNet in highres fix. I'm not 100% sure if this breaks anything so I'm setting this as a draft for now. I also cannot produce anything that causes a "big negative impact" as mentioned in the issue, as in my tests images look nearly the same with or without this setting enabled, but that does mean it can cut down generation times in half with minimal change to the final output, so I figure it's a nice QoL feature to have.