### PR TITLE
:bug: Disable flaky tests

### DIFF
--- a/tests/annotator_tests/openpose_tests/openpose_e2e_test_disabled.py
+++ b/tests/annotator_tests/openpose_tests/openpose_e2e_test_disabled.py
@@ -1,3 +1,9 @@
+"""
+Disabled because unloading openpose detection models is flaky.
+See https://github.com/Mikubill/sd-webui-controlnet/actions/runs/6758718106/job/18370634881
+for CI report of an example flaky run.
+"""
+
 import unittest
 import cv2
 import numpy as np


### PR DESCRIPTION
This PR disables `openpose_e2e_test` as it is verified to be flaky on CI.