### PR TITLE
Make dw_pose default openpose preprocessor

### DIFF
--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -907,7 +907,7 @@ preprocessor_filters = {
     "Canny": "canny",
     "Depth": "depth_midas",
     "Normal": "normal_bae",
-    "OpenPose": "openpose_full",
+    "OpenPose": "dw_openpose_full",
     "MLSD": "mlsd",
     "Lineart": "lineart_standard (from white bg & black line)",
     "SoftEdge": "softedge_pidinet",


### PR DESCRIPTION
As dw pose has better detection in most situations. This PR proposes makeing `dw_openpose_full` the default openpose control type preprocessor.