### PR TITLE
disable run preprocessor if no cn input image

### DIFF
--- a/javascript/active_units.js
+++ b/javascript/active_units.js
@@ -73,6 +73,7 @@
                 this.inputImageContainer = tab.querySelector('.cnet-input-image-group .cnet-image');
                 this.controlTypeRadios = tab.querySelectorAll('.controlnet_control_type_filter_group input[type="radio"]');
                 this.resizeModeRadios = tab.querySelectorAll('.controlnet_resize_mode_radio input[type="radio"]');
+                this.runPreprocessorButton = tab.querySelector('.cnet-run-preprocessor');
 
                 const tabs = tab.parentNode;
                 this.tabNav = tabs.querySelector('.tab-nav');
@@ -218,13 +219,24 @@
             }
 
             attachImageStateChangeObserver() {
-                if (!this.isImg2Img) return;
-
                 new MutationObserver((mutationsList) => {
                     const changeObserved = imgChangeObserved(mutationsList);
                     if (changeObserved === ImgChangeType.ADD ||
                         changeObserved === ImgChangeType.REMOVE) {
-                        this.updateResizeModeState();
+                        if (this.isImg2Img)
+                            this.updateResizeModeState();
+                    }
+
+                    if (changeObserved === ImgChangeType.ADD) {
+                        // enabling the run preprocessor button
+                        this.runPreprocessorButton.removeAttribute("disabled");
+                        this.runPreprocessorButton.title = 'Run preprocessor';
+                    }
+
+                    if (changeObserved === ImgChangeType.REMOVE) {
+                        // disabling the run preprocessor button
+                        this.runPreprocessorButton.setAttribute("disabled", true);
+                        this.runPreprocessorButton.title = "No ControlNet input image available";
                     }
                 }).observe(this.inputImageContainer, {
                     childList: true,

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -12,7 +12,7 @@
     onUiUpdate(function () {
         gradioApp().querySelectorAll('.cnet-toolbutton').forEach(function (button) {
             const tooltip = titles[button.textContent];
-            if (tooltip) {
+            if (tooltip && (!button.hasAttribute("title"))) {
                 button.title = tooltip;
             }
         })

--- a/javascript/img2img_input_display.js
+++ b/javascript/img2img_input_display.js
@@ -18,11 +18,23 @@
             const badge = container.querySelector('.cnet-badge');
             if (badge) badge.remove();
 
-            if (imgDataURL) {
-                // Do not add fallback image if controlnet input already exists.
-                if (container.querySelector('img'))
-                    continue;
+            // retrieve the beginning of the container name to build the corresponding button selector
+            id_slice = container.id.slice(0,31);
+            const run_preprocess_btn = document.querySelector('#'+id_slice+'_controlnet_trigger_preprocessor');
 
+            // Do not add fallback image if controlnet input already exists.
+            if (container.querySelector('img')) {
+                // enabling the run preprocessor button
+                run_preprocess_btn.removeAttribute("disabled");
+                run_preprocess_btn.title = 'Run preprocessor';
+                continue;
+            } else {
+                // disabling the run preprocessor button
+                run_preprocess_btn.setAttribute("disabled","disabled");
+                run_preprocess_btn.title = "No ControlNet input image available";
+            }
+            
+            if (imgDataURL) {
                 // Set the background image
                 container.style.backgroundImage = `url('${imgDataURL}')`;
 

--- a/javascript/img2img_input_display.js
+++ b/javascript/img2img_input_display.js
@@ -18,23 +18,11 @@
             const badge = container.querySelector('.cnet-badge');
             if (badge) badge.remove();
 
-            // retrieve the beginning of the container name to build the corresponding button selector
-            id_slice = container.id.slice(0,31);
-            const run_preprocess_btn = document.querySelector('#'+id_slice+'_controlnet_trigger_preprocessor');
-
-            // Do not add fallback image if controlnet input already exists.
-            if (container.querySelector('img')) {
-                // enabling the run preprocessor button
-                run_preprocess_btn.removeAttribute("disabled");
-                run_preprocess_btn.title = 'Run preprocessor';
-                continue;
-            } else {
-                // disabling the run preprocessor button
-                run_preprocess_btn.setAttribute("disabled","disabled");
-                run_preprocess_btn.title = "No ControlNet input image available";
-            }
-            
             if (imgDataURL) {
+                // Do not add fallback image if controlnet input already exists.
+                if (container.querySelector('img')) {
+                    continue;
+                }
                 // Set the background image
                 container.style.backgroundImage = `url('${imgDataURL}')`;
 

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -28,7 +28,9 @@ class ToolButton(gr.Button, gr.components.FormComponent):
     """Small button with single emoji as text, fits inside gradio forms"""
 
     def __init__(self, **kwargs):
-        super().__init__(variant="tool", elem_classes=["cnet-toolbutton"], **kwargs)
+        super().__init__(variant="tool", 
+                         elem_classes=kwargs.pop('elem_classes', []) + ["cnet-toolbutton"], 
+                         **kwargs)
 
     def get_block_name(self):
         return "button"
@@ -303,6 +305,7 @@ class ControlNetUiGroup(object):
                 value=ControlNetUiGroup.trigger_symbol,
                 visible=True,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_trigger_preprocessor",
+                elem_classes=['cnet-run-preprocessor'],
             )
             self.model = gr.Dropdown(
                 list(global_state.cn_models.keys()),


### PR DESCRIPTION
In response to issue https://github.com/Mikubill/sd-webui-controlnet/issues/1867 and related to PR [#1747](https://github.com/Mikubill/sd-webui-controlnet/pull/1747), I suggest those modifications to the Javascript code.

The run preprocessor button is enabled only if an image input exists in the ControlNet input tab. The hint of the button is changed accordingly.

One problem I have:
at the first start of webui, the button is enabled without any input image. I don't know where in the code I can change this initial state. But I don't think it is a big issue as the user will not expect any result with a totally blank canvas I believe.