### PR TITLE
Repair ControlNet infotext parsing

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -263,7 +263,7 @@ class Script(scripts.Script, metaclass=(
         The return value should be an array of all components that are used in processing.
         Values of those returned components will be passed to run() and process() functions.
         """
-        infotext = Infotext()        
+        infotext = Infotext()
         
         controls = ()
         max_models = shared.opts.data.get("control_net_max_models_num", 1)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1,6 +1,7 @@
 import gc
 import os
 import logging
+import re
 from collections import OrderedDict
 from copy import copy
 from typing import Dict, Optional, Tuple
@@ -21,6 +22,7 @@ from scripts.controlnet_ui.controlnet_ui_group import ControlNetUiGroup, UiContr
 from scripts.logging import logger
 from modules.processing import StableDiffusionProcessingImg2Img, StableDiffusionProcessingTxt2Img
 from modules.images import save_image
+from scripts.infotext import Infotext
 
 import cv2
 import numpy as np
@@ -246,24 +248,23 @@ class Script(scripts.Script, metaclass=(
             model="None"
         )
 
-    def uigroup(self, tabname: str, is_img2img: bool, elem_id_tabname: str):
+    def uigroup(self, tabname: str, is_img2img: bool, elem_id_tabname: str) -> Tuple[ControlNetUiGroup, gr.State]:
         group = ControlNetUiGroup(
             gradio_compat,
-            self.infotext_fields,
             Script.get_default_ui_unit(),
             self.preprocessor,
         )
         group.render(tabname, elem_id_tabname, is_img2img)
         group.register_callbacks(is_img2img)
-        return group.render_and_register_unit(tabname, is_img2img)
+        return group, group.render_and_register_unit(tabname, is_img2img)
 
     def ui(self, is_img2img):
         """this function should create gradio UI elements. See https://gradio.app/docs/#components
         The return value should be an array of all components that are used in processing.
         Values of those returned components will be passed to run() and process() functions.
         """
-        self.infotext_fields = []
-        self.paste_field_names = []
+        infotext = Infotext()        
+        
         controls = ()
         max_models = shared.opts.data.get("control_net_max_models_num", 1)
         elem_id_tabname = ("img2img" if is_img2img else "txt2img") + "_controlnet"
@@ -274,14 +275,18 @@ class Script(scripts.Script, metaclass=(
                         for i in range(max_models):
                             with gr.Tab(f"ControlNet Unit {i}", 
                                         elem_classes=['cnet-unit-tab']):
-                                controls += (self.uigroup(f"ControlNet-{i}", is_img2img, elem_id_tabname),)
+                                group, state = self.uigroup(f"ControlNet-{i}", is_img2img, elem_id_tabname)
+                                infotext.register_unit(i, group)
+                                controls += (state,)
                 else:
                     with gr.Column():
-                        controls += (self.uigroup(f"ControlNet", is_img2img, elem_id_tabname),)
+                        group, state = self.uigroup(f"ControlNet", is_img2img, elem_id_tabname)
+                        infotext.register_unit(0, group)
+                        controls += (state,)
 
-        if shared.opts.data.get("control_net_sync_field_args", False):
-            for _, field_name in self.infotext_fields:
-                self.paste_field_names.append(field_name)
+        if shared.opts.data.get("control_net_sync_field_args", True):
+            self.infotext_fields = infotext.infotext_fields
+            self.paste_field_names = infotext.paste_field_names
 
         return controls
     
@@ -562,39 +567,19 @@ class Script(scripts.Script, metaclass=(
     @staticmethod
     def get_enabled_units(p):
         units = external_code.get_all_units_in_processing(p)
-        enabled_units = []
-
         if len(units) == 0:
             # fill a null group
             remote_unit = Script.parse_remote_call(p, Script.get_default_ui_unit(), 0)
             if remote_unit.enabled:
                 units.append(remote_unit)
-
-        for idx, unit in enumerate(units):
-            unit = Script.parse_remote_call(p, unit, idx)
-            if not unit.enabled:
-                continue
-
-            enabled_units.append(copy(unit))
-            if len(units) != 1:
-                log_key = f"ControlNet {idx}"
-            else:
-                log_key = "ControlNet"
-
-            log_value = {
-                "preprocessor": unit.module,
-                "model": unit.model,
-                "weight": unit.weight,
-                "starting/ending": str((unit.guidance_start, unit.guidance_end)),
-                "resize mode": str(unit.resize_mode),
-                "pixel perfect": str(unit.pixel_perfect),
-                "control mode": str(unit.control_mode),
-                "preprocessor params": str((unit.processor_res, unit.threshold_a, unit.threshold_b)),
-            }
-            log_value = str(log_value).replace('\'', '').replace('{', '').replace('}', '')
-
-            p.extra_generation_params.update({log_key: log_value})
-
+        
+        enabled_units = [
+            local_unit
+            for idx, unit in enumerate(units)
+            for local_unit in (Script.parse_remote_call(p, unit, idx),)
+            if local_unit.enabled
+        ]
+        Infotext.write_infotext(enabled_units, p)
         return enabled_units
 
     @staticmethod
@@ -1064,7 +1049,7 @@ def on_ui_settings():
     shared.opts.add_option("control_net_allow_script_control", shared.OptionInfo(
         False, "Allow other script to control this extension", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_sync_field_args", shared.OptionInfo(
-        False, "Passing ControlNet parameters with \"Send to img2img\"", gr.Checkbox, {"interactive": True}, section=section))
+        True, "Paste ControlNet parameters in infotext", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_show_batch_images_in_ui", shared.OptionInfo(
         False, "Show batch images in gradio gallery output", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_increment_seed_during_batch", shared.OptionInfo(
@@ -1080,4 +1065,5 @@ def on_ui_settings():
 
 batch_hijack.instance.do_hijack()
 script_callbacks.on_ui_settings(on_ui_settings)
+script_callbacks.on_infotext_pasted(Infotext.on_infotext_pasted)
 script_callbacks.on_after_component(ControlNetUiGroup.on_after_component)

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -574,7 +574,7 @@ class Script(scripts.Script, metaclass=(
                 units.append(remote_unit)
         
         enabled_units = [
-            local_unit
+            copy(local_unit)
             for idx, unit in enumerate(units)
             for local_unit in (Script.parse_remote_call(p, unit, idx),)
             if local_unit.enabled

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -1,8 +1,7 @@
 import gradio as gr
 import functools
-from typing import List, Optional, Union, Dict, Callable
+from typing import List, Optional, Union, Callable
 import numpy as np
-import base64
 
 from scripts.utils import svg_preprocess
 from scripts import (
@@ -101,12 +100,10 @@ class ControlNetUiGroup(object):
     def __init__(
         self,
         gradio_compat: bool,
-        infotext_fields: List[str],
         default_unit: external_code.ControlNetUnit,
         preprocessors: List[Callable],
     ):
         self.gradio_compat = gradio_compat
-        self.infotext_fields = infotext_fields
         self.default_unit = default_unit
         self.preprocessors = preprocessors
         self.webcam_enabled = False
@@ -114,7 +111,7 @@ class ControlNetUiGroup(object):
 
         # Note: All gradio elements declared in `render` will be defined as member variable.
         self.upload_tab = None
-        self.input_image = None
+        self.image = None
         self.generated_image_group = None
         self.generated_image = None
         self.batch_tab = None
@@ -129,7 +126,7 @@ class ControlNetUiGroup(object):
         self.webcam_mirror = None
         self.send_dimen_button = None
         self.enabled = None
-        self.lowvram = None
+        self.low_vram = None
         self.pixel_perfect = None
         self.preprocessor_preview = None
         self.type_filter = None
@@ -169,7 +166,7 @@ class ControlNetUiGroup(object):
                     with gr.Tab(label="Single Image") as self.upload_tab:
                         with gr.Row(elem_classes=["cnet-image-row"]).style(equal_height=True):
                             with gr.Group(elem_classes=["cnet-input-image-group"]):
-                                self.input_image = gr.Image(
+                                self.image = gr.Image(
                                     source="upload",
                                     brush_radius=20,
                                     mirror_webcam=False,
@@ -263,9 +260,9 @@ class ControlNetUiGroup(object):
                 label="Enable",
                 value=self.default_unit.enabled,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_enable_checkbox",
-                elem_classes=['cnet-unit-enabled'],
+                elem_classes=["cnet-unit-enabled"],
             )
-            self.lowvram = gr.Checkbox(
+            self.low_vram = gr.Checkbox(
                 label="Low VRAM",
                 value=self.default_unit.low_vram,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_low_vram_checkbox",
@@ -444,7 +441,7 @@ class ControlNetUiGroup(object):
         )
         self.send_dimen_button.click(
             fn=send_dimensions,
-            inputs=[self.input_image],
+            inputs=[self.image],
             outputs=outputs,
         )
 
@@ -457,16 +454,14 @@ class ControlNetUiGroup(object):
                 "__type__": "update",
             }
 
-        self.webcam_enable.click(webcam_toggle, inputs=None, outputs=self.input_image)
+        self.webcam_enable.click(webcam_toggle, inputs=None, outputs=self.image)
 
     def register_webcam_mirror_toggle(self):
         def webcam_mirror_toggle():
             self.webcam_mirrored = not self.webcam_mirrored
             return {"mirror_webcam": self.webcam_mirrored, "__type__": "update"}
 
-        self.webcam_mirror.click(
-            webcam_mirror_toggle, inputs=None, outputs=self.input_image
-        )
+        self.webcam_mirror.click(webcam_mirror_toggle, inputs=None, outputs=self.image)
 
     def register_refresh_all_models(self):
         def refresh_all_models(*inputs):
@@ -485,21 +480,34 @@ class ControlNetUiGroup(object):
             return
 
         def build_sliders(module, pp):
+            default_res_slider_config = dict(
+                label=flag_preprocessor_resolution,
+                value=512,
+                minimum=64,
+                maximum=2048,
+                step=1,
+            )
+            # Clear old slider values so that they do not cause confusion in
+            # infotext.
+            clear_slider_update = gr.update(
+                visible=False,
+                interactive=False,
+                minimum=-1,
+                maximum=-1,
+                value=-1,
+            )
+
             grs = []
             module = global_state.get_module_basename(module)
             if module not in preprocessor_sliders_config:
                 grs += [
                     gr.update(
-                        label=flag_preprocessor_resolution,
-                        value=512,
-                        minimum=64,
-                        maximum=2048,
-                        step=1,
+                        **default_res_slider_config,
                         visible=not pp,
                         interactive=not pp,
                     ),
-                    gr.update(visible=False, interactive=False),
-                    gr.update(visible=False, interactive=False),
+                    clear_slider_update,
+                    clear_slider_update,
                     gr.update(visible=True),
                 ]
             else:
@@ -522,9 +530,9 @@ class ControlNetUiGroup(object):
                             )
                         )
                     else:
-                        grs.append(gr.update(visible=False, interactive=False))
+                        grs.append(clear_slider_update)
                 while len(grs) < 3:
-                    grs.append(gr.update(visible=False, interactive=False))
+                    grs.append(clear_slider_update)
                 grs.append(gr.update(visible=True))
             if module in model_free_preprocessors:
                 grs += [
@@ -554,13 +562,17 @@ class ControlNetUiGroup(object):
                     filtered_preprocessor_list,
                     filtered_model_list,
                     default_option,
-                    default_model
-                ) =  global_state.select_control_type(k)
+                    default_model,
+                ) = global_state.select_control_type(k)
                 return [
-                    gr.Dropdown.update(value=default_option, choices=filtered_preprocessor_list),
-                    gr.Dropdown.update(value=default_model, choices=filtered_model_list),
+                    gr.Dropdown.update(
+                        value=default_option, choices=filtered_preprocessor_list
+                    ),
+                    gr.Dropdown.update(
+                        value=default_model, choices=filtered_model_list
+                    ),
                 ] + build_sliders(default_option, pp)
-                
+
             self.type_filter.change(
                 filter_selected,
                 inputs=[self.type_filter, self.pixel_perfect],
@@ -571,9 +583,9 @@ class ControlNetUiGroup(object):
         def run_annotator(image, module, pres, pthr_a, pthr_b, t2i_w, t2i_h, pp, rm):
             if image is None:
                 return (
-                    gr.update(value=None, visible=True), 
-                    gr.update(), 
-                    *self.openpose_editor.update(''),
+                    gr.update(value=None, visible=True),
+                    gr.update(),
+                    *self.openpose_editor.update(""),
                 )
 
             img = HWC3(image["image"])            
@@ -657,7 +669,7 @@ class ControlNetUiGroup(object):
         self.trigger_preprocessor.click(
             fn=run_annotator,
             inputs=[
-                self.input_image,
+                self.image,
                 self.module,
                 self.processor_res,
                 self.threshold_a,
@@ -725,7 +737,7 @@ class ControlNetUiGroup(object):
         self.canvas_create_button.click(
             fn=fn_canvas,
             inputs=[self.canvas_height, self.canvas_width],
-            outputs=[self.input_image, self.create_canvas],
+            outputs=[self.image, self.create_canvas],
         )
 
     def register_img2img_same_input(self):
@@ -737,7 +749,7 @@ class ControlNetUiGroup(object):
             ] + [gr.update(visible=x)] * 4
 
         self.upload_independent_img_in_img2img.change(fn_same_checked, inputs=self.upload_independent_img_in_img2img, outputs=[
-            self.input_image, self.batch_image_dir, self.preprocessor_preview,
+            self.image, self.batch_image_dir, self.preprocessor_preview,
             self.image_upload_panel, self.trigger_preprocessor, self.loopback, self.resize_mode
         ])
         return
@@ -764,20 +776,6 @@ class ControlNetUiGroup(object):
         )
         if is_img2img:
             self.register_img2img_same_input()
-
-    def register_modules(
-        self, tabname: str, enabled, module, model, weight, guidance_start, guidance_end
-    ):
-        self.infotext_fields.extend(
-            [
-                (enabled, f"{tabname} Enabled"),
-                (module, f"{tabname} Preprocessor"),
-                (model, f"{tabname} Model"),
-                (weight, f"{tabname} Weight"),
-                (guidance_start, f"{tabname} Guidance Start"),
-                (guidance_end, f"{tabname} Guidance End"),
-            ]
-        )
 
     def render_and_register_unit(self, tabname: str, is_img2img: bool):
         """Render the invisible states elements for misc persistent
@@ -809,9 +807,9 @@ class ControlNetUiGroup(object):
             self.module,
             self.model,
             self.weight,
-            self.input_image,
+            self.image,
             self.resize_mode,
-            self.lowvram,
+            self.low_vram,
             self.processor_res,
             self.threshold_a,
             self.threshold_b,
@@ -820,18 +818,9 @@ class ControlNetUiGroup(object):
             self.pixel_perfect,
             self.control_mode,
         )
-        self.register_modules(
-            tabname,
-            self.enabled,
-            self.module,
-            self.model,
-            self.weight,
-            self.guidance_start,
-            self.guidance_end,
-        )
 
-        self.input_image.preprocess = functools.partial(
-            svg_preprocess, preprocess=self.input_image.preprocess
+        self.image.preprocess = functools.partial(
+            svg_preprocess, preprocess=self.image.preprocess
         )
 
         unit = gr.State(self.default_unit)
@@ -862,7 +851,7 @@ class ControlNetUiGroup(object):
         for comp in (
             self.pixel_perfect,
             self.module,
-            self.input_image,
+            self.image,
             self.processor_res,
             self.threshold_a,
             self.threshold_b,

--- a/scripts/infotext.py
+++ b/scripts/infotext.py
@@ -1,0 +1,121 @@
+from typing import List, Tuple, Union
+
+import gradio as gr
+
+from modules.processing import StableDiffusionProcessing
+
+from scripts import external_code
+from scripts.logging import logger
+from scripts.controlnet_ui.controlnet_ui_group import ControlNetUiGroup
+
+
+def field_to_displaytext(fieldname: str) -> str:
+    return " ".join([word.capitalize() for word in fieldname.split("_")])
+
+
+def displaytext_to_field(text: str) -> str:
+    return "_".join([word.lower() for word in text.split(" ")])
+
+
+def parse_value(value: str) -> Union[str, float, int, bool]:
+    if value in ("True", "False"):
+        return value == "True"
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value  # Plain string.
+
+
+def serialize_unit(unit: external_code.ControlNetUnit) -> str:
+    log_value = {
+        field_to_displaytext(field): getattr(unit, field)
+        for field in vars(external_code.ControlNetUnit()).keys()
+        if field not in ("image", "enabled") and getattr(unit, field) != -1
+        # Note: exclude hidden slider values.
+    }
+    assert all("," not in str(v) and ":" not in str(v) for v in log_value.values())
+    return ", ".join(f"{field}: {value}" for field, value in log_value.items())
+
+
+def parse_unit(text: str) -> external_code.ControlNetUnit:
+    return external_code.ControlNetUnit(
+        enabled=True,
+        **{
+            displaytext_to_field(key): parse_value(value)
+            for item in text.split(",")
+            for (key, value) in (item.strip().split(": "),)
+        },
+    )
+
+
+class Infotext(object):
+    def __init__(self) -> None:
+        self.infotext_fields: List[Tuple[gr.components.IOComponent, str]] = []
+        self.paste_field_names: List[str] = []
+
+    @staticmethod
+    def unit_prefix(unit_index: int) -> str:
+        return f"ControlNet {unit_index}"
+
+    def register_unit(self, unit_index: int, uigroup: ControlNetUiGroup) -> None:
+        """Register the unit's UI group. By regsitering the unit, A1111 will be
+        able to paste values from infotext to IOComponents.
+
+        Args:
+            unit_index: The index of the ControlNet unit
+            uigroup: The ControlNetUiGroup instance that contains all gradio
+                     iocomponents.
+        """
+        unit_prefix = Infotext.unit_prefix(unit_index)
+        for field in vars(external_code.ControlNetUnit()).keys():
+            # Exclude image for infotext.
+            if field == "image":
+                continue
+
+            # Every field in ControlNetUnit should have a cooresponding
+            # IOComponent in ControlNetUiGroup.
+            io_component = getattr(uigroup, field)
+            component_locator = f"{unit_prefix} {field}"
+            self.infotext_fields.append((io_component, component_locator))
+            self.paste_field_names.append(component_locator)
+
+    @staticmethod
+    def write_infotext(
+        units: List[external_code.ControlNetUnit], p: StableDiffusionProcessing
+    ):
+        """Write infotext to `p`."""
+        p.extra_generation_params.update(
+            {
+                Infotext.unit_prefix(i): serialize_unit(unit)
+                for i, unit in enumerate(units)
+                if unit.enabled
+            }
+        )
+
+    @staticmethod
+    def on_infotext_pasted(infotext: str, results: dict) -> None:
+        """Parse ControlNet infotext string and write result to `results` dict."""
+        updates = {}
+        for k, v in results.items():
+            if not k.startswith("ControlNet"):
+                continue
+
+            assert isinstance(v, str), f"Expect string but got {v}."
+            try:
+                for field, value in vars(parse_unit(v)).items():
+                    if field == "image":
+                        continue
+
+                    assert value is not None, f"{field} == None"
+                    component_locator = f"{k} {field}"
+                    updates[component_locator] = value
+                    logger.debug(f"InfoText: Setting {component_locator} = {value}")
+            except Exception:
+                logger.warn(
+                    f"Failed to parse infotext, legacy format infotext is no longer supported:\n{v}"
+                )
+
+        results.update(updates)

--- a/tests/cn_script/batch_hijack_test.py
+++ b/tests/cn_script/batch_hijack_test.py
@@ -59,7 +59,7 @@ class TestGetControlNetBatchesWorks(unittest.TestCase):
 
         batch_units = [unit for unit in self.p.script_args if getattr(unit, 'input_mode', batch_hijack.InputMode.SIMPLE) == batch_hijack.InputMode.BATCH]
         if batch_units:
-            self.assertEqual(min(len(unit.batch_images) for unit in batch_units), len(batches))
+            self.assertEqual(min(len(list(unit.batch_images)) for unit in batch_units), len(batches))
         else:
             self.assertEqual(1, len(batches))
 


### PR DESCRIPTION
Closes #1793

This was broken (and has been for quite some time now) after ControlNet params started being stored altogether as part of a single key and not separate keys per param. The ideal solution would be rework how this is handled altogether so it accounts for more parameters in a cleaner way, but this is just patching the functionality that previously existed for now.

This also allows the `Parse ControlNet parameters in infotext` setting (previously titled `Passing ControlNet parameters with "Send to img2img"` which is unclear and technically incorrect since it also applies to txt2img) to be handled at runtime rather than requiring a restart of the webui, as the setting previously was only taken into account during the UI creation process.

~~Setting as a draft because [`active_units.js`](https://github.com/Mikubill/sd-webui-controlnet/blob/main/javascript/active_units.js) doesn't trigger UI updates when the infotext is parsed currently. Not sure what's going on as it does recognize the changes once the ControlNet tab is switched or the `Enabled` checkbox is unticked (easier to see this behavior if loading the infotext from an image using multiple ControlNet modules).~~