### PR TITLE
:fire: Remove gradio version check

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -38,16 +38,6 @@ from scripts.processor import model_free_preprocessors
 from scripts.controlnet_model_guess import build_model_by_guess
 
 
-gradio_compat = True
-try:
-    from distutils.version import LooseVersion
-    from importlib_metadata import version
-    if LooseVersion(version("gradio")) < LooseVersion("3.10"):
-        gradio_compat = False
-except ImportError:
-    pass
-
-
 # Gradio 3.32 bug fix
 import tempfile
 gradio_tempfile_path = os.path.join(tempfile.gettempdir(), 'gradio')
@@ -261,7 +251,6 @@ class Script(scripts.Script, metaclass=(
 
     def uigroup(self, tabname: str, is_img2img: bool, elem_id_tabname: str) -> Tuple[ControlNetUiGroup, gr.State]:
         group = ControlNetUiGroup(
-            gradio_compat,
             Script.get_default_ui_unit(),
             self.preprocessor,
         )

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -100,11 +100,9 @@ class ControlNetUiGroup(object):
 
     def __init__(
         self,
-        gradio_compat: bool,
         default_unit: external_code.ControlNetUnit,
         preprocessors: List[Callable],
     ):
-        self.gradio_compat = gradio_compat
         self.default_unit = default_unit
         self.preprocessors = preprocessors
         self.webcam_enabled = False
@@ -504,9 +502,6 @@ class ControlNetUiGroup(object):
         self.refresh_models.click(refresh_all_models, self.model, self.model, show_progress=False)
 
     def register_build_sliders(self):
-        if not self.gradio_compat:
-            return
-
         def build_sliders(module: str, pp: bool):
             logger.debug(
                 f"Prevent update slider value: {self.prevent_next_n_slider_value_update}"


### PR DESCRIPTION
Closes #2262.

I believe the gradio version check there is no longer necessary as we now only target A1111 1.6.0+ users.