### PR TITLE
Quick edit of preprocessor result with photopea

### DIFF
--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -188,6 +188,10 @@
       layer.visible = layerStates[i];
     }
   }
+
+  function hasActiveDocument() {
+    app.echoToOE(app.documents.length > 0 ? "true" : "false");
+  }
   // End of photopea functions
 
   const MESSAGE_END_ACK = "done";
@@ -318,29 +322,27 @@
 
   const cnetRegisteredAccordions = new Set();
   function loadPhotopea() {
-    // Simulate an `input` DOM event for Gradio Textbox component. Needed after
-    // you edit its contents in javascript, otherwise your edits
-    // will only visible on web page and not sent to python.
-    function updateInput(target) {
-      let e = new Event("input", { bubbles: true })
-      Object.defineProperty(e, "target", { value: target })
-      target.dispatchEvent(e);
-    }
-
     function registerCallbacks(accordion) {
       const photopeaMainTrigger = accordion.querySelector('.cnet-photopea-main-trigger');
+      const closeModalButton = accordion.querySelector('.cnet-photopea-edit .cnet-modal-close');
       const tabs = accordion.querySelectorAll('.cnet-unit-tab');
-      tabs.forEach(tab => {
-        const photopeaChildTrigger = tab.querySelector('.cnet-photopea-child-trigger');
-        photopeaChildTrigger.addEventListener('click', () => {
-          photopeaMainTrigger.click();
-        });
-      });
-
       const photopeaWindow = accordion.querySelector('.photopea-iframe').contentWindow;
       const photopeaContext = new PhotopeaContext(photopeaWindow, tabs);
+
+      tabs.forEach(tab => {
+        const photopeaChildTrigger = tab.querySelector('.cnet-photopea-child-trigger');
+        photopeaChildTrigger.addEventListener('click', async () => {
+          photopeaMainTrigger.click();
+          if (await photopeaContext.invoke(hasActiveDocument) === "false") {
+            await photopeaContext.fetchFromControlNet(tabs);
+          }
+        });
+      });
       accordion.querySelector('.photopea-fetch').addEventListener('click', () => photopeaContext.fetchFromControlNet(tabs));
-      accordion.querySelector('.photopea-send').addEventListener('click', () => photopeaContext.sendToControlNet(tabs));
+      accordion.querySelector('.photopea-send').addEventListener('click', () => {
+        photopeaContext.sendToControlNet(tabs)
+        closeModalButton.click();
+      });
     }
 
     const accordions = gradioApp().querySelectorAll('#controlnet');

--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -57,6 +57,20 @@
     app.open(base64image, null, /* asSmart */ true);
     app.echoToOE('success');
   }
+
+  function setLayerNames(names) {
+    const layers = app.activeDocument.layers;
+    if (layers.length !== names.length) {
+      console.error("layer length does not match names length");
+      echoToOE("error");
+      return;
+    }
+
+    for (let i = 0; i < names.length; i++) {
+      const layer = layers[i];
+      layer.name = names[i];
+    }
+  }
   // End of photopea functions
 
   /**
@@ -65,14 +79,17 @@
    * Add those detected maps to the created document.
    */
   async function fetchFromControlNet(tabs, photopeaWindow) {
-    for (const tab of tabs) {
+    const layerNames = [];
+    for (const [i, tab] of tabs.entries()) {
       const generatedImage = tab.querySelector('.cnet-generated-image-group .cnet-image img');
       if (!generatedImage) continue;
       await invoke(photopeaWindow, pasteImage, generatedImage.src);
       // Wait 200ms for pasting to fully complete so that we do not ended up with 2 separate
       // documents.
       await new Promise(r => setTimeout(r, 200));
+      layerNames.push(`unit-${i}`);
     }
+    await invoke(photopeaWindow, setLayerNames, layerNames.reverse());
   }
 
   /**

--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -1,7 +1,88 @@
 (function () {
+  const MESSAGE_END_ACK = "done";
+  const MESSAGE_ERROR = "error";
+
+  // From https://github.com/huchenlei/stable-diffusion-ps-pea/blob/main/src/Photopea.ts
+  function postMessageToPhotopea(message, photopeaWindow) {
+    return new Promise((resolve, reject) => {
+      const responseDataPieces = [];
+      let hasError = false;
+      const photopeaMessageHandle = (event) => {
+        if (event.source !== photopeaWindow) {
+          return;
+        }
+        // Filter out the ping messages
+        if (typeof event.data === 'string' && event.data.includes('MSFAPI#')) {
+          return;
+        }
+        // Ignore "done" when no data has been received. The "done" can come from
+        // MSFAPI ping.
+        if (event.data === MESSAGE_END_ACK && responseDataPieces.length === 0) {
+          return;
+        }
+        if (event.data === MESSAGE_END_ACK) {
+          window.removeEventListener("message", photopeaMessageHandle);
+          if (hasError) {
+            reject('Photopea Error.');
+          } else {
+            resolve(responseDataPieces.length === 1 ? responseDataPieces[0] : responseDataPieces);
+          }
+        } else if (event.data === MESSAGE_ERROR) {
+          responseDataPieces.push(event.data);
+          hasError = true;
+        } else {
+          responseDataPieces.push(event.data);
+        }
+      };
+
+      window.addEventListener("message", photopeaMessageHandle);
+      setTimeout(() => reject("Photopea message timeout"), 5000);
+      photopeaWindow.postMessage(message, "*");
+    });
+  }
+
+  // From https://github.com/huchenlei/stable-diffusion-ps-pea/blob/main/src/Photopea.ts
+  async function invoke(photopeaWindow, func, ...args) {
+    const message = `${func.toString()} ${func.name}(${args.map(arg => JSON.stringify(arg)).join(',')});`;
+    try {
+      return await postMessageToPhotopea(message, photopeaWindow);
+    } catch (e) {
+      throw `Failed to invoke ${func.name}. ${e}.`;
+    }
+  }
+
+  // Functions to be called within photopea context.
+  // Start of photopea functions
+  function pasteImage(base64image, asLayer) {
+    app.open(base64image, null, /* asSmart */ asLayer);
+    app.echoToOE('success');
+  }
+  // End of photopea functions
+
+  /**
+   * Fetch detected maps from each ControlNet units. 
+   * Create a new photopea document.
+   * Add those detected maps to the created document.
+   */
+  async function fetchFromControlNet(tabs, photopeaWindow) {
+    for (let i = 0; i < tabs.length; i++) {
+      const tab = tabs[i];
+      const generatedImage = tab.querySelector('.cnet-generated-image-group .cnet-image img');
+      if (!generatedImage) continue;
+      await invoke(photopeaWindow, pasteImage, generatedImage.src, /* asLayer */ i > 0);
+    }
+  }
+
+  /**
+   * Send the images in the active photopea document back to each ControlNet units.
+   */
+  async function sendToControlNet() {
+    console.log('send to ControlNet');
+  }
+
   const cnetRegisteredAccordions = new Set();
   function loadPhotopea() {
-    // Simulate an `input` DOM event for Gradio Textbox component. Needed after 
+    // Simulate an `input` DOM event for Gradio Textbox component. Needed after
     // you edit its contents in javascript, otherwise your edits
     // will only visible on web page and not sent to python.
     function updateInput(target) {
@@ -10,7 +91,7 @@
       target.dispatchEvent(e);
     }
 
-    function registerChildTriggers(accordion) {
+    function registerCallbacks(accordion) {
       const photopeaMainTrigger = accordion.querySelector('.cnet-photopea-main-trigger');
       const tabs = accordion.querySelectorAll('.cnet-unit-tab');
       tabs.forEach(tab => {
@@ -19,12 +100,16 @@
           photopeaMainTrigger.click();
         });
       });
+
+      const photopeaWindow = accordion.querySelector('.photopea-iframe').contentWindow;
+      accordion.querySelector('.photopea-fetch').addEventListener('click', () => fetchFromControlNet(tabs, photopeaWindow));
+      accordion.querySelector('.photopea-send').addEventListener('click', sendToControlNet);
     }
 
     const accordions = gradioApp().querySelectorAll('#controlnet');
     accordions.forEach(accordion => {
       if (cnetRegisteredAccordions.has(accordion)) return;
-      registerChildTriggers(accordion);
+      registerCallbacks(accordion);
       cnetRegisteredAccordions.add(accordion);
     });
   }

--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -53,8 +53,8 @@
 
   // Functions to be called within photopea context.
   // Start of photopea functions
-  function pasteImage(base64image, asLayer) {
-    app.open(base64image, null, /* asSmart */ asLayer);
+  function pasteImage(base64image) {
+    app.open(base64image, null, /* asSmart */ true);
     app.echoToOE('success');
   }
   // End of photopea functions
@@ -65,11 +65,13 @@
    * Add those detected maps to the created document.
    */
   async function fetchFromControlNet(tabs, photopeaWindow) {
-    for (let i = 0; i < tabs.length; i++) {
-      const tab = tabs[i];
+    for (const tab of tabs) {
       const generatedImage = tab.querySelector('.cnet-generated-image-group .cnet-image img');
       if (!generatedImage) continue;
-      await invoke(photopeaWindow, pasteImage, generatedImage.src, /* asLayer */ i > 0);
+      await invoke(photopeaWindow, pasteImage, generatedImage.src);
+      // Wait 200ms for pasting to fully complete so that we do not ended up with 2 separate
+      // documents.
+      await new Promise(r => setTimeout(r, 200));
     }
   }
 
@@ -77,7 +79,7 @@
    * Send the images in the active photopea document back to each ControlNet units.
    */
   async function sendToControlNet() {
-    console.log('send to ControlNet');
+
   }
 
   const cnetRegisteredAccordions = new Set();

--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -1,0 +1,33 @@
+(function () {
+  const cnetRegisteredAccordions = new Set();
+  function loadPhotopea() {
+    // Simulate an `input` DOM event for Gradio Textbox component. Needed after 
+    // you edit its contents in javascript, otherwise your edits
+    // will only visible on web page and not sent to python.
+    function updateInput(target) {
+      let e = new Event("input", { bubbles: true })
+      Object.defineProperty(e, "target", { value: target })
+      target.dispatchEvent(e);
+    }
+
+    function registerChildTriggers(accordion) {
+      const photopeaMainTrigger = accordion.querySelector('.cnet-photopea-main-trigger');
+      const tabs = accordion.querySelectorAll('.cnet-unit-tab');
+      tabs.forEach(tab => {
+        const photopeaChildTrigger = tab.querySelector('.cnet-photopea-child-trigger');
+        photopeaChildTrigger.addEventListener('click', () => {
+          photopeaMainTrigger.click();
+        });
+      });
+    }
+
+    const accordions = gradioApp().querySelectorAll('#controlnet');
+    accordions.forEach(accordion => {
+      if (cnetRegisteredAccordions.has(accordion)) return;
+      registerChildTriggers(accordion);
+      cnetRegisteredAccordions.add(accordion);
+    });
+  }
+
+  onUiUpdate(loadPhotopea);
+})();

--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -88,6 +88,25 @@
     return new Blob(byteArrays, { type: contentType });
   }
 
+  function createBlackImageBase64(width, height) {
+    // Create a canvas element
+    var canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+
+    // Get the context of the canvas
+    var ctx = canvas.getContext('2d');
+
+    // Fill the canvas with black color
+    ctx.fillStyle = 'black';
+    ctx.fillRect(0, 0, width, height);
+
+    // Get the base64 encoded string
+    var base64Image = canvas.toDataURL('image/png');
+
+    return base64Image;
+  }
+
   // Functions to be called within photopea context.
   // Start of photopea functions
   function pasteImage(base64image) {
@@ -256,7 +275,15 @@
      * Add those detected maps to the created document.
      */
     async fetchFromControlNet(tabs) {
-      const layerNames = [];
+      if (tabs.length === 0) return;
+      const isImg2Img = tabs[0].querySelector('.cnet-unit-enabled').id.includes('img2img');
+      const generationType = isImg2Img ? 'img2img' : 'txt2img';
+      const width = gradioApp().querySelector(`#${generationType}_width input[type=number]`).value;
+      const height = gradioApp().querySelector(`#${generationType}_height input[type=number]`).value;
+
+      const layerNames = ["background"];
+      await this.invoke(pasteImage, createBlackImageBase64(width, height));
+      await new Promise(r => setTimeout(r, 200));
       for (const [i, tab] of tabs.entries()) {
         const generatedImage = tab.querySelector('.cnet-generated-image-group .cnet-image img');
         if (!generatedImage) continue;

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -323,8 +323,8 @@ class Script(scripts.Script, metaclass=(
         max_models = shared.opts.data.get("control_net_unit_count", 3)
         elem_id_tabname = ("img2img" if is_img2img else "txt2img") + "_controlnet"
         with gr.Group(elem_id=elem_id_tabname):
-            photopea = Photopea()
             with gr.Accordion(f"ControlNet {controlnet_version.version_flag}", open = False, elem_id="controlnet"):
+                photopea = Photopea()
                 if max_models > 1:
                     with gr.Tabs(elem_id=f"{elem_id_tabname}_tabs"):
                         for i in range(max_models):

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -22,6 +22,7 @@ from scripts.utils import load_state_dict, get_unique_axis0
 from scripts.hook import ControlParams, UnetHook, HackedImageRNG
 from scripts.enums import ControlModelType, StableDiffusionVersion
 from scripts.controlnet_ui.controlnet_ui_group import ControlNetUiGroup, UiControlNetUnit
+from scripts.controlnet_ui.photopea import Photopea
 from scripts.logging import logger
 from modules.processing import StableDiffusionProcessingImg2Img, StableDiffusionProcessingTxt2Img
 from modules.images import save_image
@@ -261,10 +262,11 @@ class Script(scripts.Script, metaclass=(
             model="None"
         )
 
-    def uigroup(self, tabname: str, is_img2img: bool, elem_id_tabname: str) -> Tuple[ControlNetUiGroup, gr.State]:
+    def uigroup(self, tabname: str, is_img2img: bool, elem_id_tabname: str, photopea: Photopea) -> Tuple[ControlNetUiGroup, gr.State]:
         group = ControlNetUiGroup(
             Script.get_default_ui_unit(),
             self.preprocessor,
+            photopea,
         )
         group.render(tabname, elem_id_tabname, is_img2img)
         group.register_callbacks(is_img2img)
@@ -321,18 +323,19 @@ class Script(scripts.Script, metaclass=(
         max_models = shared.opts.data.get("control_net_unit_count", 3)
         elem_id_tabname = ("img2img" if is_img2img else "txt2img") + "_controlnet"
         with gr.Group(elem_id=elem_id_tabname):
+            photopea = Photopea()
             with gr.Accordion(f"ControlNet {controlnet_version.version_flag}", open = False, elem_id="controlnet"):
                 if max_models > 1:
                     with gr.Tabs(elem_id=f"{elem_id_tabname}_tabs"):
                         for i in range(max_models):
                             with gr.Tab(f"ControlNet Unit {i}", 
                                         elem_classes=['cnet-unit-tab']):
-                                group, state = self.uigroup(f"ControlNet-{i}", is_img2img, elem_id_tabname)
+                                group, state = self.uigroup(f"ControlNet-{i}", is_img2img, elem_id_tabname, photopea)
                                 ui_groups.append(group)
                                 controls.append(state)
                 else:
                     with gr.Column():
-                        group, state = self.uigroup(f"ControlNet", is_img2img, elem_id_tabname)
+                        group, state = self.uigroup(f"ControlNet", is_img2img, elem_id_tabname, photopea)
                         ui_groups.append(group)
                         controls.append(state)
                 with gr.Accordion(f"Batch Options", open=False, elem_id="controlnet_batch_options"):

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -220,7 +220,6 @@ class ControlNetUiGroup(object):
                                     visible=True,
                                     elem_classes=["cnet-close-preview"],
                                 )
-                        self.photopea.attach_photopea_output(tabname, self.generated_image)
 
                 with gr.Tab(label="Batch") as self.batch_tab:
                     self.batch_image_dir = gr.Textbox(
@@ -228,6 +227,8 @@ class ControlNetUiGroup(object):
                         placeholder="Leave empty to use img2img batch controlnet input directory",
                         elem_id=f"{elem_id_tabname}_{tabname}_batch_image_dir",
                     )
+
+            self.photopea.attach_photopea_output(self.generated_image)
 
             with gr.Accordion(
                 label="Open New Canvas", visible=False

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -220,6 +220,7 @@ class ControlNetUiGroup(object):
                                     visible=True,
                                     elem_classes=["cnet-close-preview"],
                                 )
+                        self.photopea.attach_photopea_output(tabname, self.generated_image)
 
                 with gr.Tab(label="Batch") as self.batch_tab:
                     self.batch_image_dir = gr.Textbox(

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -9,7 +9,6 @@ from scripts.utils import svg_preprocess
 from scripts import (
     global_state,
     external_code,
-    processor,
     batch_hijack,
 )
 from scripts.processor import (
@@ -24,6 +23,7 @@ from scripts.logging import logger
 from scripts.controlnet_ui.openpose_editor import OpenposeEditor
 from scripts.controlnet_ui.preset import ControlNetPresetUI
 from scripts.controlnet_ui.tool_button import ToolButton
+from scripts.controlnet_ui.photopea import Photopea
 from modules import shared
 from modules.ui_components import FormRow
 
@@ -102,9 +102,11 @@ class ControlNetUiGroup(object):
         self,
         default_unit: external_code.ControlNetUnit,
         preprocessors: List[Callable],
+        photopea: Photopea,
     ):
         self.default_unit = default_unit
         self.preprocessors = preprocessors
+        self.photopea = photopea
         self.webcam_enabled = False
         self.webcam_mirrored = False
 
@@ -209,6 +211,7 @@ class ControlNetUiGroup(object):
                             with gr.Group(
                                 elem_classes=["cnet-generated-image-control-group"]
                             ):
+                                self.photopea.render_child_trigger()
                                 self.openpose_editor.render_edit()
                                 preview_check_elem_id = f"{elem_id_tabname}_{tabname}_controlnet_preprocessor_preview_checkbox"
                                 preview_close_button_js = f"document.querySelector('#{preview_check_elem_id} input[type=\\'checkbox\\']').click();"

--- a/scripts/controlnet_ui/photopea.py
+++ b/scripts/controlnet_ui/photopea.py
@@ -38,7 +38,7 @@ class Photopea(object):
             )
         )
 
-    def attach_photopea_output(tabname: str, generated_image: gr.Image):
+    def attach_photopea_output(self, generated_image: gr.Image):
         """Called in ControlNetUiGroup to attach preprocessor preview image Gradio element
         as the photopea output. If the front-end directly change the img HTML element's src
         to reflect the edited image result from photopea, the backend won't be notified.
@@ -49,17 +49,16 @@ class Photopea(object):
         and has no ability to accept image upload directly.
         
         Arguments:
-            tabname: "ControlNet" or "ControlNet-{i}".
             generated_image: preprocessor result Gradio Image output element.
         
         Returns:
             None
         """
         output = gr.Image(
-            visible=True,
+            visible=False,
             source="upload",
             type="numpy",
-            elem_classes=[f"cnet-photopea-output-{tabname}"],
+            elem_classes=[f"cnet-photopea-output"],
         )
 
         output.upload(

--- a/scripts/controlnet_ui/photopea.py
+++ b/scripts/controlnet_ui/photopea.py
@@ -1,0 +1,33 @@
+import gradio as gr
+
+from scripts.controlnet_ui.modal import ModalInterface
+
+
+PHOTOPEA_URL = "https://www.photopea.com/"
+PHOTOPEA_LOGO = "https://www.photopea.com/promo/icon256.png"
+
+
+class Photopea(object):
+    def __init__(self) -> None:
+        self.modal = None
+        self.triggers = []
+        self.render_editor()
+
+    def render_editor(self):
+        """Render the editor modal."""
+        self.modal = ModalInterface(
+            f'<iframe src="{PHOTOPEA_URL}"></iframe>',
+            open_button_text="Edit",
+            open_button_classes=["cnet-photopea-main-trigger"],
+            open_button_extra_attrs="hidden",
+        ).create_modal(visible=False)
+
+    def render_child_trigger(self):
+        self.triggers.append(
+            gr.HTML(
+                f"""<div class="cnet-photopea-child-trigger">
+                Edit
+                <img src="{PHOTOPEA_LOGO}" style="width: 0.75rem; height 0.75rem; margin-left: 2px;"/>
+            </div>"""
+            )
+        )

--- a/scripts/controlnet_ui/photopea.py
+++ b/scripts/controlnet_ui/photopea.py
@@ -20,12 +20,12 @@ class Photopea(object):
             open_button_text="Edit",
             open_button_classes=["cnet-photopea-main-trigger"],
             open_button_extra_attrs="hidden",
-        ).create_modal(visible=False)
+        ).create_modal(visible=True)
 
     def render_child_trigger(self):
         self.triggers.append(
             gr.HTML(
-                f"""<div class="cnet-photopea-child-trigger">
+            f"""<div class="cnet-photopea-child-trigger">
                 Edit
                 <img src="{PHOTOPEA_LOGO}" style="width: 0.75rem; height 0.75rem; margin-left: 2px;"/>
             </div>"""

--- a/scripts/controlnet_ui/photopea.py
+++ b/scripts/controlnet_ui/photopea.py
@@ -15,18 +15,19 @@ class Photopea(object):
 
     def render_editor(self):
         """Render the editor modal."""
-        self.modal = ModalInterface(
-            f"""
-            <div class="photopea-button-group">
-                <button class="photopea-button photopea-fetch">Fetch from ControlNet</button>
-                <button class="photopea-button photopea-send">Send to ControlNet</button>
-            </div>
-            <iframe class="photopea-iframe" src="{PHOTOPEA_URL}"></iframe>
-            """,
-            open_button_text="Edit",
-            open_button_classes=["cnet-photopea-main-trigger"],
-            open_button_extra_attrs="hidden",
-        ).create_modal(visible=True)
+        with gr.Group(elem_classes=["cnet-photopea-edit"]):
+            self.modal = ModalInterface(
+                f"""
+                <div class="photopea-button-group">
+                    <button class="photopea-button photopea-fetch">Fetch from ControlNet</button>
+                    <button class="photopea-button photopea-send">Send to ControlNet</button>
+                </div>
+                <iframe class="photopea-iframe" src="{PHOTOPEA_URL}"></iframe>
+                """,
+                open_button_text="Edit",
+                open_button_classes=["cnet-photopea-main-trigger"],
+                open_button_extra_attrs="hidden",
+            ).create_modal(visible=True)
 
     def render_child_trigger(self):
         self.triggers.append(

--- a/scripts/controlnet_ui/photopea.py
+++ b/scripts/controlnet_ui/photopea.py
@@ -31,9 +31,39 @@ class Photopea(object):
     def render_child_trigger(self):
         self.triggers.append(
             gr.HTML(
-            f"""<div class="cnet-photopea-child-trigger">
+                f"""<div class="cnet-photopea-child-trigger">
                 Edit
                 <img src="{PHOTOPEA_LOGO}" style="width: 0.75rem; height 0.75rem; margin-left: 2px;"/>
             </div>"""
             )
+        )
+
+    def attach_photopea_output(tabname: str, generated_image: gr.Image):
+        """Called in ControlNetUiGroup to attach preprocessor preview image Gradio element
+        as the photopea output. If the front-end directly change the img HTML element's src
+        to reflect the edited image result from photopea, the backend won't be notified.
+
+        In this method we let the front-end upload the result image an invisible gr.Image
+        instance and mirrors the value to preprocessor preview gr.Image. This is because
+        the generated image gr.Image instance is inferred to be an output image by Gradio
+        and has no ability to accept image upload directly.
+        
+        Arguments:
+            tabname: "ControlNet" or "ControlNet-{i}".
+            generated_image: preprocessor result Gradio Image output element.
+        
+        Returns:
+            None
+        """
+        output = gr.Image(
+            visible=True,
+            source="upload",
+            type="numpy",
+            elem_classes=[f"cnet-photopea-output-{tabname}"],
+        )
+
+        output.upload(
+            fn=lambda img: img,
+            inputs=[output],
+            outputs=[generated_image],
         )

--- a/scripts/controlnet_ui/photopea.py
+++ b/scripts/controlnet_ui/photopea.py
@@ -16,7 +16,13 @@ class Photopea(object):
     def render_editor(self):
         """Render the editor modal."""
         self.modal = ModalInterface(
-            f'<iframe src="{PHOTOPEA_URL}"></iframe>',
+            f"""
+            <div class="photopea-button-group">
+                <button class="photopea-button photopea-fetch">Fetch from ControlNet</button>
+                <button class="photopea-button photopea-send">Send to ControlNet</button>
+            </div>
+            <iframe class="photopea-iframe" src="{PHOTOPEA_URL}"></iframe>
+            """,
             open_button_text="Edit",
             open_button_classes=["cnet-photopea-main-trigger"],
             open_button_extra_attrs="hidden",

--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@
     /* 15% from the top and centered */
     padding: 20px;
     border: 1px solid #888;
-    width: 80%;
+    width: 95%;
     height: 90vh;
     /* Could be more or less, depending on screen size */
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
@@ -157,4 +157,9 @@
     opacity: 0;
     width: 100%;
     height: 100%;
+}
+
+.photopea-button-group {
+    position: absolute;
+    top: -22px; /* 20px modal padding + 2px margin */
 }

--- a/style.css
+++ b/style.css
@@ -159,7 +159,20 @@
     height: 100%;
 }
 
+/* Photopea integration styles */
 .photopea-button-group {
     position: absolute;
-    top: -22px; /* 20px modal padding + 2px margin */
+    top: -30px; /* 20px modal padding + 10px margin */
+}
+
+.photopea-button {
+    font-size: 3rem;
+    font-weight: bold;
+    padding: 2px !important;
+    margin: 2px !important;
+    box-shadow: var(--shadow-drop);
+    border: 1px solid var(--button-secondary-border-color);
+    border-radius: var(--radius-sm);
+    background: var(--background-fill-primary);
+    color: var(--block-label-text-color);
 }

--- a/style.css
+++ b/style.css
@@ -86,7 +86,8 @@
 .cnet-download-pose a,
 .cnet-close-preview,
 .cnet-edit-pose,
-.cnet-upload-pose {
+.cnet-upload-pose,
+.cnet-photopea-child-trigger {
     font-size: x-small !important;
     font-weight: bold !important;
     padding: 2px !important;
@@ -104,7 +105,8 @@
 .cnet-download-pose:hover a,
 .cnet-close-preview:hover a,
 .cnet-edit-pose:hover,
-.cnet-upload-pose:hover {
+.cnet-upload-pose:hover,
+.cnet-photopea-child-trigger:hover {
     color: var(--block-label-text-color) !important;
 }
 


### PR DESCRIPTION
Closes #1736.
Provides better experience on https://github.com/Mikubill/sd-webui-controlnet/issues/2148.

How to use it during inpaint:
Task, generate a necklace on the girl's neck with a specific shape.
Step1: Draw inpaint mask.
![s1 (1)](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/7d945067-71b7-4b2f-bd37-215c55f3326d)
Step2: Upload necklace image and preprocess with canny.
![s2 (1)](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/4586e462-de4c-4981-ae96-680515934ffe)
Step3: Click `Edit` on generated preprocessor image. A photopea editor modal will popup. The preprocessor image will be fetched from controlnet and paste in the editor automatically.
![s3 (1)](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/d0087a39-abe0-4dc8-8279-b02390112e0e)
Step4: Align the position of the necklace canny edge map to desired location.
![s4 (1)](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/85da33a1-856a-4ecc-b159-ff519bdefefd)
Step5: Click `Send to ControlNet` on the top left corner of the modal to update the canny edge map used by ControlNet.
![s5](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/20214cd2-a58f-4a80-ae4f-4fe5719a50c9)
Step6: Generate.
![s6](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/ce0cb883-2925-41ee-946b-0097ccdc4564)
