### PR TITLE
Set scripts.hook - control_params as empty list at default / Fix TypeError

### DIFF
--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -843,7 +843,7 @@ class UnetHook(nn.Module):
             return h
 
         def move_all_control_model_to_cpu():
-            for param in getattr(outer, 'control_params', []):
+            for param in getattr(outer, 'control_params', []) or []:
                 if isinstance(param.control_model, torch.nn.Module):
                     param.control_model.to("cpu")
 


### PR DESCRIPTION
Using IP_Adapter_sd15, It can somehow fail to attach control params before hook.

I found that somehow it is restoring control_params to None, which is causing some weird error when we try to generate image with no prompt after using controlnet:

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/35677394/958528c6-2e35-4b6a-a007-21d8b15447e3)

And the full stack trace goes:
```
    Traceback (most recent call last):
      File "C:\debug-webui\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\hook.py", line 855, in forward_webui
        return forward(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\hook.py", line 491, in forward
        for param in outer.control_params:
    TypeError: 'NoneType' object is not iterable

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "C:\debug-webui\stable-diffusion-webui\modules\call_queue.py", line 57, in f
        res = list(func(*args, **kwargs))
      File "C:\debug-webui\stable-diffusion-webui\modules\call_queue.py", line 36, in f
        res = func(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\modules\txt2img.py", line 55, in txt2img
        processed = processing.process_images(p)
      File "C:\debug-webui\stable-diffusion-webui\modules\processing.py", line 732, in process_images
        res = process_images_inner(p)
      File "C:\debug-webui\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\batch_hijack.py", line 42, in processing_process_images_hijack
        return getattr(processing, '__controlnet_original_process_images_inner')(p, *args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\modules\processing.py", line 867, in process_images_inner
        samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
      File "C:\debug-webui\stable-diffusion-webui\modules\processing.py", line 1140, in sample
        samples = self.sampler.sample(self, x, conditioning, unconditional_conditioning, image_conditioning=self.txt2img_image_conditioning(x))
      File "C:\debug-webui\stable-diffusion-webui\modules\sd_samplers_kdiffusion.py", line 235, in sample
        samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
      File "C:\debug-webui\stable-diffusion-webui\modules\sd_samplers_common.py", line 261, in launch_sampling
        return func()
      File "C:\debug-webui\stable-diffusion-webui\modules\sd_samplers_kdiffusion.py", line 235, in <lambda>
        samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
      File "C:\debug-webui\stable-diffusion-webui\venv\lib\site-packages\torch\utils\_contextlib.py", line 115, in decorate_context
        return func(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\repositories\k-diffusion\k_diffusion\sampling.py", line 594, in sample_dpmpp_2m
        denoised = model(x, sigmas[i] * s_in, **extra_args)
      File "C:\debug-webui\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
        return forward_call(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\modules\sd_samplers_cfg_denoiser.py", line 175, in forward
        x_out[a:b] = self.inner_model(x_in[a:b], sigma_in[a:b], cond=make_condition_dict(subscript_cond(cond_in, a, b), image_cond_in[a:b]))
      File "C:\debug-webui\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
        return forward_call(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\repositories\k-diffusion\k_diffusion\external.py", line 112, in forward
        eps = self.get_eps(input * c_in, self.sigma_to_t(sigma), **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\repositories\k-diffusion\k_diffusion\external.py", line 138, in get_eps
        return self.inner_model.apply_model(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\modules\sd_hijack_utils.py", line 17, in <lambda>
        setattr(resolved_obj, func_path[-1], lambda *args, **kwargs: self(*args, **kwargs))
      File "C:\debug-webui\stable-diffusion-webui\modules\sd_hijack_utils.py", line 28, in __call__
        return self.__orig_func(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\repositories\stable-diffusion-stability-ai\ldm\models\diffusion\ddpm.py", line 858, in apply_model
        x_recon = self.model(x_noisy, t, **cond)
      File "C:\debug-webui\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
        return forward_call(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\repositories\stable-diffusion-stability-ai\ldm\models\diffusion\ddpm.py", line 1335, in forward
        out = self.diffusion_model(x, t, context=cc)
      File "C:\debug-webui\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
        return forward_call(*args, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\extensions\sd_webui_masactrl\scripts\masactrl_controller.py", line 659, in forward
        return self.org_forward(x, timesteps=timesteps, context=context, y=y, **kwargs)
      File "C:\debug-webui\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\hook.py", line 857, in forward_webui
        move_all_control_model_to_cpu()
      File "C:\debug-webui\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\hook.py", line 846, in move_all_control_model_to_cpu
        for param in getattr(outer, 'control_params', []):
    TypeError: 'NoneType' object is not iterable

---
```



After fix, ControlNet works.

```
Total progress: 100%|██████████████████████████████████████████████████████████████████| 20/20 [00:02<00:00,  7.63it/s]
2023-11-02 19:04:02,277 - ControlNet - INFO - Loading model from cache: ip-adapter_sd15 [6a3f6166]:02<00:00,  9.22it/s]
2023-11-02 19:04:02,287 - ControlNet - INFO - Loading preprocessor: ip-adapter_clip_sd15
2023-11-02 19:04:02,287 - ControlNet - INFO - preprocessor resolution = 512
2023-11-02 19:04:07,478 - ControlNet - INFO - ControlNet Hooked - Time = 5.275851249694824
rp_selected_tab : None, self.mode : Matrix
Mode : Matrix, polymask : None
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:03<00:00,  5.96it/s]
ControlNet: Restoring...███████████████████████████████████████████████████████████████| 20/20 [00:03<00:00,  5.45it/s]
Total progress: 100%|██████████████████████████████████████████████████████████████████| 20/20 [00:03<00:00,  5.54it/s]
2023-11-02 19:04:11,818 - ControlNet - INFO - Loading model from cache: ip-adapter_sd15 [6a3f6166]:03<00:00,  5.45it/s]
2023-11-02 19:04:11,827 - ControlNet - INFO - Loading preprocessor: ip-adapter_clip_sd15
2023-11-02 19:04:11,827 - ControlNet - INFO - preprocessor resolution = 512
2023-11-02 19:04:17,093 - ControlNet - INFO - ControlNet Hooked - Time = 5.3572001457214355
rp_selected_tab : None, self.mode : Matrix
Mode : Matrix, polymask : None
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:03<00:00,  5.55it/s]
ControlNet: Restoring...███████████████████████████████████████████████████████████████| 20/20 [00:03<00:00,  5.27it/s]
Total progress: 100%|██████████████████████████████████████████████████████████████████| 20/20 [00:03<00:00,  5.42it/s]
Total progress: 100%|██████████████████████████████████████████████████████████████████| 20/20 [00:03<00:00,  5.27it/s] 
```