### PR TITLE
1.1.420 Image-wise ControlNet and StyleAlign (Hertz et al.)

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -25,6 +25,11 @@ class ControlMode(Enum):
     CONTROL = "ControlNet is more important"
 
 
+class BatchOption(Enum):
+    DEFAULT = "All ControlNet unit for all images in a batch"
+    SEPARATE = "Each ControlNet unit for each image in a batch"
+
+
 class ResizeMode(Enum):
     """
     Resize modes for ControlNet input images.

--- a/scripts/controlnet_version.py
+++ b/scripts/controlnet_version.py
@@ -1,4 +1,4 @@
-version_flag = 'v1.1.419'
+version_flag = 'v1.1.420'
 
 from scripts.logging import logger
 

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -54,3 +54,4 @@ class AutoMachine(Enum):
 
     Read = "Read"
     Write = "Write"
+    StyleAlign = "StyleAlign"


### PR DESCRIPTION
Since `sd-webui-controlnet` 1.1.420, users will be able to use image-wise controlnets. And, based on image-wise controlnets, the "StyleAlign" is avaliable.

[Style Aligned Image Generation via Shared Attention](https://style-aligned-gen.github.io/)
[Amir Hertz* 1](https://amirhertz.github.io/) [Andrey Voynov* 1](https://style-aligned-gen.github.io/) [Shlomi Fruchter† 1](https://style-aligned-gen.github.io/) [Daniel Cohen-Or† 1,2](https://danielcohenor.com/)
*1 Google Research 2 Tel Aviv University*

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/22252293-ffb5-4ede-89b0-a821940f1d78)

Previously, all ControlNet units will be applied to all images in your batch. Now, if you use “each ControlNet unit for each image in a batch”, you will have each ControlNet unit for each image in your batch.

For example, if your batch size is 4, then your 

    ControlNet unit 0 will be applied to image 0, 
    ControlNet unit 1 will be applied to image 1, 
    ControlNet unit 2 will be applied to image 2, 
    ControlNet unit 3 will be applied to image 3 ...

And you can use “[StyleAlign] Align image style in the batch” to align the style of all images in a batch (via shared attention reference).

(If the number of batch size does not match ControlNet unit count, the remainder of the division will be used)

# Sanity Check

Some example images used in the Sanity Check:

<img src="https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/16f3b4ef-de25-437a-a889-de716d1feec4" width="100">

<img src="https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/7bce08ad-f2de-4593-b96a-04ee773a0878" width="100">

<img src="https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/ae3256dc-cb29-4e06-90c1-e94de4b48798" width="100">

<img src="https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/3b0b57be-f682-4545-91f0-5c2052ac75ed" width="100">

The model is `realisticVisionV51_v51VAE`: https://civitai.com/models/4201?modelVersionId=130072

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/d7137c7b-aec8-4fba-bc72-e8ade240c869)

Prompt

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/8c27f6c0-36a0-461a-96cc-2d182cb6e2f5)

Positive:

best quality, very detailed, high resolution, 4k, 8k, 35 mm, a handsome man, looking at viewer, street

Negative:

text, watermark, low quality, medium quality, blurry, censored, deformed, mutated, anime, toon, render, 3d, ilustration, moles, dark skin spots

Parameters:

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/6df6b5b6-2688-4053-81e4-ec79e835c7dc)

4x Openpose CN (control_v11p_sd15_openpose):

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/6c8a3899-7eae-49f4-8614-2087cb9eab9e)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/27c3eed5-3be3-4ff5-8915-0800b860ef6b)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/e7225d2b-dc37-43dc-b533-67389de8c19a)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/bb351772-0b29-4781-a206-eeab78d7c3e5)

All default parameters.

Note that here we use openpose (rather than openpose_full) without face landmarks to avoid the style influence of face appearance.

Also, if you do not have 4 controlnet units, go to settings->controlnet->ControlNet unit number to have any number of units.

Check "Each ControlNet unit for each image in a batch"

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/d273650e-e6b8-4558-9e36-7adfd1e1490f)

Generate, you will get this

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/4a598ced-e729-45f2-b32f-9e4abbdbb7f1)

The 4 images are generated by these 4 poses

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/5ffcec27-dd64-43aa-b4cd-e9fe4cfbf53f)

You can see this is what "Each ControlNet unit for each image in a batch".

Then check "[StyleAlign] Align image style in the batch."

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/2ae71e08-01ea-4650-8031-1a70502acdca)

Generate again, you will get the "StyleAlign" for the 4 images in a same batch:

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/19834515/97c03b74-e0d5-4686-aae0-e9ad97cf738f)

### FAQ

Q: Does this inluence speed?
A: Yes, if you use "StyleAlign", attention context is longer. Generating will be slower. But in my tests not too slow.

Q: Can I use t2ia-style/reference/ip-adapters together with StyleAlign?
A: Yes. But this behavior is still under experiment and may be changed in any future versions. (Not yet very sure what behavior should be the correct behavior because now attention will have formulations both in-batch and globally. It should already work out of box but not extensively tested.)

Q: XL? SSD? Turbo? LCM?
A: yes, yes, yes, and yes. (w/ webui 1.7.0)