### PR TITLE
Fix mask blur

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -163,8 +163,22 @@ def prepare_mask(
     mask = mask.convert("L")
     if getattr(p, "inpainting_mask_invert", False):
         mask = ImageOps.invert(mask)
-    if getattr(p, "mask_blur", 0) > 0:
-        mask = mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
+    
+    if hasattr(p, 'mask_blur'):
+        if getattr(p, "mask_blur", 0) > 0:
+            mask = mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
+    else:
+        if getattr(p, "mask_blur_x", 0) > 0:
+            np_mask = np.array(mask)
+            kernel_size = 2 * int(4 * p.mask_blur_x + 0.5) + 1
+            np_mask = cv2.GaussianBlur(np_mask, (kernel_size, 1), p.mask_blur_x)
+            mask = Image.fromarray(np_mask)
+        if getattr(p, "mask_blur_y", 0) > 0:
+            np_mask = np.array(mask)
+            kernel_size = 2 * int(4 * p.mask_blur_y + 0.5) + 1
+            np_mask = cv2.GaussianBlur(np_mask, (1, kernel_size), p.mask_blur_y)
+            mask = Image.fromarray(np_mask)
+    
     return mask
 
 

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -164,10 +164,7 @@ def prepare_mask(
     if getattr(p, "inpainting_mask_invert", False):
         mask = ImageOps.invert(mask)
     
-    if hasattr(p, 'mask_blur'):
-        if getattr(p, "mask_blur", 0) > 0:
-            mask = mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
-    else:
+    if hasattr(p, 'mask_blur_x'):
         if getattr(p, "mask_blur_x", 0) > 0:
             np_mask = np.array(mask)
             kernel_size = 2 * int(4 * p.mask_blur_x + 0.5) + 1
@@ -178,6 +175,9 @@ def prepare_mask(
             kernel_size = 2 * int(4 * p.mask_blur_y + 0.5) + 1
             np_mask = cv2.GaussianBlur(np_mask, (1, kernel_size), p.mask_blur_y)
             mask = Image.fromarray(np_mask)
+    else:
+        if getattr(p, "mask_blur", 0) > 0:
+            mask = mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
     
     return mask
 

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -167,12 +167,12 @@ def prepare_mask(
     if hasattr(p, 'mask_blur_x'):
         if getattr(p, "mask_blur_x", 0) > 0:
             np_mask = np.array(mask)
-            kernel_size = 2 * int(4 * p.mask_blur_x + 0.5) + 1
+            kernel_size = 2 * int(2.5 * p.mask_blur_x + 0.5) + 1
             np_mask = cv2.GaussianBlur(np_mask, (kernel_size, 1), p.mask_blur_x)
             mask = Image.fromarray(np_mask)
         if getattr(p, "mask_blur_y", 0) > 0:
             np_mask = np.array(mask)
-            kernel_size = 2 * int(4 * p.mask_blur_y + 0.5) + 1
+            kernel_size = 2 * int(2.5 * p.mask_blur_y + 0.5) + 1
             np_mask = cv2.GaussianBlur(np_mask, (1, kernel_size), p.mask_blur_y)
             mask = Image.fromarray(np_mask)
     else:


### PR DESCRIPTION
Resolves https://github.com/Mikubill/sd-webui-controlnet/discussions/1888, https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12428

This has been broken for about 3 months now and was never accounted for in this extension. The webui switched from using `mask_blur` to separate attributes for `mask_blur_x` and `mask_blur_y` in 1.4.0, so the `mask_blur` was read as `None` by ControlNet. https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10295

Uses the same code from here to modify the mask: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/26c92f056acc795af5066779f1b8aedb8dfa983d/modules/processing.py#L1287-L1297