### PR TITLE
:bug: Init webui only once in tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,18 @@ import requests
 BASE_URL = "http://localhost:7860"
 
 
+webui_initialized = False
+def _initialize_webui():
+    global webui_initialized
+    if webui_initialized:
+        return
+
+    from modules import initialize
+    initialize.imports()
+    initialize.initialize()
+    webui_initialized = True
+
+
 def setup_test_env():
     os.environ['IGNORE_CMD_ARGS_ERRORS'] = 'True'
 
@@ -20,10 +32,7 @@ def setup_test_env():
         if p not in sys.path:
             sys.path.append(str(p))
 
-    # Initialize shared opts.
-    from modules import initialize
-    initialize.imports()
-    initialize.initialize()
+    _initialize_webui()
 
 
 def readImage(path):


### PR DESCRIPTION
In most recent version of A1111. `module.initialize.initialize` is only expected to be called once. Calling it multiple times gives following error:

```
ERROR extensions/sd-webui-controlnet/tests/annotator_tests/openpose_tests/detection_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/annotator_tests/openpose_tests/json_encode_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/annotator_tests/openpose_tests/openpose_e2e_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/cn_script/batch_hijack_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/cn_script/cn_script_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/cn_script/utils_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/external_code_api/external_code_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/external_code_api/importlib_reload_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/external_code_api/script_args_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/web_api/control_types_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/web_api/detect_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/web_api/img2img_test.py - RuntimeError: patch for register_schedule is already applied
ERROR extensions/sd-webui-controlnet/tests/web_api/txt2img_test.py - RuntimeError: patch for register_schedule is already applied
```

This PR makes sure that we only call `initialize` once in CI tests.