### PR TITLE
Don't show progress for UI actions

### DIFF
--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -455,6 +455,7 @@ class ControlNetUiGroup(object):
             fn=send_dimensions,
             inputs=[self.image],
             outputs=outputs,
+            show_progress=False
         )
 
     def register_webcam_toggle(self):
@@ -466,14 +467,14 @@ class ControlNetUiGroup(object):
                 "__type__": "update",
             }
 
-        self.webcam_enable.click(webcam_toggle, inputs=None, outputs=self.image)
+        self.webcam_enable.click(webcam_toggle, inputs=None, outputs=self.image, show_progress=False)
 
     def register_webcam_mirror_toggle(self):
         def webcam_mirror_toggle():
             self.webcam_mirrored = not self.webcam_mirrored
             return {"mirror_webcam": self.webcam_mirrored, "__type__": "update"}
 
-        self.webcam_mirror.click(webcam_mirror_toggle, inputs=None, outputs=self.image)
+        self.webcam_mirror.click(webcam_mirror_toggle, inputs=None, outputs=self.image, show_progress=False)
 
     def register_refresh_all_models(self):
         def refresh_all_models(*inputs):
@@ -485,7 +486,7 @@ class ControlNetUiGroup(object):
                 value=selected, choices=list(global_state.cn_models.keys())
             )
 
-        self.refresh_models.click(refresh_all_models, self.model, self.model)
+        self.refresh_models.click(refresh_all_models, self.model, self.model, show_progress=False)
 
     def register_build_sliders(self):
         if not self.gradio_compat:
@@ -584,8 +585,8 @@ class ControlNetUiGroup(object):
             self.refresh_models,
             self.control_mode
         ]
-        self.module.change(build_sliders, inputs=inputs, outputs=outputs)
-        self.pixel_perfect.change(build_sliders, inputs=inputs, outputs=outputs)
+        self.module.change(build_sliders, inputs=inputs, outputs=outputs, show_progress=False)
+        self.pixel_perfect.change(build_sliders, inputs=inputs, outputs=outputs, show_progress=False)
 
         if self.type_filter is not None:
 
@@ -619,6 +620,7 @@ class ControlNetUiGroup(object):
                 filter_selected,
                 inputs=[self.type_filter],
                 outputs=[self.module, self.model],
+                show_progress=False
             )
 
     def register_run_annotator(self, is_img2img: bool):
@@ -749,6 +751,7 @@ class ControlNetUiGroup(object):
                 self.openpose_editor.download_link,
                 self.openpose_editor.modal,
             ],
+            show_progress=False
         )
 
     def register_create_canvas(self):
@@ -756,11 +759,13 @@ class ControlNetUiGroup(object):
             lambda: gr.Accordion.update(visible=True),
             inputs=None,
             outputs=self.create_canvas,
+            show_progress=False
         )
         self.canvas_cancel_button.click(
             lambda: gr.Accordion.update(visible=False),
             inputs=None,
             outputs=self.create_canvas,
+            show_progress=False
         )
 
         def fn_canvas(h, w):
@@ -772,6 +777,7 @@ class ControlNetUiGroup(object):
             fn=fn_canvas,
             inputs=[self.canvas_height, self.canvas_width],
             outputs=[self.image, self.create_canvas],
+            show_progress=False
         )
 
     def register_img2img_same_input(self):
@@ -794,6 +800,7 @@ class ControlNetUiGroup(object):
                 self.loopback,
                 self.resize_mode,
             ],
+            show_progress=False
         )
         return
 


### PR DESCRIPTION
Things like changing Control Type/Preprocessor and showing/hiding controls (preview, new canvas, camera, sliders) are snappier without all those loading animations.