### PR TITLE
Update controlnet_ui_group.py

### DIFF
--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -155,7 +155,7 @@ class ControlNetUiGroup(object):
         with gr.Group(visible=not is_img2img) as self.image_upload_panel:
             with gr.Tabs():
                     with gr.Tab(label="Single Image") as self.upload_tab:
-                        with gr.Row(elem_classes=["cnet-image-row"], style={"equal_height": True}):
+                        with gr.Row(elem_classes=["cnet-image-row"], equal_height=True):
                             with gr.Group(elem_classes=["cnet-input-image-group"]):
                                 self.image = gr.Image(
                                     source="upload",
@@ -176,7 +176,7 @@ class ControlNetUiGroup(object):
                                     elem_id=f"{elem_id_tabname}_{tabname}_generated_image",
                                     elem_classes=["cnet-image"], 
                                     interactive=False,
-                                    style={"height": "242px"}
+                                    height=242
                                 )  # Gradio's magic number. Only 242 works.
 
                                 with gr.Group(

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -155,7 +155,7 @@ class ControlNetUiGroup(object):
         with gr.Group(visible=not is_img2img) as self.image_upload_panel:
             with gr.Tabs():
                     with gr.Tab(label="Single Image") as self.upload_tab:
-                        with gr.Row(elem_classes=["cnet-image-row"]).style(equal_height=True):
+                        with gr.Row(elem_classes=["cnet-image-row"], style={"equal_height": True}):
                             with gr.Group(elem_classes=["cnet-input-image-group"]):
                                 self.image = gr.Image(
                                     source="upload",
@@ -174,9 +174,9 @@ class ControlNetUiGroup(object):
                                     value=None,
                                     label="Preprocessor Preview",
                                     elem_id=f"{elem_id_tabname}_{tabname}_generated_image",
-                                    elem_classes=["cnet-image"], interactive=False
-                                ).style(
-                                    height=242
+                                    elem_classes=["cnet-image"], 
+                                    interactive=False,
+                                    style={"height": "242px"}
                                 )  # Gradio's magic number. Only 242 works.
 
                                 with gr.Group(


### PR DESCRIPTION
After switching the "Autometic 1111" repository to the pre-release version "v1.6.0-RC-5-ge004384e," the control net started encountering the following error:

```
D:\AI\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\controlnet_ui\controlnet_ui_group.py:158: GradioDeprecationWarning: The `style` method is deprecated. Please set these arguments in the constructor instead.
  with gr.Row(elem_classes=["cnet-image-row"]).style(equal_height=True):
D:\AI\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\controlnet_ui\controlnet_ui_group.py:173: GradioDeprecationWarning: The `style` method is deprecated. Please set these arguments in the constructor instead.
  self.generated_image = gr.Image(
```

To resolve this issue, I made the necessary adjustments...

Here's how the startup codes currently appear:

```
venv "D:\AI\stable-diffusion-webui\venv\Scripts\Python.exe"
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)]
Version: v1.6.0-RC-5-ge004384e
Commit hash: e004384e460ad4568736dfff459c1ea809f05794

Launching Web UI with arguments: --xformers --opt-sdp-no-mem-attention --no-half-vae --autolaunch
Civitai Helper: Get Custom Model Folder
Civitai Helper: Load setting from: D:\AI\stable-diffusion-webui\extensions\Stable-Diffusion-Webui-Civitai-Helper\setting.json
Civitai Helper: No setting file, use default
[-] ADetailer initialized. version: 23.8.1, num models: 12
2023-08-25 20:17:35,608 - ControlNet - INFO - ControlNet v1.1.312
ControlNet preprocessor location: D:\AI\stable-diffusion-webui\extensions\sd-webui-controlnet\annotator\downloads
2023-08-25 20:17:35,689 - ControlNet - INFO - ControlNet v1.1.312
Loading weights [fdcf7423a3] from D:\AI\stable-diffusion-webui\models\Stable-diffusion\Anime\Anime Mix (midnight) 155.safetensors
Creating model from config: D:\AI\stable-diffusion-webui\configs\v1-inference.yaml
Running on local URL:  http://127.0.0.1:7860

To create a public link, set `share=True` in `launch()`.
[Lobe]: Initializing Lobe
Startup time: 16.3s (prepare environment: 2.7s, import torch: 2.6s, import gradio: 0.8s, setup paths: 0.6s, initialize shared: 0.2s, other imports: 0.5s, setup codeformer: 0.2s, list SD models: 1.0s, load scripts: 5.7s, create ui: 1.8s, gradio launch: 0.2s).
Loading VAE weights specified in settings: D:\AI\stable-diffusion-webui\models\VAE\kl-f8-anime3.vae.pt
Applying attention optimization: xformers... done.
Model loaded in 5.7s (load weights from disk: 0.5s, create model: 1.3s, apply weights to model: 1.8s, apply dtype to VAE: 1.0s, load VAE: 0.2s, load textual inversion embeddings: 0.1s, calculate empty prompt: 0.8s).
```