### PR TITLE
:bug: Set default model/module to string values

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -154,8 +154,8 @@ class ControlNetUnit:
     Represents an entire ControlNet processing unit.
     """
     enabled: bool = True
-    module: Optional[str] = None
-    model: Optional[str] = None
+    module: str = "none"
+    model: str = "None"
     weight: float = 1.0
     image: Optional[InputImage] = None
     resize_mode: Union[ResizeMode, int, str] = ResizeMode.INNER_FIT

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -687,7 +687,7 @@ class Script(scripts.Script, metaclass=(
         incompatible.
         """
         # No need to check if the ControlModelType does not require model to be present.
-        if unit.model.lower() == "none":
+        if unit.model is None or unit.model.lower() == "none":
             return
 
         sd_version = global_state.get_sd_version()

--- a/tests/web_api/txt2img_test.py
+++ b/tests/web_api/txt2img_test.py
@@ -242,11 +242,22 @@ class TestAlwaysonTxt2ImgWorking(unittest.TestCase):
 
     def test_reference(self):
         self.run_test_unit("reference_only", "None", StableDiffusionVersion.SD1x)
-        
+        self.run_test_unit("reference_only", "None", StableDiffusionVersion.SDXL)
+
     def test_unrecognized_param(self):
         unit = self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"][0]
         unit["foo"] = True
         unit["is_ui"] = False
+        self.assert_status_ok()
+
+    def test_default_model(self):
+        # Model "None" should be used when model is not specified in the payload.
+        self.simple_txt2img["alwayson_scripts"]["ControlNet"]["args"] = [
+            {
+                "input_image": utils.readImage("test/test_files/img2img_basic.png"),
+                "module": "reference_only",
+            }
+        ]
         self.assert_status_ok()
 
 


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2331.

This PR fixes the issue that `None` value not handled by `check_sd_version_compatible`. This PR also sets default value for ControlNetUnit.module and model to match the values used in the gradio UI.
