### PR TITLE
Fix missing typing for `List`

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 from fastapi import FastAPI, Body
 from fastapi.exceptions import HTTPException


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2088

Title. Fixes an error like below that would come up.

```shell
*** Error executing callback app_started_callback for Q:\AI\git\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\api.py
    Traceback (most recent call last):
      File "Q:\AI\git\stable-diffusion-webui\modules\script_callbacks.py", line 139, in app_started_callback
        c.callback(demo, app)
      File "Q:\AI\git\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\api.py", line 89, in controlnet_api
        controlnet_input_images: List[str] = Body([], title="Controlnet Input Images"),
    NameError: name 'List' is not defined
```