### PR TITLE
[New Feature] ControlNet unit preset management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ annotator/downloads/
 web_tests/results/
 web_tests/expectations/
 *_diff.png
+
+# Presets
+presets/

--- a/javascript/active_units.js
+++ b/javascript/active_units.js
@@ -85,6 +85,7 @@
                 this.attachImageUploadListener();
                 this.attachImageStateChangeObserver();
                 this.attachA1111SendInfoObserver();
+                this.attachPresetDropdownObserver();
 
                 // Initial updates:
                 if (this.isImg2Img)
@@ -299,6 +300,25 @@
                         }, 2000);
                     });
                 }
+            }
+
+            attachPresetDropdownObserver() {
+                const presetDropDown = this.tab.querySelector('.cnet-preset-dropdown');
+
+                new MutationObserver((mutationsList) => {
+                    for (const mutation of mutationsList) {
+                        if (mutation.removedNodes.length > 0) {
+                            setTimeout(() => {
+                                this.updateActiveState();
+                                this.updateActiveUnitCount();
+                            }, 100);
+                            return;
+                        }
+                    }
+                }).observe(presetDropDown, {
+                    childList: true,
+                    subtree: true,
+                });
             }
         }
 

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -7,6 +7,8 @@
         '📝': 'Open new canvas',
         '📷': 'Enable webcam',
         '⇄': 'Mirror webcam',
+        '💾': 'Save preset',
+        '🗑️': 'Delete preset',
     };
 
     onUiUpdate(function () {

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -21,21 +21,9 @@ from scripts.processor import (
 from scripts.logging import logger
 from scripts.controlnet_ui.openpose_editor import OpenposeEditor
 from scripts.controlnet_ui.preset import ControlNetPresetUI
+from scripts.controlnet_ui.tool_button import ToolButton
 from modules import shared
 from modules.ui_components import FormRow
-
-
-class ToolButton(gr.Button, gr.components.FormComponent):
-    """Small button with single emoji as text, fits inside gradio forms"""
-
-    def __init__(self, **kwargs):
-        super().__init__(variant="tool", 
-                         elem_classes=kwargs.pop('elem_classes', []) + ["cnet-toolbutton"], 
-                         **kwargs)
-
-    def get_block_name(self):
-        return "button"
-
 
 class UiControlNetUnit(external_code.ControlNetUnit):
     """The data class that stores all states of a ControlNetUnit."""

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -20,6 +20,7 @@ from scripts.processor import (
 )
 from scripts.logging import logger
 from scripts.controlnet_ui.openpose_editor import OpenposeEditor
+from scripts.controlnet_ui.preset import ControlNetPresetUI
 from modules import shared
 from modules.ui_components import FormRow
 
@@ -147,6 +148,7 @@ class ControlNetUiGroup(object):
         self.loopback = None
         self.use_preview_as_input = None
         self.openpose_editor = None
+        self.preset_panel = None
         self.upload_independent_img_in_img2img = None
         self.image_upload_panel = None
 
@@ -411,6 +413,8 @@ class ControlNetUiGroup(object):
             elem_classes="controlnet_loopback_checkbox",
             visible=not is_img2img
         )
+
+        self.preset_panel = ControlNetPresetUI()
 
     def register_send_dimensions(self, is_img2img: bool):
         """Register event handler for send dimension button."""
@@ -775,6 +779,9 @@ class ControlNetUiGroup(object):
         self.openpose_editor.register_callbacks(
             self.generated_image, self.use_preview_as_input
         )
+        self.preset_panel.register_callbacks(*[
+            getattr(self, key) for key in vars(external_code.ControlNetUnit()).keys()
+        ])
         if is_img2img:
             self.register_img2img_same_input()
 

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -414,7 +414,7 @@ class ControlNetUiGroup(object):
             visible=not is_img2img
         )
 
-        self.preset_panel = ControlNetPresetUI()
+        self.preset_panel = ControlNetPresetUI(id_prefix=f"{elem_id_tabname}_{tabname}_")
 
     def register_send_dimensions(self, is_img2img: bool):
         """Register event handler for send dimension button."""

--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -1,0 +1,176 @@
+import os
+import gradio as gr
+
+from typing import Dict, List
+
+from modules import ui_components, scripts
+from scripts.infotext import parse_unit, serialize_unit
+from scripts import external_code
+
+save_symbol = "\U0001f4be"  # 💾
+delete_symbol = "\U0001f5d1\ufe0f"  # 🗑️
+
+NEW_PRESET = "New Preset"
+
+
+def load_presets(preset_dir: str) -> Dict[str, str]:
+    if not os.path.exists(preset_dir):
+        os.makedirs(preset_dir)
+        return {}
+
+    presets = {}
+    for filename in os.listdir(preset_dir):
+        if filename.endswith(".txt"):
+            with open(os.path.join(preset_dir, filename), "r") as f:
+                presets[filename.replace(".txt", "")] = f.read()
+    return presets
+
+
+class ControlNetPresetUI(object):
+    preset_directory = os.path.join(scripts.basedir(), "presets")
+    presets = load_presets(preset_directory)
+
+    def __init__(self):
+        self.dropdown = None
+        self.save_button = None
+        self.delete_button = None
+        self.preset_name = None
+        self.confirm_preset_name = None
+        self.name_dialog = None
+        self.render()
+
+    def render(self):
+        with gr.Row():
+            self.dropdown = gr.Dropdown(
+                label="Styles",
+                show_label=False,
+                elem_classes=["cnet-preset-dropdown"],
+                choices=ControlNetPresetUI.dropdown_choices(),
+                value=NEW_PRESET,
+                tooltip="Presets",
+            )
+            self.save_button = ui_components.ToolButton(
+                value=save_symbol,
+                elem_classes=["cnet-preset-save"],
+                tooltip="Save preset",
+            )
+            self.delete_button = ui_components.ToolButton(
+                value=delete_symbol,
+                elem_classes=["cnet-preset-delete"],
+                tooltip="Delete preset",
+            )
+
+        with gr.Box(
+            elem_classes=["popup-dialog", "cnet-preset-enter-name"],
+        ) as self.name_dialog:
+            self.preset_name = gr.Textbox(
+                label="Preset name",
+                show_label=True,
+                lines=1,
+                elem_classes=["cnet-preset-name"],
+            )
+            self.confirm_preset_name = gr.Button(
+                value="Confirm", elem_classes=["cnet-preset-confirm-name"]
+            )
+
+    def register_callbacks(self, *ui_states):
+        self.dropdown.change(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, *ui_states],
+            show_progress=False,
+        )
+
+        def save_preset(name: str, *ui_states):
+            if name == NEW_PRESET:
+                return gr.update(visible=True)
+
+            ControlNetPresetUI.save_preset(
+                name, external_code.ControlNetUnit(*ui_states)
+            )
+            return gr.update()
+
+        self.save_button.click(
+            fn=save_preset,
+            inputs=[self.dropdown, *ui_states],
+            outputs=[self.name_dialog],
+            show_progress=False,
+        ).then(
+            fn=None,
+            _js=f"""
+            (name) => {{
+                if (name !== "{NEW_PRESET}")
+                    popup(gradioApp().getElementById('{self.name_dialog.elem_id}'));
+            }}""",
+            inputs=[self.dropdown],
+        )
+
+        def delete_preset(name: str):
+            ControlNetPresetUI.delete_preset(name)
+            return gr.Dropdown.update(
+                choices=ControlNetPresetUI.dropdown_choices(),
+                value=NEW_PRESET,
+            )
+
+        self.delete_button.click(
+            fn=delete_preset,
+            inputs=[self.dropdown],
+            outputs=[self.dropdown],
+            show_progress=False,
+        )
+
+        self.name_dialog.visible = False
+
+        def save_new_preset(new_name: str, *ui_states):
+            ControlNetPresetUI.save_preset(
+                new_name, external_code.ControlNetUnit(*ui_states)
+            )
+
+        self.confirm_preset_name.click(
+            fn=save_new_preset,
+            inputs=[self.preset_name, *ui_states],
+            outputs=None,
+            show_progress=False,
+        ).then(fn=None, _js="closePopup")
+
+    @staticmethod
+    def dropdown_choices() -> List[str]:
+        return list(ControlNetPresetUI.presets.keys()) + [NEW_PRESET]
+
+    @staticmethod
+    def save_preset(name: str, unit: external_code.ControlNetUnit):
+        infotext = serialize_unit(unit)
+        with open(
+            os.path.join(ControlNetPresetUI.preset_directory, f"{name}.txt"), "w"
+        ) as f:
+            f.write(infotext)
+
+        ControlNetPresetUI.presets[name] = infotext
+
+    @staticmethod
+    def delete_preset(name: str):
+        if name not in ControlNetPresetUI.presets:
+            return
+
+        del ControlNetPresetUI.presets[name]
+
+        file = os.path.join(ControlNetPresetUI.preset_directory, f"{name}.txt")
+        if os.path.exists(file):
+            os.unlink(file)
+
+    @staticmethod
+    def apply_preset(name: str):
+        if name == NEW_PRESET:
+            return (
+                gr.update(visible=False),
+                (gr.update(),) * len(vars(external_code.ControlNetUnit()).keys()),
+            )
+
+        assert name in ControlNetPresetUI.presets
+        infotext = ControlNetPresetUI.presets[name]
+        unit = parse_unit(infotext)
+
+        return gr.update(visible=True), *[
+            gr.update(value=value) if value is not None else gr.update()
+            for value in vars(unit).values()
+        ]

--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -3,8 +3,9 @@ import gradio as gr
 
 from typing import Dict, List
 
-from modules import ui_components, scripts
+from modules import scripts
 from scripts.infotext import parse_unit, serialize_unit
+from scripts.controlnet_ui.tool_button import ToolButton
 from scripts.logging import logger
 from scripts import external_code
 
@@ -54,17 +55,17 @@ class ControlNetPresetUI(object):
                 choices=ControlNetPresetUI.dropdown_choices(),
                 value=NEW_PRESET,
             )
-            self.save_button = ui_components.ToolButton(
+            self.save_button = ToolButton(
                 value=save_symbol,
                 elem_classes=["cnet-preset-save"],
                 tooltip="Save preset",
             )
-            self.delete_button = ui_components.ToolButton(
+            self.delete_button = ToolButton(
                 value=delete_symbol,
                 elem_classes=["cnet-preset-delete"],
                 tooltip="Delete preset",
             )
-            self.refresh_button = ui_components.ToolButton(
+            self.refresh_button = ToolButton(
                 value=refresh_symbol,
                 elem_classes=["cnet-preset-refresh"],
                 tooltip="Refresh preset",
@@ -81,7 +82,7 @@ class ControlNetPresetUI(object):
                     lines=1,
                     elem_classes=["cnet-preset-name"],
                 )
-                self.confirm_preset_name = ui_components.ToolButton(
+                self.confirm_preset_name = ToolButton(
                     value=save_symbol,
                     elem_classes=["cnet-preset-confirm-name"],
                     tooltip="Save preset",

--- a/scripts/controlnet_ui/tool_button.py
+++ b/scripts/controlnet_ui/tool_button.py
@@ -1,0 +1,12 @@
+import gradio as gr
+
+class ToolButton(gr.Button, gr.components.FormComponent):
+    """Small button with single emoji as text, fits inside gradio forms"""
+
+    def __init__(self, **kwargs):
+        super().__init__(variant="tool", 
+                         elem_classes=kwargs.pop('elem_classes', []) + ["cnet-toolbutton"], 
+                         **kwargs)
+
+    def get_block_name(self):
+        return "button"

--- a/scripts/infotext.py
+++ b/scripts/infotext.py
@@ -6,7 +6,6 @@ from modules.processing import StableDiffusionProcessing
 
 from scripts import external_code
 from scripts.logging import logger
-from scripts.controlnet_ui.controlnet_ui_group import ControlNetUiGroup
 
 
 def field_to_displaytext(fieldname: str) -> str:
@@ -63,7 +62,7 @@ class Infotext(object):
     def unit_prefix(unit_index: int) -> str:
         return f"ControlNet {unit_index}"
 
-    def register_unit(self, unit_index: int, uigroup: ControlNetUiGroup) -> None:
+    def register_unit(self, unit_index: int, uigroup) -> None:
         """Register the unit's UI group. By regsitering the unit, A1111 will be
         able to paste values from infotext to IOComponents.
 


### PR DESCRIPTION
Users have requested to be able to save easily save and load controlnet unit presets in https://github.com/Mikubill/sd-webui-controlnet/issues/1854.

This PR implements a preset manager UI that allows users to save/load ControlNet unit presets. Presets are persisted locally as text file under `presets/`.

 
![Screen Capture 025 - Stable Diffusion - 127 0 0 1](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/5aa48bdd-c003-44b8-893a-686669ff8798)

Known issues:
- Preprocessor sliders values are not populated due to issue mentioned in #1833 .
- Toolbuttons are having wrong hover hint.