### PR TITLE
✨Add JSON pose file upload button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The WebUI extension for ControlNet and other injection-based SD controls.
 
-![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/00787fd1-1bc5-4b90-9a23-9683f8458b85)
+![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/51172d20-606b-4b9f-aba5-db2f2417cb0b)
 
 This extension is for AUTOMATIC1111's [Stable Diffusion web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui), allows the Web UI to add [ControlNet](https://github.com/lllyasviel/ControlNet) to the original Stable Diffusion model to generate images. The addition is on-the-fly, the merging is not required.
 

--- a/javascript/active_units.js
+++ b/javascript/active_units.js
@@ -223,11 +223,18 @@
                     if (!this.enabledCheckbox.checked)
                         this.enabledCheckbox.click();
                 });
+
+                // Automatically check `enable` checkbox when JSON pose file is uploaded.
+                this.tab.querySelector('.cnet-upload-pose input').addEventListener('change', (event) => {
+                    if (!event.target.files) return;
+                    if (!this.enabledCheckbox.checked)
+                        this.enabledCheckbox.click();
+                });
             }
 
             attachImageStateChangeObserver() {
                 new MutationObserver((mutationsList) => {
-                    const changeObserved = imgChangeObserved(mutationsList);                    
+                    const changeObserved = imgChangeObserved(mutationsList);
 
                     if (changeObserved === ImgChangeType.ADD) {
                         // enabling the run preprocessor button

--- a/javascript/openpose_editor.js
+++ b/javascript/openpose_editor.js
@@ -55,17 +55,16 @@
                 }
             });
         }
+        const tabs = gradioApp().querySelectorAll('.cnet-unit-tab');
+        tabs.forEach(tab => {
+            if (cnetOpenposeEditorRegisteredElements.has(tab)) return;
+            cnetOpenposeEditorRegisteredElements.add(tab);
 
-        const imageRows = gradioApp().querySelectorAll('.cnet-image-row');
-        imageRows.forEach(imageRow => {
-            if (cnetOpenposeEditorRegisteredElements.has(imageRow)) return;
-            cnetOpenposeEditorRegisteredElements.add(imageRow);
-
-            const generatedImageGroup = imageRow.querySelector('.cnet-generated-image-group');
+            const generatedImageGroup = tab.querySelector('.cnet-generated-image-group');
             const editButton = generatedImageGroup.querySelector('.cnet-edit-pose');
 
             editButton.addEventListener('click', async () => {
-                const inputImageGroup = imageRow.querySelector('.cnet-input-image-group');
+                const inputImageGroup = tab.querySelector('.cnet-input-image-group');
                 const inputImage = inputImageGroup.querySelector('.cnet-image img');
                 const downloadLink = generatedImageGroup.querySelector('.cnet-download-pose a');
                 const modalId = editButton.id.replace('cnet-modal-open-', '');
@@ -74,7 +73,7 @@
                 await navigateIframe(modalIframe);
                 modalIframe.contentWindow.postMessage({
                     modalId,
-                    imageURL: inputImage.src,
+                    imageURL: inputImage ? inputImage.src : undefined,
                     poseURL: downloadLink.href,
                 }, '*');
                 // Focus the iframe so that the focus is no longer on the `Edit` button.
@@ -93,25 +92,29 @@
                 const downloadLink = generatedImageGroup.querySelector('.cnet-download-pose a');
                 const renderButton = generatedImageGroup.querySelector('.cnet-render-pose');
                 const poseTextbox = generatedImageGroup.querySelector('.cnet-pose-json textarea');
+                const allowPreviewCheckbox = tab.querySelector('.cnet-allow-preview input');
+
+                if (!allowPreviewCheckbox.checked)
+                    allowPreviewCheckbox.click();
 
                 downloadLink.href = poseURL;
                 poseTextbox.value = poseURL;
                 updateInput(poseTextbox);
                 renderButton.click();
             }
-            
+
             // Updates preview image when edit is done.
             window.addEventListener('message', (event) => {
                 const message = event.data;
                 const modalId = editButton.id.replace('cnet-modal-open-', '');
                 if (message.modalId !== modalId) return;
-                updatePreviewPose(message.poseURL);                
+                updatePreviewPose(message.poseURL);
 
                 const closeModalButton = generatedImageGroup.querySelector('.cnet-modal .cnet-modal-close');
                 closeModalButton.click();
             });
 
-            const inputImageGroup = imageRow.querySelector('.cnet-input-image-group');
+            const inputImageGroup = tab.querySelector('.cnet-input-image-group');
             const uploadButton = inputImageGroup.querySelector('.cnet-upload-pose input');
             // Updates preview image when JSON file is uploaded.
             uploadButton.addEventListener('change', (event) => {
@@ -131,12 +134,12 @@
     }
 
     function loadPlaceHolder() {
-        const imageRows = gradioApp().querySelectorAll('.cnet-image-row');
-        imageRows.forEach(imageRow => {
-            if (cnetOpenposeEditorRegisteredElements.has(imageRow)) return;
-            cnetOpenposeEditorRegisteredElements.add(imageRow);
+        const tabs = gradioApp().querySelectorAll('.cnet-image-row');
+        tabs.forEach(tab => {
+            if (cnetOpenposeEditorRegisteredElements.has(tab)) return;
+            cnetOpenposeEditorRegisteredElements.add(tab);
 
-            const generatedImageGroup = imageRow.querySelector('.cnet-generated-image-group');
+            const generatedImageGroup = tab.querySelector('.cnet-generated-image-group');
             const editButton = generatedImageGroup.querySelector('.cnet-edit-pose');
             const modalContent = generatedImageGroup.querySelector('.cnet-modal-content');
 

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -166,6 +166,8 @@ class ControlNetUiGroup(object):
         Returns:
             None
         """
+        self.openpose_editor = OpenposeEditor()
+        
         with gr.Group(visible=not is_img2img) as self.image_upload_panel:
             self.save_detected_map = gr.Checkbox(value=True, visible=False)
             with gr.Tabs():
@@ -186,6 +188,8 @@ class ControlNetUiGroup(object):
                                 )
                                 else None,
                             )
+                            self.openpose_editor.render_upload()
+                            
                         with gr.Group(
                             visible=False, elem_classes=["cnet-generated-image-group"]
                         ) as self.generated_image_group:
@@ -201,7 +205,7 @@ class ControlNetUiGroup(object):
                             with gr.Group(
                                 elem_classes=["cnet-generated-image-control-group"]
                             ):
-                                self.openpose_editor = OpenposeEditor()
+                                self.openpose_editor.render_edit()
                                 preview_check_elem_id = f"{elem_id_tabname}_{tabname}_controlnet_preprocessor_preview_checkbox"
                                 preview_close_button_js = f"document.querySelector('#{preview_check_elem_id} input[type=\\'checkbox\\']').click();"
                                 gr.HTML(
@@ -830,7 +834,8 @@ class ControlNetUiGroup(object):
         self.register_shift_preview()
         self.register_create_canvas()
         self.openpose_editor.register_callbacks(
-            self.generated_image, self.use_preview_as_input
+            self.generated_image, self.use_preview_as_input,
+            self.model,
         )
         assert self.type_filter is not None
         self.preset_panel.register_callbacks(

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -296,6 +296,7 @@ class ControlNetUiGroup(object):
             self.preprocessor_preview = gr.Checkbox(
                 label="Allow Preview",
                 value=False,
+                elem_classes=["cnet-allow-preview"],
                 elem_id=preview_check_elem_id,
                 visible=not is_img2img,
             )

--- a/scripts/controlnet_ui/openpose_editor.py
+++ b/scripts/controlnet_ui/openpose_editor.py
@@ -79,7 +79,7 @@ class OpenposeEditor(object):
         model: gr.Dropdown,
     ):
         def render_pose(pose_url: str) -> Tuple[Dict, Dict]:
-            json_string = parse_data_url(pose_url)
+            json_string = parse_data_url(pose_url).decode('utf-8')
             poses, height, weight = decode_json_as_poses(json_string)
             logger.info("Preview as input is enabled.")
             return (
@@ -97,12 +97,14 @@ class OpenposeEditor(object):
                 ),
                 # Use preview as input.
                 gr.update(value=True),
+                # Self content.
+                *self.update(json_string),
             )
 
         self.render_button.click(
             fn=render_pose,
             inputs=[self.pose_input],
-            outputs=[generated_image, use_preview_as_input],
+            outputs=[generated_image, use_preview_as_input, *self.outputs()],
         )
 
         def update_upload_link(model: str) -> Dict:

--- a/scripts/controlnet_ui/openpose_editor.py
+++ b/scripts/controlnet_ui/openpose_editor.py
@@ -38,6 +38,7 @@ class OpenposeEditor(object):
         self.modal = None
 
     def render_edit(self):
+        """Renders the buttons in preview image control button group."""
         # The hidden button to trigger a re-render of generated image.
         self.render_button = gr.Button(visible=False, elem_classes=["cnet-render-pose"])
         # The hidden element that stores the pose json for backend retrieval.
@@ -55,10 +56,13 @@ class OpenposeEditor(object):
             open_button_extra_attrs=f'title="Send pose to {OpenposeEditor.editor_url} for edit."',
         ).create_modal(visible=False)
         self.download_link = gr.HTML(
-            value="", visible=False, elem_classes=["cnet-download-pose"]
+            value=f"""<a href='' download='{OpenposeEditor.download_file}'>JSON</a>""",
+            visible=False,
+            elem_classes=["cnet-download-pose"],
         )
 
     def render_upload(self):
+        """Renders the button in input image control button group."""
         self.upload_link = gr.HTML(
             value="""
             <label>Upload JSON</label>
@@ -100,9 +104,10 @@ class OpenposeEditor(object):
             inputs=[self.pose_input],
             outputs=[generated_image, use_preview_as_input],
         )
-        
+
         def update_upload_link(model: str) -> Dict:
             return gr.update(visible="openpose" in model.lower())
+
         model.change(fn=update_upload_link, inputs=[model], outputs=[self.upload_link])
 
     def outputs(self) -> List[Any]:

--- a/style.css
+++ b/style.css
@@ -84,7 +84,8 @@
 /* Gradio button style */
 .cnet-download-pose a,
 .cnet-close-preview,
-.cnet-edit-pose {
+.cnet-edit-pose,
+.cnet-upload-pose {
     font-size: x-small !important;
     font-weight: bold !important;
     padding: 2px !important;
@@ -101,7 +102,8 @@
 
 .cnet-download-pose:hover a,
 .cnet-close-preview:hover a,
-.cnet-edit-pose:hover {
+.cnet-edit-pose:hover,
+.cnet-upload-pose:hover {
     color: var(--block-label-text-color) !important;
 }
 
@@ -140,6 +142,21 @@
     opacity: 50%;
 }
 
-.controlnet_row{
+.controlnet_row {
     margin-top: 10px !important;
+}
+
+/* JSON pose upload button styling */
+.cnet-upload-pose {
+    position: relative;
+    overflow: hidden;
+    display: inline-block;
+}
+
+.cnet-upload-pose input[type=file] {
+    font-size: 100px;
+    position: absolute;
+    left: 0;
+    top: 0;
+    opacity: 0;
 }

--- a/style.css
+++ b/style.css
@@ -71,7 +71,8 @@
     }
 }
 
-.cnet-generated-image-control-group {
+.cnet-generated-image-control-group,
+.cnet-upload-pose {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
@@ -147,12 +148,6 @@
 }
 
 /* JSON pose upload button styling */
-.cnet-upload-pose {
-    position: relative;
-    overflow: hidden;
-    display: inline-block;
-}
-
 .cnet-upload-pose input[type=file] {
     font-size: 100px;
     position: absolute;


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2236.

This PR adds an `upload JSON file` button when openpose control type is selected. This allows users directly use the JSON pose files they save, instead of going into the openpose editor and upload JSON there.

UI after change:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/51172d20-606b-4b9f-aba5-db2f2417cb0b)