### PR TITLE
:bug: Replace 3.10 match statement

### DIFF
--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -27,16 +27,11 @@ class StableDiffusionVersion(Enum):
         return StableDiffusionVersion.UNKNOWN
 
     def encoder_block_num(self) -> int:
-        match self:
-            case StableDiffusionVersion.SD1x:
-                return 12
-            case StableDiffusionVersion.SD2x:
-                return 12
-            case StableDiffusionVersion.SDXL:
-                return 9
-            case StableDiffusionVersion.UNKNOWN:
-                return 12
-
+        if self in (StableDiffusionVersion.SD1x, StableDiffusionVersion.SD2x, StableDiffusionVersion.UNKNOWN):
+            return 12
+        else:
+            return 9 # SDXL
+            
     def controlnet_layer_num(self) -> int:
         return self.encoder_block_num() + 1
 

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -207,15 +207,14 @@ class ControlParams:
         self.used_hint_inpaint_hijack = None
     
     def disabled_by_hr_option(self, is_in_high_res_fix: bool) -> bool:
-        match self.hr_option:
-            case HiResFixOption.BOTH:
-                control_disabled = False
-            case HiResFixOption.LOW_RES_ONLY:
-                control_disabled = is_in_high_res_fix
-            case HiResFixOption.HIGH_RES_ONLY:
-                control_disabled = not is_in_high_res_fix
-            case _:
-                control_disabled = False
+        if self.hr_option == HiResFixOption.BOTH:
+            control_disabled = False
+        elif self.hr_option == HiResFixOption.LOW_RES_ONLY:
+            control_disabled = is_in_high_res_fix
+        elif self.hr_option == HiResFixOption.HIGH_RES_ONLY:
+            control_disabled = not is_in_high_res_fix
+        else:
+            assert False, "NOTREACHED"
         return control_disabled
 
 


### PR DESCRIPTION
Closes #2381.

Replace 3.10 feature match statement with if/else blocks for backward compatibility.