### PR TITLE
Option to only apply ControlNet to specific txt2img passes

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1038,10 +1038,10 @@ def on_ui_settings():
         3, "Multi ControlNet: Max models amount (requires restart)", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}, section=section))
     shared.opts.add_option("control_net_model_cache_size", shared.OptionInfo(
         1, "Model cache size (requires restart)", gr.Slider, {"minimum": 1, "maximum": 5, "step": 1}, section=section))
+    shared.opts.add_option("control_net_txt2img_pass", shared.OptionInfo(
+        "Both", "ControlNet txt2img passes to apply", gr.Dropdown, {"choices": ["Both", "Pre-hires", "Hires"]}, section=section))
     shared.opts.add_option("control_net_inpaint_blur_sigma", shared.OptionInfo(
         7, "ControlNet inpainting Gaussian blur sigma", gr.Slider, {"minimum": 0, "maximum": 64, "step": 1}, section=section))
-    shared.opts.add_option("control_net_no_high_res_fix", shared.OptionInfo(
-        False, "Do not apply ControlNet during highres fix", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_no_detectmap", shared.OptionInfo(
         False, "Do not append detectmap to output", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_detectmap_autosaving", shared.OptionInfo(
@@ -1061,6 +1061,11 @@ def on_ui_settings():
     shared.opts.add_option("controlnet_ignore_noninpaint_mask", shared.OptionInfo(
         False, "Ignore mask on ControlNet input image if control type is not inpaint", 
         gr.Checkbox, {"interactive": True}, section=section))
+    
+    # Settings migration
+    no_high_res_fix = shared.opts.data.get("control_net_no_high_res_fix", None)
+    if shared.opts.data.get("control_net_txt2img_pass", None) is None and no_high_res_fix is not None:
+        shared.opts.data["control_net_txt2img_pass"] = "Pre-hires" if no_high_res_fix else "Both"
 
 
 batch_hijack.instance.do_hijack()


### PR DESCRIPTION
Follow-up to https://github.com/Mikubill/sd-webui-controlnet/pull/1832

The intent of this PR is to make the application of ControlNet in txt2img fully customizable. This consists of options to apply ControlNet to 1) both pre-hires fix and during hires fix (default), 2) only to pre-hires fix (already implemented as part of aforementioned PR), or **3) only during hires fix**. The benefit here, for the newly available option 3, is it would allow for using a higher denoise strength in hires fix when paired with certain ControlNet models (i.e. canny, lineart, tile, etc), meaning no extra step is needed to take the result into img2img.

I'd like to pass the pre-hires fix image into ControlNet automatically when 1) this option is set to "Hires", 2) hires fix is enabled, and 3) when the input image is empty, so I'm setting this as a draft for now. If I can't get that done relatively easily though I'll just submit this as-is.