### PR TITLE
opencv-python-headless

### DIFF
--- a/annotator/zoe/zoedepth/models/base_models/midas_repo/environment.yaml
+++ b/annotator/zoe/zoedepth/models/base_models/midas_repo/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - pip=22.3.1
   - numpy=1.23.4
   - pip:
-    - opencv-python==4.6.0.66
+    - opencv-python-headless==4.6.0.66
     - imutils==0.5.4
     - timm==0.6.12
     - einops==0.6.0


### PR DESCRIPTION
This replaces the opencv package with a headless variant, to avoid dependency on libglib2, libgl1 etc. Ref #1881