### PR TITLE
:bug: Fix preset application

### DIFF
--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -104,7 +104,37 @@ class ControlNetPresetUI(object):
                 )
 
     def register_callbacks(self, control_type: gr.Radio, *ui_states):
+        # Do application 5 times
+        # If first update triggers control type change, wrong module will be
+        # selected
+        # 2nd update will be executed at the same time with the module update
+        # If 3rd update triggers module change, wrong slider values will
+        # be used.
+        # 4th update will be executed at the same time with slider updates
+        # 5th update will be updating slider values
+        # TODO(huchenlei): This is exetremely hacky, need to find a better way
+        # to achieve the functionality.
         self.dropdown.change(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
+        ).then(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
+        ).then(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
+        ).then(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
+        ).then(
             fn=ControlNetPresetUI.apply_preset,
             inputs=[self.dropdown],
             outputs=[self.delete_button, control_type, *ui_states],


### PR DESCRIPTION
We need to rework the whole UI update logic later. This PR is just a temporary fix.

Before the fix, preprocessor/slider values will be overwritten by ControlType/Preprocessor updates, when applying preset.