### PR TITLE
:loud_sound: Add tracemalloc to track memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ This extension adds these command line arguments to the webui:
     --no-half-controlnet                                                                       load controlnet models in full precision
     --controlnet-preprocessor-cache-size                                                       Cache size for controlnet preprocessor results
     --controlnet-loglevel                                                                      Log level for the controlnet extension
+    --controlnet-tracemalloc                                                                   Enable malloc memory tracing
 ```
 
 # MacOS Support

--- a/preload.py
+++ b/preload.py
@@ -31,3 +31,9 @@ def preload(parser):
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Set the log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
     )
+    parser.add_argument(
+        "--controlnet-tracemalloc",
+        action="store_true",
+        help="Enable memory tracing.",
+        default=None,
+    )


### PR DESCRIPTION
https://github.com/Mikubill/sd-webui-controlnet/issues/990

This PR adds support to log malloc memory usage breakdown on each generation. This feature is guarded behind commandline flag `--controlnet-tracemalloc`.

Sample output:
```
2023-12-30 22:26:26,381 - ControlNet - DEBUG - controlnet_main_entry ran in: 5.299 sec
2023-12-30 22:26:26,382 - ControlNet - INFO - After hook malloc:
2023-12-30 22:26:26,505 - ControlNet - INFO - D:\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\controlnet.py:460: size=1536 KiB (+1536 KiB), count=4 (+4), average=384 KiB
2023-12-30 22:26:26,506 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:468: size=189 KiB (+189 KiB), count=995 (+995), average=195 B
2023-12-30 22:26:26,507 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:461: size=179 KiB (+179 KiB), count=847 (+847), average=216 B
2023-12-30 22:26:26,507 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:1622: size=156 KiB (+156 KiB), count=144 (+144), average=1112 B
2023-12-30 22:26:26,507 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:458: size=148 KiB (+148 KiB), count=1333 (+1333), average=114 B
2023-12-30 22:26:26,508 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:473: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
2023-12-30 22:26:26,509 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:472: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
2023-12-30 22:26:26,509 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:471: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
2023-12-30 22:26:26,510 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:470: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
2023-12-30 22:26:26,510 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:469: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
2023-12-30 22:26:26,511 - ControlNet - INFO - ControlNet Hooked - Time = 5.428318023681641
2023-12-30 22:26:26,511 - ControlNet - DEBUG - controlnet_hack ran in: 5.428 sec
2023-12-30 22:26:26,511 - ControlNet - DEBUG - process ran in: 5.428 sec
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [01:00<00:00,  3.02s/it]
2023-12-30 22:27:29,567 - ControlNet - INFO - After generation:███████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [00:57<00:00,  2.97s/it]
2023-12-30 22:27:29,689 - ControlNet - INFO - D:\stable-diffusion-webui\modules\processing.py:908: size=768 KiB (+768 KiB), count=2 (+2), average=384 KiB
2023-12-30 22:27:29,690 - ControlNet - INFO - D:\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\controlnet.py:1150: size=768 KiB (+768 KiB), count=2 (+2), average=384 KiB
2023-12-30 22:27:29,690 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:468: size=189 KiB (+189 KiB), count=995 (+995), average=195 B
2023-12-30 22:27:29,691 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:461: size=179 KiB (+179 KiB), count=847 (+847), average=216 B
2023-12-30 22:27:29,691 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:1622: size=156 KiB (+156 KiB), count=144 (+144), average=1112 B
2023-12-30 22:27:29,692 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:458: size=148 KiB (+148 KiB), count=1333 (+1333), average=114 B
2023-12-30 22:27:29,692 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:473: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
2023-12-30 22:27:29,693 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:472: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
2023-12-30 22:27:29,693 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:471: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
2023-12-30 22:27:29,693 - ControlNet - INFO - d:\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py:470: size=106 KiB (+106 KiB), count=847 (+847), average=128 B
```