### PR TITLE
🔊 Meaningful error message for sd version conflict

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -19,7 +19,8 @@ from scripts.adapter import Adapter, StyleAdapter, Adapter_light
 from scripts.controlnet_lllite import PlugableControlLLLite, clear_all_lllite
 from scripts.controlmodel_ipadapter import PlugableIPAdapter, clear_all_ip_adapter
 from scripts.utils import load_state_dict, get_unique_axis0
-from scripts.hook import ControlParams, UnetHook, ControlModelType, HackedImageRNG
+from scripts.hook import ControlParams, UnetHook, HackedImageRNG
+from scripts.enums import ControlModelType
 from scripts.controlnet_ui.controlnet_ui_group import ControlNetUiGroup, UiControlNetUnit
 from scripts.logging import logger
 from modules.processing import StableDiffusionProcessingImg2Img, StableDiffusionProcessingTxt2Img

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -24,3 +24,33 @@ class StableDiffusionVersion(Enum):
             return StableDiffusionVersion.SDXL
 
         return StableDiffusionVersion.UNKNOWN
+
+
+class ControlModelType(Enum):
+    """
+    The type of Control Models (supported or not).
+    """
+
+    ControlNet = "ControlNet, Lvmin Zhang"
+    T2I_Adapter = "T2I_Adapter, Chong Mou"
+    T2I_StyleAdapter = "T2I_StyleAdapter, Chong Mou"
+    T2I_CoAdapter = "T2I_CoAdapter, Chong Mou"
+    MasaCtrl = "MasaCtrl, Mingdeng Cao"
+    GLIGEN = "GLIGEN, Yuheng Li"
+    AttentionInjection = "AttentionInjection, Lvmin Zhang"  # A simple attention injection written by Lvmin
+    StableSR = "StableSR, Jianyi Wang"
+    PromptDiffusion = "PromptDiffusion, Zhendong Wang"
+    ControlLoRA = "ControlLoRA, Wu Hecong"
+    ReVision = "ReVision, Stability"
+    IPAdapter = "IPAdapter, Hu Ye"
+    Controlllite = "Controlllite, Kohya"
+
+
+# Written by Lvmin
+class AutoMachine(Enum):
+    """
+    Lvmin's algorithm for Attention/AdaIn AutoMachine States.
+    """
+
+    Read = "Read"
+    Write = "Write"

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -1,14 +1,13 @@
 import torch
-import einops
 import hashlib
 import numpy as np
 import torch.nn as nn
 from functools import partial
-import modules.processing
 
 
 from enum import Enum
 from scripts.logging import logger
+from scripts.enums import ControlModelType, AutoMachine
 from modules import devices, lowvram, shared, scripts
 
 cond_cast_unet = getattr(devices, 'cond_cast_unet', lambda x: x)
@@ -123,36 +122,6 @@ class HackedImageRNG:
         result = predict_q_sample(self.sd_model, x0, ts, result)
         logger.info(f'[ControlNet] Initial noise hack applied to {result.shape}.')
         return result
-
-
-class ControlModelType(Enum):
-    """
-    The type of Control Models (supported or not).
-    """
-
-    ControlNet = "ControlNet, Lvmin Zhang"
-    T2I_Adapter = "T2I_Adapter, Chong Mou"
-    T2I_StyleAdapter = "T2I_StyleAdapter, Chong Mou"
-    T2I_CoAdapter = "T2I_CoAdapter, Chong Mou"
-    MasaCtrl = "MasaCtrl, Mingdeng Cao"
-    GLIGEN = "GLIGEN, Yuheng Li"
-    AttentionInjection = "AttentionInjection, Lvmin Zhang"  # A simple attention injection written by Lvmin
-    StableSR = "StableSR, Jianyi Wang"
-    PromptDiffusion = "PromptDiffusion, Zhendong Wang"
-    ControlLoRA = "ControlLoRA, Wu Hecong"
-    ReVision = "ReVision, Stability"
-    IPAdapter = "IPAdapter, Hu Ye"
-    Controlllite = "Controlllite, Kohya"
-
-
-# Written by Lvmin
-class AutoMachine(Enum):
-    """
-    Lvmin's algorithm for Attention/AdaIn AutoMachine States.
-    """
-
-    Read = "Read"
-    Write = "Write"
 
 
 class TorchHijackForUnet:


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2222.

This PR adds a check on sd version conflict between ControlNet model and sd model. This can be useful for debugging purpose for API callers, as they do not have the auto model filtering in the UI.

Sample error message:
```shell
Exception: ControlNet model kohya_controllllite_xl_canny [2ed264be](StableDiffusionVersion.SDXL) is not compatible with sd model(StableDiffusionVersion.SD1x)
```