### PR TITLE
:wrench: Support SDXL in tests

### DIFF
--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -1,0 +1,26 @@
+from enum import Enum
+
+
+class StableDiffusionVersion(Enum):
+    """The version family of stable diffusion model."""
+
+    UNKNOWN = 0
+    SD1x = 1
+    SD2x = 2
+    SDXL = 3
+
+    @staticmethod
+    def detect_from_model_name(model_name: str) -> "StableDiffusionVersion":
+        """Based on the model name provided, guess what stable diffusion version it is.
+        This might not be accurate without actually inspect the file content.
+        """
+        if "15" in model_name or "1.5" in model_name:
+            return StableDiffusionVersion.SD1x
+
+        if "21" in model_name or "2.1" in model_name:
+            return StableDiffusionVersion.SD2x
+
+        if "xl" in model_name.lower():
+            return StableDiffusionVersion.SDXL
+
+        return StableDiffusionVersion.UNKNOWN

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,12 @@ python -m coverage run
           --api-server-stop
 ```
 
+## Setting environment variables
+Setting `CONTROLNET_TEST_SD_VERSION` for stable diffusion model family used during testing.
+- 1 for SD1.x
+- 2 for SD2.x
+- 3 for SDXL
+
 ## Run test
 ```shell
 python -m pytest -vv --junitxml=test/results.xml --cov ./extensions/sd-webui-controlnet --cov-report=xml --verify-base-url ./extensions/sd-webui-controlnet/tests

--- a/tests/annotator_tests/openpose_tests/body_test.py
+++ b/tests/annotator_tests/openpose_tests/body_test.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from annotator.openpose.body import Body, Keypoint, BodyResult
 

--- a/tests/annotator_tests/openpose_tests/detection_test.py
+++ b/tests/annotator_tests/openpose_tests/detection_test.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from annotator.openpose.util import faceDetect, handDetect
 from annotator.openpose.body import Keypoint, BodyResult

--- a/tests/annotator_tests/openpose_tests/json_encode_test.py
+++ b/tests/annotator_tests/openpose_tests/json_encode_test.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from annotator.openpose import encode_poses_as_json, PoseResult, Keypoint
 from annotator.openpose.body import BodyResult

--- a/tests/annotator_tests/openpose_tests/openpose_e2e_test_disabled.py
+++ b/tests/annotator_tests/openpose_tests/openpose_e2e_test_disabled.py
@@ -13,7 +13,7 @@ from typing import Dict
 
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from annotator.openpose import OpenposeDetector
 

--- a/tests/cn_script/batch_hijack_test.py
+++ b/tests/cn_script/batch_hijack_test.py
@@ -3,7 +3,7 @@ import importlib
 from typing import Any
 
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from modules import processing, scripts, shared
 from scripts import controlnet, external_code, batch_hijack

--- a/tests/cn_script/cn_script_test.py
+++ b/tests/cn_script/cn_script_test.py
@@ -6,7 +6,7 @@ import numpy as np
 import importlib
 
 utils = importlib.import_module("extensions.sd-webui-controlnet.tests.utils", "utils")
-utils.setup_test_env()
+
 
 from scripts import external_code, processor
 from scripts.controlnet import prepare_mask, Script, set_numpy_seed

--- a/tests/cn_script/utils_test.py
+++ b/tests/cn_script/utils_test.py
@@ -1,6 +1,6 @@
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from scripts.utils import ndarray_lru_cache, get_unique_axis0
 

--- a/tests/external_code_api/external_code_test.py
+++ b/tests/external_code_api/external_code_test.py
@@ -4,7 +4,7 @@ import importlib
 import numpy as np
 
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from copy import copy
 from scripts import external_code

--- a/tests/external_code_api/importlib_reload_test.py
+++ b/tests/external_code_api/importlib_reload_test.py
@@ -1,7 +1,7 @@
 import unittest
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from scripts import external_code
 

--- a/tests/external_code_api/script_args_test.py
+++ b/tests/external_code_api/script_args_test.py
@@ -1,7 +1,7 @@
 import unittest
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from scripts import external_code
 

--- a/tests/external_code_api/script_args_test.py
+++ b/tests/external_code_api/script_args_test.py
@@ -10,7 +10,7 @@ class TestGetAllUnitsFrom(unittest.TestCase):
     def setUp(self):
         self.control_unit = {
             "module": "none",
-            "model": utils.get_model(),
+            "model": utils.get_model("canny"),
             "image": utils.readImage("test/test_files/img2img_basic.png"),
             "resize_mode": 1,
             "low_vram": False,

--- a/tests/web_api/control_types_test.py
+++ b/tests/web_api/control_types_test.py
@@ -4,7 +4,7 @@ import requests
 
 utils = importlib.import_module(
     'extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
+
 
 from scripts.processor import preprocessor_filters
 

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -3,7 +3,6 @@ import unittest
 import importlib
 utils = importlib.import_module(
     'extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
 
 
 class TestDetectEndpointWorking(unittest.TestCase):

--- a/tests/web_api/img2img_test.py
+++ b/tests/web_api/img2img_test.py
@@ -1,16 +1,20 @@
+import os
 import unittest
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
 import requests
-
+from scripts.enums import StableDiffusionVersion
 
 
 class TestImg2ImgWorkingBase(unittest.TestCase):
     def setUp(self):
+        sd_version = StableDiffusionVersion(int(
+            os.environ.get("CONTROLNET_TEST_SD_VERSION", StableDiffusionVersion.SD1x.value)))
+        self.model = utils.get_model("canny", sd_version)
+
         controlnet_unit = {
             "module": "none",
-            "model": utils.get_model(),
+            "model": self.model,
             "weight": 1.0,
             "input_image": utils.readImage("test/test_files/img2img_basic.png"),
             "mask": utils.readImage("test/test_files/img2img_basic.png"),
@@ -87,7 +91,7 @@ class TestImg2ImgWorkingBase(unittest.TestCase):
     def test_img2img_default_params(self):
         self.simple_img2img["alwayson_scripts"]["ControlNet"]["args"] = [{
             "input_image": utils.readImage("test/test_files/img2img_basic.png"),
-            "model": utils.get_model(),
+            "model": self.model,
         }]
         self.assert_status_ok()
 

--- a/tests/web_api/txt2img_test.py
+++ b/tests/web_api/txt2img_test.py
@@ -1,17 +1,21 @@
+import os
 import unittest
+import requests
 import importlib
 utils = importlib.import_module('extensions.sd-webui-controlnet.tests.utils', 'utils')
-utils.setup_test_env()
-import requests
-
+from scripts.enums import StableDiffusionVersion
 
 
 class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
     def setUp(self):
+        sd_version = StableDiffusionVersion(int(
+            os.environ.get("CONTROLNET_TEST_SD_VERSION", StableDiffusionVersion.SD1x.value)))
+        self.model = utils.get_model("canny", sd_version)
+        
         controlnet_unit = {
             "enabled": True,
             "module": "none",
-            "model": utils.get_model(),
+            "model": self.model,
             "weight": 1.0,
             "image": utils.readImage("test/test_files/img2img_basic.png"),
             "mask": utils.readImage("test/test_files/img2img_basic.png"),
@@ -99,7 +103,7 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
         self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"] = [
             {
                 "input_image": utils.readImage("test/test_files/img2img_basic.png"),
-                "model": utils.get_model(),
+                "model": self.model,
             }
         ]
 
@@ -116,8 +120,8 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
                 self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"] = [
                     {
                         "input_image": utils.readImage("test/test_files/img2img_basic.png"),
-                        "model": utils.get_model(),
-                        "module": module
+                        "model": self.model,
+                        "module": module,                    
                     }
                 ]
                 self.assert_status_ok(f'Running preprocessor module: {module}')
@@ -128,7 +132,7 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
                 self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"] = [
                     {
                         "input_image": utils.readImage("test/test_files/img2img_basic.png"),
-                        "model": utils.get_model(),
+                        "model": self.model,
                         param: -1,
                     }
                 ]
@@ -140,7 +144,7 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
                 self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"] = [
                     {
                         "input_image": utils.readImage("test/test_files/img2img_basic.png"),
-                        "model": utils.get_model(),
+                        "model": self.model,
                         "module": "depth",
                         "save_detected_map": save_map,
                     }

--- a/tests/web_api/txt2img_test.py
+++ b/tests/web_api/txt2img_test.py
@@ -121,7 +121,7 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
                     {
                         "input_image": utils.readImage("test/test_files/img2img_basic.png"),
                         "model": self.model,
-                        "module": module,                    
+                        "module": module,
                     }
                 ]
                 self.assert_status_ok(f'Running preprocessor module: {module}')


### PR DESCRIPTION
This PR let users use SDXL models when running tests. This is a part of larger effort of having more SDXL test coverage described in #2231.

Users can specify sd version via environment variable `CONTROLNET_TEST_SD_VERSION`.
1 for SD1.x
2 for SD2.x
3 for SDXL

SDXL tests are only runnable locally right now, as downloading the 5GB SDXL base model on CI machine is not really viable.