### PR TITLE
:sparkles: Filter cn model by sd version active

### DIFF
--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -611,7 +611,7 @@ class ControlNetUiGroup(object):
                 filtered_model_list,
                 default_option,
                 default_model,
-            ) = global_state.select_control_type(k)
+            ) = global_state.select_control_type(k, global_state.get_sd_version())
 
             if self.prevent_next_n_module_update > 0:
                 self.prevent_next_n_module_update -= 1

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -14,10 +14,10 @@ class StableDiffusionVersion(Enum):
         """Based on the model name provided, guess what stable diffusion version it is.
         This might not be accurate without actually inspect the file content.
         """
-        if "15" in model_name or "1.5" in model_name:
+        if any(f"sd{v}" in model_name.lower() for v in ("14", "15", "16")):
             return StableDiffusionVersion.SD1x
 
-        if "21" in model_name or "2.1" in model_name:
+        if "sd21" in model_name or "2.1" in model_name:
             return StableDiffusionVersion.SD2x
 
         if "xl" in model_name.lower():

--- a/tests/cn_script/global_state_test.py
+++ b/tests/cn_script/global_state_test.py
@@ -1,0 +1,67 @@
+import importlib
+utils = importlib.import_module("extensions.sd-webui-controlnet.tests.utils", "utils")
+
+from scripts.global_state import select_control_type, ui_preprocessor_keys
+from scripts.enums import StableDiffusionVersion
+
+
+dummy_value = "dummy"
+cn_models = {
+    "None": dummy_value,
+    "canny_sd15": dummy_value,
+    "canny_sdxl": dummy_value,
+}
+
+
+# Tests for the select_control_type function
+class TestSelectControlType:
+    def test_all_control_type(self):
+        result = select_control_type("All", cn_models=cn_models)
+        assert result == (
+            [ui_preprocessor_keys, list(cn_models.keys()), "none", "None"]
+        ), "Expected all preprocessors and models"
+
+    def test_sd_version(self):
+        (_, filtered_model_list, _, default_model) = select_control_type(
+            "Canny", sd_version=StableDiffusionVersion.UNKNOWN, cn_models=cn_models
+        )
+        assert filtered_model_list == [
+            "None",
+            "canny_sd15",
+            "canny_sdxl",
+        ], "UNKNOWN sd version should match all models"
+        assert default_model == "canny_sd15"
+
+        (_, filtered_model_list, _, default_model) = select_control_type(
+            "Canny", sd_version=StableDiffusionVersion.SD1x, cn_models=cn_models
+        )
+        assert filtered_model_list == [
+            "None",
+            "canny_sd15",
+        ], "sd1x version should only sd1x"
+        assert default_model == "canny_sd15"
+
+        (_, filtered_model_list, _, default_model) = select_control_type(
+            "Canny", sd_version=StableDiffusionVersion.SDXL, cn_models=cn_models
+        )
+        assert filtered_model_list == [
+            "None",
+            "canny_sdxl",
+        ], "sdxl version should only sdxl"
+        assert default_model == "canny_sdxl"
+
+    def test_invert_preprocessor(self):
+        for control_type in ("Canny", "Lineart", "Scribble/Sketch", "MLSD"):
+            filtered_preprocessor_list, _, _, _ = select_control_type(
+                control_type, cn_models=cn_models
+            )
+            assert any(
+                "invert" in module.lower() for module in filtered_preprocessor_list
+            )
+
+    def test_no_module_available(self):
+        (_, filtered_model_list, _, default_model) = select_control_type(
+            "Depth", cn_models=cn_models
+        )
+        assert filtered_model_list == ["None"]
+        assert default_model == "None"


### PR DESCRIPTION
Part of larger effort: https://github.com/Mikubill/sd-webui-controlnet/issues/2222.

This PR let `select_control_type` function only return ControlNet models that matches the currently active sd model's version. API endpoint `/controlnet/control_types`'s behaviour will not be affected.

TODO:
When user change SD model in A1111, trigger an update to module/models.