### PR TITLE
:sparkles: Control inpaint crop per ControlNet unit

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -167,6 +167,9 @@ class ControlNetUnit:
     guidance_end: float = 1.0
     pixel_perfect: bool = False
     control_mode: Union[ControlMode, int, str] = ControlMode.BALANCED
+    # Whether to crop input image based on A1111 img2img mask. This flag is only used when `inpaint area`
+    # in A1111 is set to `Only masked`. In API, this correspond to `inpaint_full_res = True`.
+    inpaint_crop_input_image: bool = True
     
     # Whether save the detected map of this unit. Setting this option to False prevents saving the
     # detected map or sending detected map along with generated images via API.

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -794,10 +794,7 @@ class Script(scripts.Script, metaclass=(
             # based on `extra_generation_params` these scripts attach on `p`, and subject to change
             # in the future.
             # TODO: Change this to a more robust condition once A1111 offers a way to verify script name.
-            is_upscale_script = (
-                any("upscale" in k.lower() for k in getattr(p, "extra_generation_params", {}).keys()) or
-                not shared.opts.data.get("controlnet_crop_upscale_script_only", True)
-            )
+            is_upscale_script = any("upscale" in k.lower() for k in getattr(p, "extra_generation_params", {}).keys())
             logger.debug(f"is_upscale_script={is_upscale_script}")
             # Note: `inpaint_full_res` is "inpaint area" on UI. The flag is `True` when "Only masked"
             # option is selected.
@@ -809,7 +806,11 @@ class Script(scripts.Script, metaclass=(
             # Crop ControlNet input image based on A1111 inpaint mask given.
             # This logic is crutial in upscale scripts, as they use A1111 mask + inpaint_full_res 
             # to crop tiles.
-            if 'reference' not in unit.module and is_only_masked_inpaint and is_upscale_script:
+            if (
+                'reference' not in unit.module
+                and is_only_masked_inpaint
+                and (is_upscale_script or unit.inpaint_crop_input_image)
+            ):
                 logger.debug("A1111 inpaint mask START")
                 input_image = [input_image[:, :, i] for i in range(input_image.shape[2])]
                 input_image = [Image.fromarray(x) for x in input_image]
@@ -1230,10 +1231,6 @@ def on_ui_settings():
         False, "Disable openpose edit", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_ignore_noninpaint_mask", shared.OptionInfo(
         False, "Ignore mask on ControlNet input image if control type is not inpaint", 
-        gr.Checkbox, {"interactive": True}, section=section))
-    shared.opts.add_option("controlnet_crop_upscale_script_only", shared.OptionInfo(
-        False, "Crop ControlNet input image only when invoking upscale script."
-        "(If not chekced, ControlNet input image will also be cropped when invoking inpaint with inpaint area set to 'Only masked')",
         gr.Checkbox, {"interactive": True}, section=section))
 
 

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -335,8 +335,7 @@ class ControlNetUiGroup(object):
             # Note: The checkbox needs to exist for both img2img and txt2img as infotext
             # needs the checkbox value.
             self.inpaint_crop_input_image = gr.Checkbox(
-                label="Crop Input Image",
-                info="Crop input image based on A1111 mask.",
+                label="Crop input image based on A1111 mask",
                 value=False,
                 elem_classes=["cnet-crop-input-image"],
                 visible=False,

--- a/scripts/infotext.py
+++ b/scripts/infotext.py
@@ -29,11 +29,20 @@ def parse_value(value: str) -> Union[str, float, int, bool]:
 
 
 def serialize_unit(unit: external_code.ControlNetUnit) -> str:
-    # Note: "advanced weighting" is excluded as it is an API-only field.
+    excluded_fields = (
+        "image",
+        "enabled",
+        # Note: "advanced_weighting" is excluded as it is an API-only field.
+        "advanced_weighting",
+        # Note: "inpaint_crop_image" is img2img inpaint only flag, which does not
+        # provide much information when restoring the unit.
+        "inpaint_crop_input_image",
+    )
+    
     log_value = {
         field_to_displaytext(field): getattr(unit, field)
         for field in vars(external_code.ControlNetUnit()).keys()
-        if field not in ("image", "enabled", "advanced_weighting") and getattr(unit, field) != -1
+        if field not in excluded_fields and getattr(unit, field) != -1
         # Note: exclude hidden slider values.
     }
     if not all("," not in str(v) and ":" not in str(v) for v in log_value.values()):


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2369.

This PR adds a new checkbox to control whether the ControlNet input image should be cropped to A1111 mask or not.

The checkbox is only visible if the user
- in img2img inpaint tab
- have inpaint area set to masked only
- check upload independent control image

