### PR TITLE
:sparkles: Add new API option send_detected_map

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from enum import Enum
 from copy import copy
 from typing import List, Any, Optional, Union, Tuple, Dict
@@ -142,43 +143,30 @@ InputImage = Union[np.ndarray, str]
 InputImage = Union[Dict[str, InputImage], Tuple[InputImage, InputImage], InputImage]
 
 
+@dataclass
 class ControlNetUnit:
     """
     Represents an entire ControlNet processing unit.
     """
-
-    def __init__(
-            self,
-            enabled: bool = True,
-            module: Optional[str] = None,
-            model: Optional[str] = None,
-            weight: float = 1.0,
-            image: Optional[InputImage] = None,
-            resize_mode: Union[ResizeMode, int, str] = ResizeMode.INNER_FIT,
-            low_vram: bool = False,
-            processor_res: int = -1,
-            threshold_a: float = -1,
-            threshold_b: float = -1,
-            guidance_start: float = 0.0,
-            guidance_end: float = 1.0,
-            pixel_perfect: bool = False,
-            control_mode: Union[ControlMode, int, str] = ControlMode.BALANCED,
-            **_kwargs,
-    ):
-        self.enabled = enabled
-        self.module = module
-        self.model = model
-        self.weight = weight
-        self.image = image
-        self.resize_mode = resize_mode
-        self.low_vram = low_vram
-        self.processor_res = processor_res
-        self.threshold_a = threshold_a
-        self.threshold_b = threshold_b
-        self.guidance_start = guidance_start
-        self.guidance_end = guidance_end
-        self.pixel_perfect = pixel_perfect
-        self.control_mode = control_mode
+    enabled: bool = True
+    module: Optional[str] = None
+    model: Optional[str] = None
+    weight: float = 1.0
+    image: Optional[InputImage] = None
+    resize_mode: Union[ResizeMode, int, str] = ResizeMode.INNER_FIT
+    low_vram: bool = False
+    processor_res: int = -1
+    threshold_a: float = -1
+    threshold_b: float = -1
+    guidance_start: float = 0.0
+    guidance_end: float = 1.0
+    pixel_perfect: bool = False
+    control_mode: Union[ControlMode, int, str] = ControlMode.BALANCED
+    
+    # Whether save the detected map of this unit. Setting this option to False prevents saving the
+    # detected map or sending detected map along with generated images via API.
+    # Currently the option is only accessible in API calls.
+    save_detected_map: bool = True
 
     def __eq__(self, other):
         if not isinstance(other, ControlNetUnit):

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -811,11 +811,15 @@ class Script(scripts.Script, metaclass=(
                 thr_a=unit.threshold_a,
                 thr_b=unit.threshold_b,
             )
-
+            
+            def store_detected_map(detected_map, module: str) -> None:
+                if unit.save_detected_map:
+                    detected_maps.append((detected_map, module))
+            
             if high_res_fix:
                 if is_image:
                     hr_control, hr_detected_map = Script.detectmap_proc(detected_map, unit.module, resize_mode, hr_y, hr_x)
-                    detected_maps.append((hr_detected_map, unit.module))
+                    store_detected_map(hr_detected_map, unit.module)
                 else:
                     hr_control = detected_map
             else:
@@ -823,10 +827,10 @@ class Script(scripts.Script, metaclass=(
 
             if is_image:
                 control, detected_map = Script.detectmap_proc(detected_map, unit.module, resize_mode, h, w)
-                detected_maps.append((detected_map, unit.module))
+                store_detected_map(detected_map, unit.module)
             else:
                 control = detected_map
-                detected_maps.append((input_image, unit.module))
+                store_detected_map(input_image, unit.module)
 
             if control_model_type == ControlModelType.T2I_StyleAdapter:
                 control = control['last_hidden_state']

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -150,6 +150,7 @@ class ControlNetUiGroup(object):
         self.preset_panel = None
         self.upload_independent_img_in_img2img = None
         self.image_upload_panel = None
+        self.save_detected_map = None
 
         # Internal states for UI state pasting.
         self.prevent_next_n_module_update = 0
@@ -168,6 +169,7 @@ class ControlNetUiGroup(object):
             None
         """
         with gr.Group(visible=not is_img2img) as self.image_upload_panel:
+            self.save_detected_map = gr.Checkbox(value=True, visible=False)
             with gr.Tabs():
                 with gr.Tab(label="Single Image") as self.upload_tab:
                     with gr.Row(elem_classes=["cnet-image-row"], equal_height=True):

--- a/tests/web_api/txt2img_test.py
+++ b/tests/web_api/txt2img_test.py
@@ -133,6 +133,22 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
                     }
                 ]
                 self.assert_status_ok(f'Run with {param} = -1.')
+                
+    def test_save_detected_map(self):
+        for save_map in (True, False):
+            with self.subTest(save_map=save_map):
+                self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"] = [
+                    {
+                        "input_image": utils.readImage("test/test_files/img2img_basic.png"),
+                        "model": utils.get_model(),
+                        "module": "depth",
+                        "save_detected_map": save_map,
+                    }
+                ]
+            
+                resp = requests.post(self.url_txt2img, json=self.simple_txt2img).json()
+                self.assertEqual(2 if save_map else 1, len(resp["images"]))
+                
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/1432.

This PR adds a new API option `send_detected_map`. This option allows users prevent the detected map image in the response image array to save web traffic.

Notes: 
- The option will be captured in the ControlNet infotext, but will not be adjustable in WebUI for now.
- The option is per ControlNet unit, so if you use multiple ControlNet units, you need to specify this option in every unit.
- Adding a global level args in the API is not possible as it would need change in A1111 repo.