### PR TITLE
Revert MiDaS CPU workaround for MPS

### DIFF
--- a/annotator/midas/__init__.py
+++ b/annotator/midas/__init__.py
@@ -17,15 +17,13 @@ def apply_midas(input_image, a=np.pi * 2.0, bg_th=0.1):
     global model
     if model is None:
         model = MiDaSInference(model_type="dpt_hybrid")
-    if devices.get_device_for("controlnet").type != 'mps':
-        model = model.to(devices.get_device_for("controlnet"))
+    model = model.to(devices.get_device_for("controlnet"))
     
     assert input_image.ndim == 3
     image_depth = input_image
     with torch.no_grad():
         image_depth = torch.from_numpy(image_depth).float()
-        if devices.get_device_for("controlnet").type != 'mps':
-            image_depth = image_depth.to(devices.get_device_for("controlnet"))
+        image_depth = image_depth.to(devices.get_device_for("controlnet"))
         image_depth = image_depth / 127.5 - 1.0
         image_depth = rearrange(image_depth, 'h w c -> 1 c h w')
         depth = model(image_depth)[0]


### PR DESCRIPTION
It looks like using CPU instead of MPS for the MiDaS preprocessor isn't necessary any longer. There was a bug in macOS and/or PyTorch that previously had resulted in corrupted results when running the MiDaS preprocessor with MPS but I no longer see that issue.