### PR TITLE
:fire: Remove disable_control_type option

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1110,8 +1110,6 @@ def on_ui_settings():
         False, "Show batch images in gradio gallery output", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_increment_seed_during_batch", shared.OptionInfo(
         False, "Increment seed after each controlnet batch iteration", gr.Checkbox, {"interactive": True}, section=section))
-    shared.opts.add_option("controlnet_disable_control_type", shared.OptionInfo(
-        False, "Disable control type selection", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_disable_openpose_edit", shared.OptionInfo(
         False, "Disable openpose edit", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_ignore_noninpaint_mask", shared.OptionInfo(

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -837,6 +837,7 @@ class ControlNetUiGroup(object):
         self.openpose_editor.register_callbacks(
             self.generated_image, self.use_preview_as_input
         )
+        assert self.type_filter is not None
         self.preset_panel.register_callbacks(
             self,
             self.type_filter,

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -315,15 +315,14 @@ class ControlNetUiGroup(object):
             else:
                 self.upload_independent_img_in_img2img = None
 
-        if not shared.opts.data.get("controlnet_disable_control_type", False):
-            with gr.Row(elem_classes=["controlnet_control_type", "controlnet_row"]):
-                self.type_filter = gr.Radio(
-                    list(preprocessor_filters.keys()),
-                    label=f"Control Type",
-                    value="All",
-                    elem_id=f"{elem_id_tabname}_{tabname}_controlnet_type_filter_radio",
-                    elem_classes="controlnet_control_type_filter_group",
-                )
+        with gr.Row(elem_classes=["controlnet_control_type", "controlnet_row"]):
+            self.type_filter = gr.Radio(
+                list(preprocessor_filters.keys()),
+                label=f"Control Type",
+                value="All",
+                elem_id=f"{elem_id_tabname}_{tabname}_controlnet_type_filter_radio",
+                elem_classes="controlnet_control_type_filter_group",
+            )
 
         with gr.Row(elem_classes=["controlnet_preprocessor_model", "controlnet_row"]):
             self.module = gr.Dropdown(


### PR DESCRIPTION
The control type selection feature has been around for a long while and many other code has been build on top of it, e.g. preset managements, etc.

#2136 is suspected to be caused by `ui_group.type_filter` being `None`.

This PR removes `controlnet_disable_control_type` option, and make control type selection always available.