### PR TITLE
Fix for IP-Adapter preprocessor download

### DIFF
--- a/annotator/clipvision/__init__.py
+++ b/annotator/clipvision/__init__.py
@@ -2,7 +2,7 @@ import os
 import torch
 
 from modules import devices
-from modules.modelloader import load_file_from_url
+from basicsr.utils.download_util import load_file_from_url
 from annotator.annotator_path import models_path
 from transformers import CLIPVisionModelWithProjection, CLIPVisionConfig, CLIPImageProcessor
 


### PR DESCRIPTION
Previously failed with this error:
ImportError: cannot import name 'load_file_from_url' from 'modules.modelloader'