### PR TITLE
:wrench: Setup CI cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           key: preprocessor-models-v1
       - name: Download controlnet model for testing
         run: |
-          if [ ! -f "extensions/sd-webui-controlnet/models/control_v11p_sd15_canny.pth"]
+          if [ ! -f "extensions/sd-webui-controlnet/models/control_v11p_sd15_canny.pth"]; then
             curl -Lo extensions/sd-webui-controlnet/models/control_v11p_sd15_canny.pth https://huggingface.co/lllyasviel/ControlNet-v1-1/resolve/main/control_v11p_sd15_canny.pth
           fi
         working-directory: stable-diffusion-webui

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,21 @@ jobs:
           TORCH_INDEX_URL: https://download.pytorch.org/whl/cpu
           WEBUI_LAUNCH_LIVE_OUTPUT: "1"
           PYTHONUNBUFFERED: "1"
+      - name: Cache ControlNet models
+        uses: actions/cache@v3
+        with:
+          path: stable-diffusion-webui/extensions/sd-webui-controlnet/models/
+          key: controlnet-models-v1
+      - name: Cache Preprocessor models
+        uses: actions/cache@v3
+        with:
+          path: stable-diffusion-webui/extensions/sd-webui-controlnet/annotator/downloads/
+          key: preprocessor-models-v1
       - name: Download controlnet model for testing
         run: |
-          curl -Lo extensions/sd-webui-controlnet/models/control_canny-fp16.safetensors https://huggingface.co/webui/ControlNet-modules-safetensors/resolve/main/control_canny-fp16.safetensors
+          if [ ! -f "extensions/sd-webui-controlnet/models/control_v11p_sd15_canny.pth"]
+            curl -Lo extensions/sd-webui-controlnet/models/control_v11p_sd15_canny.pth https://huggingface.co/lllyasviel/ControlNet-v1-1/resolve/main/control_v11p_sd15_canny.pth
+          fi
         working-directory: stable-diffusion-webui
       - name: Start test server
         run: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           key: preprocessor-models-v1
       - name: Download controlnet model for testing
         run: |
-          if [ ! -f "extensions/sd-webui-controlnet/models/control_v11p_sd15_canny.pth"]; then
+          if [ ! -f "extensions/sd-webui-controlnet/models/control_v11p_sd15_canny.pth" ]; then
             curl -Lo extensions/sd-webui-controlnet/models/control_v11p_sd15_canny.pth https://huggingface.co/lllyasviel/ControlNet-v1-1/resolve/main/control_v11p_sd15_canny.pth
           fi
         working-directory: stable-diffusion-webui

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,7 +46,7 @@ def get_model(use_sd15: bool = True) -> str:
     r = requests.get(BASE_URL+"/controlnet/model_list")
     result = r.json()
     if "model_list" not in result:
-        return "None"
+        raise ValueError("No model available")
 
     def is_sd15(model_name: str) -> bool:
         return 'sd15' in model_name
@@ -57,7 +57,10 @@ def get_model(use_sd15: bool = True) -> str:
         if (use_sd15 and is_sd15(model)) or (not use_sd15 and not is_sd15(model))
     ]
 
-    return candidates[0] if candidates else "None"
+    if not candidates:
+        raise ValueError("No suitable model available")
+    
+    return candidates[0]
     
 
 def get_modules():


### PR DESCRIPTION
Closes #2230.

This PR also switches the model used for tests to an up-to-date sd1.5 model.