### PR TITLE
Fix debug loglevel

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -973,7 +973,7 @@ class Script(scripts.Script, metaclass=(
         return getattr(p, 'refiner_checkpoint', None) is not None
 
     def process(self, p, *args, **kwargs):
-        if not self.process_has_sdxl_refiner(p):
+        if not Script.process_has_sdxl_refiner(p):
             self.controlnet_hack(p)
         return
 
@@ -983,7 +983,7 @@ class Script(scripts.Script, metaclass=(
                                    noise_modifier=self.noise_modifier,
                                    sd_model=p.sd_model)
         self.noise_modifier = None
-        if self.process_has_sdxl_refiner(p):
+        if Script.process_has_sdxl_refiner(p):
             self.controlnet_hack(p)
         return
 


### PR DESCRIPTION
`process_has_sdxl_refiner` is a static method on `Script`. Calling it with `self.` prefix will cause issue when the method is decorated by

```python
def timer_decorator(func):
    """Time the decorated function and output the result to debug logger."""
    if logger.level != logging.DEBUG:
        return func

    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        start_time = time.time()
        result = func(*args, **kwargs)
        end_time = time.time()
        duration = end_time - start_time
        # Only report function that are significant enough.
        if duration > 1e-3:
            logger.debug(f"{func.__name__} ran in: {duration} sec")
        return result

    return wrapper
```

in debug loglevel, as `self.process_has_sdxl_refiner(p)` will be interpreted as `process_has_sdxl_refiner(self, p)`, but the function only accepts single param.

This PR fixes the issue by replacing `self.` with `Script.` in all callsites.