### PR TITLE
Ignore unrecognized ControlNetUnit params

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -309,7 +309,7 @@ def to_processing_unit(unit: Union[Dict[str, Any], ControlNetUnit]) -> ControlNe
         if 'guess_mode' in unit:
             logger.warning('Guess Mode is removed since 1.1.136. Please use Control Mode instead.')
 
-        unit = ControlNetUnit(**unit)
+        unit = ControlNetUnit(**{k: v for k, v in unit.items() if k in vars(ControlNetUnit).keys()})
 
     # temporary, check #602
     # assert isinstance(unit, ControlNetUnit), f'bad argument to controlnet extension: {unit}\nexpected Union[dict[str, Any], ControlNetUnit]'

--- a/tests/web_api/txt2img_test.py
+++ b/tests/web_api/txt2img_test.py
@@ -242,6 +242,12 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
 
     def test_reference(self):
         self.run_test_unit("reference_only", "None", StableDiffusionVersion.SD1x)
+        
+    def test_unrecognized_param(self):
+        unit = self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"][0]
+        unit["foo"] = True
+        unit["is_ui"] = False
+        self.assert_status_ok()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously we have switched `ControlNetUnit` to use `dataclass` decorator. This actually modifies the behaviour of the code, which no longer allow `ControlNetUnit` accept and ignore unrecognized params. Unrecognized params will cause exception and ControlNet not being applied.

This PR restores the original behaviour where unrecognized params from the API are ignored.