### PR TITLE
:loud_sound: Reduce debug log duration precision

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -92,7 +92,7 @@ def timer_decorator(func):
         duration = end_time - start_time
         # Only report function that are significant enough.
         if duration > 1e-3:
-            logger.debug(f"{func.__name__} ran in: {duration} sec")
+            logger.debug(f"{func.__name__} ran in: {duration:.3f} sec")
         return result
 
     return wrapper


### PR DESCRIPTION
This PR reduces duration measurement in `Script` functions to 3 decimal points.

Sample logs after change:
```
2023-11-04 17:00:32,572 - ControlNet - DEBUG - Create LRU cache (max_size=16) for preprocessor results.
2023-11-04 17:00:32,573 - ControlNet - DEBUG - __init__ ran in: 0.001 sec
2023-11-04 17:00:32,700 - ControlNet - DEBUG - uigroup ran in: 0.031 sec
2023-11-04 17:00:32,731 - ControlNet - DEBUG - uigroup ran in: 0.030 sec
2023-11-04 17:00:32,766 - ControlNet - DEBUG - uigroup ran in: 0.034 sec
2023-11-04 17:00:32,767 - ControlNet - DEBUG - ui ran in: 0.098 sec
```