### PR TITLE
No blocking generation on infotext failure

### DIFF
--- a/scripts/infotext.py
+++ b/scripts/infotext.py
@@ -36,7 +36,10 @@ def serialize_unit(unit: external_code.ControlNetUnit) -> str:
         if field not in ("image", "enabled") and getattr(unit, field) != -1
         # Note: exclude hidden slider values.
     }
-    assert all("," not in str(v) and ":" not in str(v) for v in log_value.values())
+    if not all("," not in str(v) and ":" not in str(v) for v in log_value.values()):
+        logger.error(f"Unexpected tokens encountered:\n{log_value}")
+        return ""
+    
     return ", ".join(f"{field}: {value}" for field, value in log_value.items())
 
 


### PR DESCRIPTION
User has reported the assertion got triggered in https://github.com/Mikubill/sd-webui-controlnet/issues/1966.

This PR converts the check to a soft one that does not block generation.