### PR TITLE
:sparkles: Add hr_option (Both, High res only, Low res only)

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -7,6 +7,7 @@ from modules import scripts, processing, shared
 from scripts import global_state
 from scripts.processor import preprocessor_sliders_config, model_free_preprocessors
 from scripts.logging import logger
+from scripts.enums import HiResFixOption
 
 from modules.api import api
 
@@ -170,6 +171,9 @@ class ControlNetUnit:
     # Whether to crop input image based on A1111 img2img mask. This flag is only used when `inpaint area`
     # in A1111 is set to `Only masked`. In API, this correspond to `inpaint_full_res = True`.
     inpaint_crop_input_image: bool = True
+    # If hires fix is enabled in A1111, how should this ControlNet unit be applied.
+    # The value is ignored if the generation is not using hires fix.
+    hr_option: Union[HiResFixOption, int, str] = HiResFixOption.BOTH
     
     # Whether save the detected map of this unit. Setting this option to False prevents saving the
     # detected map or sending detected map along with generated images via API.

--- a/javascript/active_units.js
+++ b/javascript/active_units.js
@@ -74,6 +74,7 @@
                 this.controlTypeRadios = tab.querySelectorAll('.controlnet_control_type_filter_group input[type="radio"]');
                 this.resizeModeRadios = tab.querySelectorAll('.controlnet_resize_mode_radio input[type="radio"]');
                 this.runPreprocessorButton = tab.querySelector('.cnet-run-preprocessor');
+                this.hrOptionRadioGroup = tab.querySelector('.controlnet_hr_option_radio ');
 
                 const tabs = tab.parentNode;
                 this.tabNav = tabs.querySelector('.tab-nav');
@@ -85,6 +86,7 @@
                 this.attachImageUploadListener();
                 this.attachImageStateChangeObserver();
                 this.attachA1111SendInfoObserver();
+                this.attachA1111HrObserver();
                 this.attachPresetDropdownObserver();
             }
 
@@ -278,6 +280,22 @@
                         }, 2000);
                     });
                 }
+            }
+
+            attachA1111HrObserver() {
+                if (this.isImg2Img) return;
+                
+                const hr_checkbox = gradioApp().querySelector('#txt2img_hr-visible-checkbox');
+                hr_checkbox.addEventListener('change', () => {
+                    if (hr_checkbox.checked) {
+                        this.hrOptionRadioGroup.removeAttribute('hidden');
+                    } else {
+                        this.hrOptionRadioGroup.setAttribute('hidden', '');
+                    }
+                });
+                
+                // Hide initially as hr is disabled by default.
+                this.hrOptionRadioGroup.setAttribute('hidden', '');
             }
 
             attachPresetDropdownObserver() {

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -19,7 +19,7 @@ from scripts.controlnet_lllite import PlugableControlLLLite, clear_all_lllite
 from scripts.controlmodel_ipadapter import PlugableIPAdapter, clear_all_ip_adapter
 from scripts.utils import load_state_dict, get_unique_axis0
 from scripts.hook import ControlParams, UnetHook, HackedImageRNG
-from scripts.enums import ControlModelType, StableDiffusionVersion
+from scripts.enums import ControlModelType, StableDiffusionVersion, HiResFixOption
 from scripts.controlnet_ui.controlnet_ui_group import ControlNetUiGroup, UiControlNetUnit
 from scripts.controlnet_ui.photopea import Photopea
 from scripts.logging import logger
@@ -956,6 +956,7 @@ class Script(scripts.Script, metaclass=(
                 control_model_type=control_model_type,
                 global_average_pooling=global_average_pooling,
                 hr_hint_cond=hr_control,
+                hr_option=HiResFixOption.from_value(unit.hr_option) if high_res_fix else HiResFixOption.BOTH,
                 soft_injection=control_mode != external_code.ControlMode.BALANCED,
                 cfg_injection=control_mode == external_code.ControlMode.CONTROL,
             )
@@ -1213,8 +1214,6 @@ def on_ui_settings():
         1, "Model cache size (requires restart)", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}, section=section))
     shared.opts.add_option("control_net_inpaint_blur_sigma", shared.OptionInfo(
         7, "ControlNet inpainting Gaussian blur sigma", gr.Slider, {"minimum": 0, "maximum": 64, "step": 1}, section=section))
-    shared.opts.add_option("control_net_no_high_res_fix", shared.OptionInfo(
-        False, "Do not apply ControlNet during highres fix", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_no_detectmap", shared.OptionInfo(
         False, "Do not append detectmap to output", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("control_net_detectmap_autosaving", shared.OptionInfo(

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -157,6 +157,7 @@ class ControlNetUiGroup(object):
         self.save_detected_map = None
         self.input_mode = gr.State(batch_hijack.InputMode.SIMPLE)
         self.inpaint_crop_input_image = None
+        self.hr_option = None
 
         # Internal states for UI state pasting.
         self.prevent_next_n_module_update = 0
@@ -449,6 +450,15 @@ class ControlNetUiGroup(object):
             label="Resize Mode",
             elem_id=f"{elem_id_tabname}_{tabname}_controlnet_resize_mode_radio",
             elem_classes="controlnet_resize_mode_radio",
+            visible=not is_img2img,
+        )
+        
+        self.hr_option = gr.Radio(
+            choices=[e.value for e in external_code.HiResFixOption],
+            value=self.default_unit.hr_option.value,
+            label="Hires-Fix Option",
+            elem_id=f"{elem_id_tabname}_{tabname}_controlnet_hr_option_radio",
+            elem_classes="controlnet_hr_option_radio",
             visible=not is_img2img,
         )
 
@@ -943,6 +953,7 @@ class ControlNetUiGroup(object):
             self.pixel_perfect,
             self.control_mode,
             self.inpaint_crop_input_image,
+            self.hr_option,
         )
 
         self.image.preprocess = functools.partial(

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Any
 
 
 class StableDiffusionVersion(Enum):
@@ -69,3 +70,19 @@ class AutoMachine(Enum):
     Read = "Read"
     Write = "Write"
     StyleAlign = "StyleAlign"
+
+
+class HiResFixOption(Enum):
+    BOTH = "Both"
+    LOW_RES_ONLY = "Low res only"
+    HIGH_RES_ONLY = "High res only"
+
+    @staticmethod
+    def from_value(value: Any) -> "HiResFixOption":
+        if isinstance(value, str):
+            return HiResFixOption(value)
+        elif isinstance(value, int):
+            return [x for x in HiResFixOption][value]
+        else:
+            assert isinstance(value, HiResFixOption)
+            return value


### PR DESCRIPTION
Closes #2378.

This PR removes global option `control_net_no_high_res_fix`, and adds the radio selection for hr option per ControlNet unit.