### PR TITLE
Disable ControlNet if model is SDXL

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -702,6 +702,11 @@ class Script(scripts.Script, metaclass=(
         if len(self.enabled_units) == 0:
            self.latest_network = None
            return
+        
+        is_sdxl = getattr(p.sd_model, 'is_sdxl', False)
+        if is_sdxl:
+            logger.warning('ControlNet does not support SDXL -- disabling')
+            return
 
         detected_maps = []
         forward_params = []


### PR DESCRIPTION
Closes #1834

Checks if an SDXL model is loaded directly after checking if any CN units are enabled, and will exit the process function with a console warning if so.