### PR TITLE
Add reset button for preset

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -9,6 +9,7 @@
         '⇄': 'Mirror webcam',
         '💾': 'Save preset',
         '🗑️': 'Delete preset',
+        '↩': 'Reset preset',
     };
 
     onUiUpdate(function () {

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -692,7 +692,7 @@ class ControlNetUiGroup(object):
                 result = external_code.visualize_inpaint_mask(result)
                 return (
                     # Update to `generated_image`
-                    gr.update(value=result, visible=True, interactive=True),
+                    gr.update(value=result, visible=True, interactive=False),
                     # preprocessor_preview
                     gr.update(value=True),
                     # openpose editor

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -25,6 +25,7 @@ from scripts.controlnet_ui.tool_button import ToolButton
 from modules import shared
 from modules.ui_components import FormRow
 
+
 class UiControlNetUnit(external_code.ControlNetUnit):
     """The data class that stores all states of a ControlNetUnit."""
 
@@ -140,6 +141,10 @@ class ControlNetUiGroup(object):
         self.upload_independent_img_in_img2img = None
         self.image_upload_panel = None
 
+        # Internal states for UI state pasting.
+        self.prevent_next_n_module_update = 0
+        self.prevent_next_n_slider_value_update = 0
+
     def render(self, tabname: str, elem_id_tabname: str, is_img2img: bool) -> None:
         """The pure HTML structure of a single ControlNetUnit. Calling this
         function will populate `self` with all gradio element declared
@@ -154,98 +159,107 @@ class ControlNetUiGroup(object):
         """
         with gr.Group(visible=not is_img2img) as self.image_upload_panel:
             with gr.Tabs():
-                    with gr.Tab(label="Single Image") as self.upload_tab:
-                        with gr.Row(elem_classes=["cnet-image-row"]).style(equal_height=True):
-                            with gr.Group(elem_classes=["cnet-input-image-group"]):
-                                self.image = gr.Image(
-                                    source="upload",
-                                    brush_radius=20,
-                                    mirror_webcam=False,
-                                    type="numpy",
-                                    tool="sketch",
-                                    elem_id=f"{elem_id_tabname}_{tabname}_input_image",
-                                    elem_classes=["cnet-image"],
-                                    brush_color=shared.opts.img2img_inpaint_mask_brush_color if hasattr(shared.opts, 'img2img_inpaint_mask_brush_color') else None
+                with gr.Tab(label="Single Image") as self.upload_tab:
+                    with gr.Row(elem_classes=["cnet-image-row"]).style(
+                        equal_height=True
+                    ):
+                        with gr.Group(elem_classes=["cnet-input-image-group"]):
+                            self.image = gr.Image(
+                                source="upload",
+                                brush_radius=20,
+                                mirror_webcam=False,
+                                type="numpy",
+                                tool="sketch",
+                                elem_id=f"{elem_id_tabname}_{tabname}_input_image",
+                                elem_classes=["cnet-image"],
+                                brush_color=shared.opts.img2img_inpaint_mask_brush_color
+                                if hasattr(
+                                    shared.opts, "img2img_inpaint_mask_brush_color"
                                 )
+                                else None,
+                            )
+                        with gr.Group(
+                            visible=False, elem_classes=["cnet-generated-image-group"]
+                        ) as self.generated_image_group:
+                            self.generated_image = gr.Image(
+                                value=None,
+                                label="Preprocessor Preview",
+                                elem_id=f"{elem_id_tabname}_{tabname}_generated_image",
+                                elem_classes=["cnet-image"],
+                                interactive=True,
+                            ).style(
+                                height=242
+                            )  # Gradio's magic number. Only 242 works.
+
                             with gr.Group(
-                                visible=False, elem_classes=["cnet-generated-image-group"]
-                            ) as self.generated_image_group:
-                                self.generated_image = gr.Image(
-                                    value=None,
-                                    label="Preprocessor Preview",
-                                    elem_id=f"{elem_id_tabname}_{tabname}_generated_image",
-                                    elem_classes=["cnet-image"], interactive=False
-                                ).style(
-                                    height=242
-                                )  # Gradio's magic number. Only 242 works.
+                                elem_classes=["cnet-generated-image-control-group"]
+                            ):
+                                self.openpose_editor = OpenposeEditor()
+                                preview_check_elem_id = f"{elem_id_tabname}_{tabname}_controlnet_preprocessor_preview_checkbox"
+                                preview_close_button_js = f"document.querySelector('#{preview_check_elem_id} input[type=\\'checkbox\\']').click();"
+                                gr.HTML(
+                                    value=f"""<a title="Close Preview" onclick="{preview_close_button_js}">Close</a>""",
+                                    visible=True,
+                                    elem_classes=["cnet-close-preview"],
+                                )
 
-                                with gr.Group(
-                                    elem_classes=["cnet-generated-image-control-group"]
-                                ):
-                                    self.openpose_editor = OpenposeEditor()
-                                    preview_check_elem_id = f"{elem_id_tabname}_{tabname}_controlnet_preprocessor_preview_checkbox"
-                                    preview_close_button_js = f"document.querySelector('#{preview_check_elem_id} input[type=\\'checkbox\\']').click();"
-                                    gr.HTML(
-                                        value=f"""<a title="Close Preview" onclick="{preview_close_button_js}">Close</a>""",
-                                        visible=True,
-                                        elem_classes=["cnet-close-preview"],
-                                    )
-
-                    with gr.Tab(label="Batch") as self.batch_tab:
-                        self.batch_image_dir = gr.Textbox(
-                            label="Input Directory",
-                            placeholder="Leave empty to use img2img batch controlnet input directory",
-                            elem_id=f"{elem_id_tabname}_{tabname}_batch_image_dir",
-                        )
-
-            with gr.Accordion(label="Open New Canvas", visible=False) as self.create_canvas:
-                    self.canvas_width = gr.Slider(
-                        label="New Canvas Width",
-                        minimum=256,
-                        maximum=1024,
-                        value=512,
-                        step=64,
-                        elem_id=f"{elem_id_tabname}_{tabname}_controlnet_canvas_width",
+                with gr.Tab(label="Batch") as self.batch_tab:
+                    self.batch_image_dir = gr.Textbox(
+                        label="Input Directory",
+                        placeholder="Leave empty to use img2img batch controlnet input directory",
+                        elem_id=f"{elem_id_tabname}_{tabname}_batch_image_dir",
                     )
-                    self.canvas_height = gr.Slider(
-                        label="New Canvas Height",
-                        minimum=256,
-                        maximum=1024,
-                        value=512,
-                        step=64,
-                        elem_id=f"{elem_id_tabname}_{tabname}_controlnet_canvas_height",
+
+            with gr.Accordion(
+                label="Open New Canvas", visible=False
+            ) as self.create_canvas:
+                self.canvas_width = gr.Slider(
+                    label="New Canvas Width",
+                    minimum=256,
+                    maximum=1024,
+                    value=512,
+                    step=64,
+                    elem_id=f"{elem_id_tabname}_{tabname}_controlnet_canvas_width",
+                )
+                self.canvas_height = gr.Slider(
+                    label="New Canvas Height",
+                    minimum=256,
+                    maximum=1024,
+                    value=512,
+                    step=64,
+                    elem_id=f"{elem_id_tabname}_{tabname}_controlnet_canvas_height",
+                )
+                with gr.Row():
+                    self.canvas_create_button = gr.Button(
+                        value="Create New Canvas",
+                        elem_id=f"{elem_id_tabname}_{tabname}_controlnet_canvas_create_button",
                     )
-                    with gr.Row():
-                        self.canvas_create_button = gr.Button(
-                            value="Create New Canvas",
-                            elem_id=f"{elem_id_tabname}_{tabname}_controlnet_canvas_create_button",
-                        )
-                        self.canvas_cancel_button = gr.Button(
-                            value="Cancel",
-                            elem_id=f"{elem_id_tabname}_{tabname}_controlnet_canvas_cancel_button",
-                        )
+                    self.canvas_cancel_button = gr.Button(
+                        value="Cancel",
+                        elem_id=f"{elem_id_tabname}_{tabname}_controlnet_canvas_cancel_button",
+                    )
 
             with gr.Row(elem_classes="controlnet_image_controls"):
-                    gr.HTML(
-                        value="<p>Set the preprocessor to [invert] If your image has white background and black lines.</p>",
-                        elem_classes="controlnet_invert_warning",
-                    )
-                    self.open_new_canvas_button = ToolButton(
-                        value=ControlNetUiGroup.open_symbol,
-                        elem_id=f"{elem_id_tabname}_{tabname}_controlnet_open_new_canvas_button",
-                    )
-                    self.webcam_enable = ToolButton(
-                        value=ControlNetUiGroup.camera_symbol,
-                        elem_id=f"{elem_id_tabname}_{tabname}_controlnet_webcam_enable",
-                    )
-                    self.webcam_mirror = ToolButton(
-                        value=ControlNetUiGroup.reverse_symbol,
-                        elem_id=f"{elem_id_tabname}_{tabname}_controlnet_webcam_mirror",
-                    )
-                    self.send_dimen_button = ToolButton(
-                        value=ControlNetUiGroup.tossup_symbol,
-                        elem_id=f"{elem_id_tabname}_{tabname}_controlnet_send_dimen_button",
-                    )
+                gr.HTML(
+                    value="<p>Set the preprocessor to [invert] If your image has white background and black lines.</p>",
+                    elem_classes="controlnet_invert_warning",
+                )
+                self.open_new_canvas_button = ToolButton(
+                    value=ControlNetUiGroup.open_symbol,
+                    elem_id=f"{elem_id_tabname}_{tabname}_controlnet_open_new_canvas_button",
+                )
+                self.webcam_enable = ToolButton(
+                    value=ControlNetUiGroup.camera_symbol,
+                    elem_id=f"{elem_id_tabname}_{tabname}_controlnet_webcam_enable",
+                )
+                self.webcam_mirror = ToolButton(
+                    value=ControlNetUiGroup.reverse_symbol,
+                    elem_id=f"{elem_id_tabname}_{tabname}_controlnet_webcam_mirror",
+                )
+                self.send_dimen_button = ToolButton(
+                    value=ControlNetUiGroup.tossup_symbol,
+                    elem_id=f"{elem_id_tabname}_{tabname}_controlnet_send_dimen_button",
+                )
 
         with FormRow(elem_classes=["controlnet_main_options"]):
             self.enabled = gr.Checkbox(
@@ -265,7 +279,10 @@ class ControlNetUiGroup(object):
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_pixel_perfect_checkbox",
             )
             self.preprocessor_preview = gr.Checkbox(
-                label="Allow Preview", value=False, elem_id=preview_check_elem_id, visible=not is_img2img
+                label="Allow Preview",
+                value=False,
+                elem_id=preview_check_elem_id,
+                visible=not is_img2img,
             )
             self.use_preview_as_input = gr.Checkbox(
                 label="Preview as Input",
@@ -280,7 +297,7 @@ class ControlNetUiGroup(object):
                     label="Upload independent control image",
                     value=False,
                     elem_id=f"{elem_id_tabname}_{tabname}_controlnet_same_img2img_checkbox",
-                    elem_classes=['cnet-unit-same_img2img'],
+                    elem_classes=["cnet-unit-same_img2img"],
                 )
             else:
                 self.upload_independent_img_in_img2img = None
@@ -306,7 +323,7 @@ class ControlNetUiGroup(object):
                 value=ControlNetUiGroup.trigger_symbol,
                 visible=not is_img2img,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_trigger_preprocessor",
-                elem_classes=['cnet-run-preprocessor']
+                elem_classes=["cnet-run-preprocessor"],
             )
             self.model = gr.Dropdown(
                 list(global_state.cn_models.keys()),
@@ -356,7 +373,7 @@ class ControlNetUiGroup(object):
                 minimum=64,
                 maximum=2048,
                 visible=False,
-                interactive=False,
+                interactive=True,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_preprocessor_resolution_slider",
             )
             self.threshold_a = gr.Slider(
@@ -365,7 +382,7 @@ class ControlNetUiGroup(object):
                 minimum=64,
                 maximum=1024,
                 visible=False,
-                interactive=False,
+                interactive=True,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_threshold_A_slider",
             )
             self.threshold_b = gr.Slider(
@@ -374,7 +391,7 @@ class ControlNetUiGroup(object):
                 minimum=64,
                 maximum=1024,
                 visible=False,
-                interactive=False,
+                interactive=True,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_threshold_B_slider",
             )
 
@@ -392,7 +409,7 @@ class ControlNetUiGroup(object):
             label="Resize Mode",
             elem_id=f"{elem_id_tabname}_{tabname}_controlnet_resize_mode_radio",
             elem_classes="controlnet_resize_mode_radio",
-            visible=not is_img2img
+            visible=not is_img2img,
         )
 
         self.loopback = gr.Checkbox(
@@ -400,10 +417,12 @@ class ControlNetUiGroup(object):
             value=self.default_unit.loopback,
             elem_id=f"{elem_id_tabname}_{tabname}_controlnet_automatically_send_generated_images_checkbox",
             elem_classes="controlnet_loopback_checkbox",
-            visible=not is_img2img
+            visible=not is_img2img,
         )
 
-        self.preset_panel = ControlNetPresetUI(id_prefix=f"{elem_id_tabname}_{tabname}_")
+        self.preset_panel = ControlNetPresetUI(
+            id_prefix=f"{elem_id_tabname}_{tabname}_"
+        )
 
     def register_send_dimensions(self, is_img2img: bool):
         """Register event handler for send dimension button."""
@@ -473,19 +492,12 @@ class ControlNetUiGroup(object):
         if not self.gradio_compat:
             return
 
-        def build_sliders(module, pp):
-            default_res_slider_config = dict(
-                label=flag_preprocessor_resolution,
-                value=512,
-                minimum=64,
-                maximum=2048,
-                step=1,
-            )
+        def build_sliders(module: str, pp: bool, prevent_next_n_update: int):
             # Clear old slider values so that they do not cause confusion in
             # infotext.
             clear_slider_update = gr.update(
                 visible=False,
-                interactive=False,
+                interactive=True,
                 minimum=-1,
                 maximum=-1,
                 value=-1,
@@ -494,11 +506,20 @@ class ControlNetUiGroup(object):
             grs = []
             module = global_state.get_module_basename(module)
             if module not in preprocessor_sliders_config:
+                default_res_slider_config = dict(
+                    label=flag_preprocessor_resolution,
+                    minimum=64,
+                    maximum=2048,
+                    step=1,
+                )
+                if self.prevent_next_n_slider_value_update == 0:
+                    default_res_slider_config["value"] = 512
+
                 grs += [
                     gr.update(
                         **default_res_slider_config,
                         visible=not pp,
-                        interactive=not pp,
+                        interactive=True,
                     ),
                     copy(clear_slider_update),
                     copy(clear_slider_update),
@@ -510,19 +531,21 @@ class ControlNetUiGroup(object):
                         visible = True
                         if slider_config["name"] == flag_preprocessor_resolution:
                             visible = not pp
-                        grs.append(
-                            gr.update(
-                                label=slider_config["name"],
-                                value=slider_config["value"],
-                                minimum=slider_config["min"],
-                                maximum=slider_config["max"],
-                                step=slider_config["step"]
-                                if "step" in slider_config
-                                else 1,
-                                visible=visible,
-                                interactive=visible,
-                            )
+                        slider_update = gr.update(
+                            label=slider_config["name"],
+                            minimum=slider_config["min"],
+                            maximum=slider_config["max"],
+                            step=slider_config["step"]
+                            if "step" in slider_config
+                            else 1,
+                            visible=visible,
+                            interactive=True,
                         )
+                        if self.prevent_next_n_slider_value_update == 0:
+                            slider_update["value"] = slider_config["value"]
+
+                        grs.append(slider_update)
+
                     else:
                         grs.append(copy(clear_slider_update))
                 while len(grs) < 3:
@@ -535,9 +558,18 @@ class ControlNetUiGroup(object):
                 ]
             else:
                 grs += [gr.update(visible=True), gr.update(visible=True)]
+
+            self.prevent_next_n_slider_value_update = max(
+                0, self.prevent_next_n_slider_value_update - 1
+            )
+
+            print(self.prevent_next_n_slider_value_update)
             return grs
 
-        inputs = [self.module, self.pixel_perfect]
+        inputs = [
+            self.module,
+            self.pixel_perfect,
+        ]
         outputs = [
             self.processor_res,
             self.threshold_a,
@@ -551,26 +583,30 @@ class ControlNetUiGroup(object):
 
         if self.type_filter is not None:
 
-            def filter_selected(k, pp):
+            def filter_selected(k: str):
+                if self.prevent_next_n_module_update > 0:
+                    self.prevent_next_n_module_update -= 1
+                    return gr.skip(), gr.skip()
+
                 (
                     filtered_preprocessor_list,
                     filtered_model_list,
                     default_option,
                     default_model,
                 ) = global_state.select_control_type(k)
-                return [
+                return (
                     gr.Dropdown.update(
                         value=default_option, choices=filtered_preprocessor_list
                     ),
                     gr.Dropdown.update(
                         value=default_model, choices=filtered_model_list
                     ),
-                ] + build_sliders(default_option, pp)
+                )
 
             self.type_filter.change(
                 filter_selected,
-                inputs=[self.type_filter, self.pixel_perfect],
-                outputs=[self.module, self.model, *outputs],
+                inputs=[self.type_filter],
+                outputs=[self.module, self.model],
             )
 
     def register_run_annotator(self, is_img2img: bool):
@@ -582,7 +618,7 @@ class ControlNetUiGroup(object):
                     *self.openpose_editor.update(""),
                 )
 
-            img = HWC3(image["image"])            
+            img = HWC3(image["image"])
             has_mask = not (
                 (image["mask"][:, :, 0] <= 5).all()
                 or (image["mask"][:, :, 0] >= 250).all()
@@ -591,7 +627,9 @@ class ControlNetUiGroup(object):
                 color = HWC3(image["image"])
                 alpha = image["mask"][:, :, 0:1]
                 img = np.concatenate([color, alpha], axis=2)
-            elif has_mask and not shared.opts.data.get("controlnet_ignore_noninpaint_mask", False):
+            elif has_mask and not shared.opts.data.get(
+                "controlnet_ignore_noninpaint_mask", False
+            ):
                 img = HWC3(image["mask"][:, :, 0])
 
             module = global_state.get_module_basename(module)
@@ -644,7 +682,7 @@ class ControlNetUiGroup(object):
                 result = external_code.visualize_inpaint_mask(result)
                 return (
                     # Update to `generated_image`
-                    gr.update(value=result, visible=True, interactive=False),
+                    gr.update(value=result, visible=True, interactive=True),
                     # preprocessor_preview
                     gr.update(value=True),
                     # openpose editor
@@ -742,10 +780,19 @@ class ControlNetUiGroup(object):
                 gr.update(value=False, visible=x),
             ] + [gr.update(visible=x)] * 4
 
-        self.upload_independent_img_in_img2img.change(fn_same_checked, inputs=self.upload_independent_img_in_img2img, outputs=[
-            self.image, self.batch_image_dir, self.preprocessor_preview,
-            self.image_upload_panel, self.trigger_preprocessor, self.loopback, self.resize_mode
-        ])
+        self.upload_independent_img_in_img2img.change(
+            fn_same_checked,
+            inputs=self.upload_independent_img_in_img2img,
+            outputs=[
+                self.image,
+                self.batch_image_dir,
+                self.preprocessor_preview,
+                self.image_upload_panel,
+                self.trigger_preprocessor,
+                self.loopback,
+                self.resize_mode,
+            ],
+        )
         return
 
     def register_callbacks(self, is_img2img: bool):
@@ -768,9 +815,15 @@ class ControlNetUiGroup(object):
         self.openpose_editor.register_callbacks(
             self.generated_image, self.use_preview_as_input
         )
-        self.preset_panel.register_callbacks(self.type_filter, *[
-            getattr(self, key) for key in vars(external_code.ControlNetUnit()).keys()
-        ])
+        self.preset_panel.register_callbacks(
+            self.prevent_next_n_module_update,
+            self.prevent_next_n_slider_value_update,
+            self.type_filter,
+            *[
+                getattr(self, key)
+                for key in vars(external_code.ControlNetUnit()).keys()
+            ],
+        )
         if is_img2img:
             self.register_img2img_same_input()
 
@@ -842,7 +895,7 @@ class ControlNetUiGroup(object):
 
         def clear_preview(x):
             if x:
-                logger.info('Preview as input is cancelled.')
+                logger.info("Preview as input is cancelled.")
             return gr.update(value=False), gr.update(value=None)
 
         for comp in (
@@ -852,7 +905,7 @@ class ControlNetUiGroup(object):
             self.processor_res,
             self.threshold_a,
             self.threshold_b,
-            self.upload_independent_img_in_img2img
+            self.upload_independent_img_in_img2img,
         ):
             event_subscribers = []
             if hasattr(comp, "edit"):
@@ -867,8 +920,9 @@ class ControlNetUiGroup(object):
                 event_subscribers.append(comp.clear)
             for event_subscriber in event_subscribers:
                 event_subscriber(
-                    fn=clear_preview, inputs=self.use_preview_as_input, outputs=[self.use_preview_as_input,
-                                                                                 self.generated_image]
+                    fn=clear_preview,
+                    inputs=self.use_preview_as_input,
+                    outputs=[self.use_preview_as_input, self.generated_image],
                 )
 
         # keep input_mode in sync

--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -53,17 +53,6 @@ class ControlNetPresetUI(object):
     presets = load_presets(preset_directory)
 
     def __init__(self, id_prefix: str):
-        self.dropdown = None
-        self.save_button = None
-        self.delete_button = None
-        self.refresh_button = None
-        self.reset_button = None
-        self.preset_name = None
-        self.confirm_preset_name = None
-        self.name_dialog = None
-        self.render(id_prefix)
-
-    def render(self, id_prefix: str):
         with gr.Row():
             self.dropdown = gr.Dropdown(
                 label="Presets",

--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -122,58 +122,40 @@ class ControlNetPresetUI(object):
         # 5th update will be updating slider values
         # TODO(huchenlei): This is exetremely hacky, need to find a better way
         # to achieve the functionality.
-        self.dropdown.change(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        ).then(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        ).then(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        ).then(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        ).then(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        )
-        self.reset_button.click(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        ).then(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        ).then(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        ).then(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        ).then(
-            fn=ControlNetPresetUI.apply_preset,
-            inputs=[self.dropdown],
-            outputs=[self.delete_button, control_type, *ui_states],
-            show_progress=False,
-        )
+        for element, action in (
+            (self.dropdown, "change"),
+            (self.reset_button, "click"),
+        ):
+            getattr(element, action)(
+                fn=ControlNetPresetUI.apply_preset,
+                inputs=[self.dropdown],
+                outputs=[self.delete_button, control_type, *ui_states],
+                show_progress="hidden",
+            ).then(
+                fn=ControlNetPresetUI.apply_preset,
+                inputs=[self.dropdown],
+                outputs=[self.delete_button, control_type, *ui_states],
+                show_progress="hidden",
+            ).then(
+                fn=ControlNetPresetUI.apply_preset,
+                inputs=[self.dropdown],
+                outputs=[self.delete_button, control_type, *ui_states],
+                show_progress="hidden",
+            ).then(
+                fn=ControlNetPresetUI.apply_preset,
+                inputs=[self.dropdown],
+                outputs=[self.delete_button, control_type, *ui_states],
+                show_progress="hidden",
+            ).then(
+                fn=ControlNetPresetUI.apply_preset,
+                inputs=[self.dropdown],
+                outputs=[self.delete_button, control_type, *ui_states],
+                show_progress="hidden",
+            ).then(
+                fn=lambda: gr.update(visible=False),
+                inputs=None,
+                outputs=[self.reset_button],
+            )
 
         def save_preset(name: str, *ui_states):
             if name == NEW_PRESET:
@@ -192,7 +174,7 @@ class ControlNetPresetUI(object):
             fn=save_preset,
             inputs=[self.dropdown, *ui_states],
             outputs=[self.name_dialog, self.dropdown, self.reset_button],
-            show_progress=False,
+            show_progress="hidden",
         ).then(
             fn=None,
             _js=f"""
@@ -214,7 +196,7 @@ class ControlNetPresetUI(object):
             fn=delete_preset,
             inputs=[self.dropdown],
             outputs=[self.dropdown, self.reset_button],
-            show_progress=False,
+            show_progress="hidden",
         )
 
         self.name_dialog.visible = False
@@ -235,14 +217,14 @@ class ControlNetPresetUI(object):
             fn=save_new_preset,
             inputs=[self.preset_name, *ui_states],
             outputs=[self.name_dialog, self.dropdown],
-            show_progress=False,
+            show_progress="hidden",
         ).then(fn=None, _js="closePopup")
 
         self.refresh_button.click(
             fn=ControlNetPresetUI.refresh_preset,
             inputs=None,
             outputs=[self.dropdown],
-            show_progress=False,
+            show_progress="hidden",
         )
 
         def update_reset_button(preset_name: str, *ui_states):
@@ -254,9 +236,9 @@ class ControlNetPresetUI(object):
             current_unit = external_code.ControlNetUnit(*ui_states)
             preset_unit.image = None
             current_unit.image = None
-            
+
             # Do not compare module param that are not used in preset.
-            for module_param in ('processor_res', 'threshold_a', 'threshold_b'):
+            for module_param in ("processor_res", "threshold_a", "threshold_b"):
                 if getattr(preset_unit, module_param) == -1:
                     setattr(current_unit, module_param, -1)
 

--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -153,6 +153,26 @@ class ControlNetPresetUI(object):
             inputs=[self.dropdown],
             outputs=[self.delete_button, control_type, *ui_states],
             show_progress=False,
+        ).then(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
+        ).then(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
+        ).then(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
+        ).then(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
         )
 
         def save_preset(name: str, *ui_states):
@@ -234,6 +254,12 @@ class ControlNetPresetUI(object):
             current_unit = external_code.ControlNetUnit(*ui_states)
             preset_unit.image = None
             current_unit.image = None
+            
+            # Do not compare module param that are not used in preset.
+            for module_param in ('processor_res', 'threshold_a', 'threshold_b'):
+                if getattr(preset_unit, module_param) == -1:
+                    setattr(current_unit, module_param, -1)
+
             return gr.update(visible=vars(current_unit) != vars(preset_unit))
 
         for ui_state in ui_states:

--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -13,6 +13,7 @@ from scripts import external_code
 save_symbol = "\U0001f4be"  # 💾
 delete_symbol = "\U0001f5d1\ufe0f"  # 🗑️
 refresh_symbol = "\U0001f504"  # 🔄
+reset_symbol = "\U000021A9"  # ↩
 
 NEW_PRESET = "New Preset"
 
@@ -56,6 +57,7 @@ class ControlNetPresetUI(object):
         self.save_button = None
         self.delete_button = None
         self.refresh_button = None
+        self.reset_button = None
         self.preset_name = None
         self.confirm_preset_name = None
         self.name_dialog = None
@@ -69,6 +71,12 @@ class ControlNetPresetUI(object):
                 elem_classes=["cnet-preset-dropdown"],
                 choices=ControlNetPresetUI.dropdown_choices(),
                 value=NEW_PRESET,
+            )
+            self.reset_button = ToolButton(
+                value=reset_symbol,
+                elem_classes=["cnet-preset-reset"],
+                tooltip="Reset preset",
+                visible=False,
             )
             self.save_button = ToolButton(
                 value=save_symbol,
@@ -140,22 +148,30 @@ class ControlNetPresetUI(object):
             outputs=[self.delete_button, control_type, *ui_states],
             show_progress=False,
         )
+        self.reset_button.click(
+            fn=ControlNetPresetUI.apply_preset,
+            inputs=[self.dropdown],
+            outputs=[self.delete_button, control_type, *ui_states],
+            show_progress=False,
+        )
 
         def save_preset(name: str, *ui_states):
             if name == NEW_PRESET:
-                return gr.update(visible=True), gr.update()
+                return gr.update(visible=True), gr.update(), gr.update()
 
             ControlNetPresetUI.save_preset(
                 name, external_code.ControlNetUnit(*ui_states)
             )
-            return gr.update(), gr.update(
-                choices=ControlNetPresetUI.dropdown_choices(), value=name
+            return (
+                gr.update(),  # name dialog
+                gr.update(choices=ControlNetPresetUI.dropdown_choices(), value=name),
+                gr.update(visible=False),  # Reset button
             )
 
         self.save_button.click(
             fn=save_preset,
             inputs=[self.dropdown, *ui_states],
-            outputs=[self.name_dialog, self.dropdown],
+            outputs=[self.name_dialog, self.dropdown, self.reset_button],
             show_progress=False,
         ).then(
             fn=None,
@@ -172,12 +188,12 @@ class ControlNetPresetUI(object):
             return gr.Dropdown.update(
                 choices=ControlNetPresetUI.dropdown_choices(),
                 value=NEW_PRESET,
-            )
+            ), gr.update(visible=False)
 
         self.delete_button.click(
             fn=delete_preset,
             inputs=[self.dropdown],
-            outputs=[self.dropdown],
+            outputs=[self.dropdown, self.reset_button],
             show_progress=False,
         )
 
@@ -208,6 +224,29 @@ class ControlNetPresetUI(object):
             outputs=[self.dropdown],
             show_progress=False,
         )
+
+        def update_reset_button(preset_name: str, *ui_states):
+            if preset_name == NEW_PRESET:
+                return gr.update(visible=False)
+
+            infotext = ControlNetPresetUI.presets[preset_name]
+            preset_unit = parse_unit(infotext)
+            current_unit = external_code.ControlNetUnit(*ui_states)
+            preset_unit.image = None
+            current_unit.image = None
+            return gr.update(visible=vars(current_unit) != vars(preset_unit))
+
+        for ui_state in ui_states:
+            for action in ("edit", "click", "change", "clear", "release"):
+                if action == "release" and not isinstance(ui_state, gr.Slider):
+                    continue
+
+                if hasattr(ui_state, action):
+                    getattr(ui_state, action)(
+                        fn=update_reset_button,
+                        inputs=[self.dropdown, *ui_states],
+                        outputs=[self.reset_button],
+                    )
 
     @staticmethod
     def dropdown_choices() -> List[str]:

--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -234,6 +234,9 @@ class ControlNetPresetUI(object):
             return gr.update(visible=vars(current_unit) != vars(preset_unit))
 
         for ui_state in ui_states:
+            if isinstance(ui_state, gr.Image):
+                continue
+            
             for action in ("edit", "click", "change", "clear", "release"):
                 if action == "release" and not isinstance(ui_state, gr.Slider):
                     continue


### PR DESCRIPTION
Some changes made in this PR:
- Re-format ui group file
- Make sliders always interactive as value cannot be populated if the slider is not interactive
- Improve load speed by introducing server side counters to prevent value update when their values > 0 (This can lead to a solution to the paste PNG info of slider values)

This PR adds a `reset` button that allows users to restore to the original state of currently selected preset. Previously, user had to select `New Preset` and then select original preset again to overwrite the changes they made on the UI.