### PR TITLE
Fix zoom and mask brush color customizable

### DIFF
--- a/javascript/canvas.js
+++ b/javascript/canvas.js
@@ -6,6 +6,8 @@
                 hasApplied = true;
                 window.applyZoomAndPanIntegration("#txt2img_controlnet",Array.from({ length: 20 }, (_, i) => `#txt2img_controlnet_ControlNet-${i}_input_image`));
                 window.applyZoomAndPanIntegration("#img2img_controlnet",Array.from({ length: 20 }, (_, i) => `#img2img_controlnet_ControlNet-${i}_input_image`));
+                window.applyZoomAndPan("#txt2img_controlnet_ControlNet_input_image");
+                window.applyZoomAndPan("#img2img_controlnet_ControlNet_input_image");
                 //console.log("window.applyZoomAndPanIntegration applied.");
             } else {
                 //console.log("window.applyZoomAndPanIntegration is not available.");

--- a/javascript/canvas.js
+++ b/javascript/canvas.js
@@ -2,14 +2,12 @@
     var hasApplied = false;
     onUiUpdate(function () {
         if (!hasApplied) {
-            if (typeof window.applyZoomAndPanIntegration === "function") {  // webui 1.6.0 
+            if (typeof window.applyZoomAndPanIntegration === "function") {
                 hasApplied = true;
                 window.applyZoomAndPanIntegration("#txt2img_controlnet",Array.from({ length: 20 }, (_, i) => `#txt2img_controlnet_ControlNet-${i}_input_image`));
                 window.applyZoomAndPanIntegration("#img2img_controlnet",Array.from({ length: 20 }, (_, i) => `#img2img_controlnet_ControlNet-${i}_input_image`));
-                if (typeof window.applyZoomAndPan === "function") {  // check is nested because window.applyZoomAndPan was added in webui 1.4.0
-                    window.applyZoomAndPan("#txt2img_controlnet_ControlNet_input_image");
-                    window.applyZoomAndPan("#img2img_controlnet_ControlNet_input_image");
-                }
+                window.applyZoomAndPanIntegration("#txt2img_controlnet", ["#txt2img_controlnet_ControlNet_input_image"]);
+                window.applyZoomAndPanIntegration("#img2img_controlnet", ["#img2img_controlnet_ControlNet_input_image"]);
                 //console.log("window.applyZoomAndPanIntegration applied.");
             } else {
                 //console.log("window.applyZoomAndPanIntegration is not available.");

--- a/javascript/canvas.js
+++ b/javascript/canvas.js
@@ -4,8 +4,8 @@
         if (!hasApplied) {
             if (typeof window.applyZoomAndPanIntegration === "function") {
                 hasApplied = true;
-                window.applyZoomAndPanIntegration("#txt2img_controlnet",Array.from({ length: 20 }, (_, i) => `#txt2img_controlnet_ControlNet-${i}_input_image`));
-                window.applyZoomAndPanIntegration("#img2img_controlnet",Array.from({ length: 20 }, (_, i) => `#img2img_controlnet_ControlNet-${i}_input_image`));
+                window.applyZoomAndPanIntegration("#txt2img_controlnet", Array.from({ length: 20 }, (_, i) => `#txt2img_controlnet_ControlNet-${i}_input_image`));
+                window.applyZoomAndPanIntegration("#img2img_controlnet", Array.from({ length: 20 }, (_, i) => `#img2img_controlnet_ControlNet-${i}_input_image`));
                 window.applyZoomAndPanIntegration("#txt2img_controlnet", ["#txt2img_controlnet_ControlNet_input_image"]);
                 window.applyZoomAndPanIntegration("#img2img_controlnet", ["#img2img_controlnet_ControlNet_input_image"]);
                 //console.log("window.applyZoomAndPanIntegration applied.");

--- a/javascript/canvas.js
+++ b/javascript/canvas.js
@@ -2,12 +2,14 @@
     var hasApplied = false;
     onUiUpdate(function () {
         if (!hasApplied) {
-            if (typeof window.applyZoomAndPanIntegration === "function") {
+            if (typeof window.applyZoomAndPanIntegration === "function") {  // webui 1.6.0 
                 hasApplied = true;
                 window.applyZoomAndPanIntegration("#txt2img_controlnet",Array.from({ length: 20 }, (_, i) => `#txt2img_controlnet_ControlNet-${i}_input_image`));
                 window.applyZoomAndPanIntegration("#img2img_controlnet",Array.from({ length: 20 }, (_, i) => `#img2img_controlnet_ControlNet-${i}_input_image`));
-                window.applyZoomAndPan("#txt2img_controlnet_ControlNet_input_image");
-                window.applyZoomAndPan("#img2img_controlnet_ControlNet_input_image");
+                if (typeof window.applyZoomAndPan === "function") {  // check is nested because window.applyZoomAndPan was added in webui 1.4.0
+                    window.applyZoomAndPan("#txt2img_controlnet_ControlNet_input_image");
+                    window.applyZoomAndPan("#img2img_controlnet_ControlNet_input_image");
+                }
                 //console.log("window.applyZoomAndPanIntegration applied.");
             } else {
                 //console.log("window.applyZoomAndPanIntegration is not available.");

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -174,7 +174,7 @@ class ControlNetUiGroup(object):
                                     tool="sketch",
                                     elem_id=f"{elem_id_tabname}_{tabname}_input_image",
                                     elem_classes=["cnet-image"],
-                                    brush_color=shared.opts.img2img_inpaint_mask_brush_color
+                                    brush_color=shared.opts.img2img_inpaint_mask_brush_color if hasattr(shared.opts, 'img2img_inpaint_mask_brush_color') else None
                                 )
                             with gr.Group(
                                 visible=False, elem_classes=["cnet-generated-image-group"]

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -174,6 +174,7 @@ class ControlNetUiGroup(object):
                                     tool="sketch",
                                     elem_id=f"{elem_id_tabname}_{tabname}_input_image",
                                     elem_classes=["cnet-image"],
+                                    brush_color=shared.opts.img2img_inpaint_mask_brush_color
                                 )
                             with gr.Group(
                                 visible=False, elem_classes=["cnet-generated-image-group"]


### PR DESCRIPTION
### make zoom work with single CN module 
currently it only works with when `Multi ControlNet: Max models amount` > 1

I took a shortcut in not checking if `window.applyZoomAndPan` is a function because 
 `window.applyZoomAndPanIntegration` is a new addition, and if it is a function then `window.applyZoomAndPan` also is function 

### make the mask brush color customizable
this is a new feature of gradio
and we have already applied it into 1.6.0 RC
which can be seen in the webui 1.6.0 RC or dev, but cannot be seen in master
I did a quick test and it seems that this doesn't break the current master 1.5.2, so hopefully it is backwards compatible with previous versions as well

I'm using the same settings key with img2img inpaint canvus in 1.6.0RC `shared.opts.img2img_inpaint_mask_brush_color`
but you may want to separate it out into a different key

screenshot of canvus zoom working with singel CN module and the brush color set to red
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/40751091/bed642ed-a7d0-406e-9dd3-0a8882a54b3b)

