### PR TITLE
Fix anime_face_segment model load

### DIFF
--- a/annotator/anime_face_segment/__init__.py
+++ b/annotator/anime_face_segment/__init__.py
@@ -141,7 +141,7 @@ class AnimeFaceSegment:
             from basicsr.utils.download_util import load_file_from_url
             load_file_from_url(remote_model_path, model_dir=self.model_dir)
         net = UNet()
-        ckpt = torch.load(modelpath)
+        ckpt = torch.load(modelpath, map_location=self.device)
         for key in list(ckpt.keys()):
             if 'module.' in key:
                 ckpt[key.replace('module.', '')] = ckpt[key]


### PR DESCRIPTION
Fixes the following error when using `--use-cpu controlnet` or `--use-ipex` (where CUDA is not available):
```
Traceback (most recent call last):
  File "D:\stable-diffusion-webui\venv\lib\site-packages\gradio\routes.py", line 488, in run_predict
    output = await app.get_blocks().process_api(
  File "D:\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1431, in process_api
    result = await self.call_function(
  File "D:\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1103, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "D:\stable-diffusion-webui\venv\lib\site-packages\anyio\to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "D:\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "D:\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "D:\stable-diffusion-webui\venv\lib\site-packages\gradio\utils.py", line 707, in wrapper
    response = f(*args, **kwargs)
  File "D:\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\controlnet_ui\controlnet_ui_group.py", line 694, in run_annotator
    result, is_image = preprocessor(
  File "D:\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\utils.py", line 75, in decorated_func
    return cached_func(*args, **kwargs)
  File "D:\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\utils.py", line 63, in cached_func
    return func(*args, **kwargs)
  File "D:\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\global_state.py", line 37, in unified_preprocessor
    return preprocessor_modules[preprocessor_name](*args, **kwargs)
  File "D:\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\processor.py", line 633, in anime_face_segment
    result = model_anime_face_segment(img)
  File "D:\stable-diffusion-webui\extensions\sd-webui-controlnet\annotator\anime_face_segment\__init__.py", line 160, in __call__
    self.load_model()
  File "D:\stable-diffusion-webui\extensions\sd-webui-controlnet\annotator\anime_face_segment\__init__.py", line 144, in load_model
    ckpt = torch.load(modelpath)
  File "D:\stable-diffusion-webui\modules\safe.py", line 108, in load
    return load_with_extra(filename, *args, extra_handler=global_extra_handler, **kwargs)
  File "D:\stable-diffusion-webui\modules\safe.py", line 156, in load_with_extra
    return unsafe_torch_load(filename, *args, **kwargs)
  File "D:\stable-diffusion-webui\venv\lib\site-packages\torch\serialization.py", line 809, in load
    return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
  File "D:\stable-diffusion-webui\venv\lib\site-packages\torch\serialization.py", line 1172, in _load
    result = unpickler.load()
  File "C:\Users\vfirs\miniconda3\lib\pickle.py", line 1213, in load
    dispatch[key[0]](self)
  File "C:\Users\vfirs\miniconda3\lib\pickle.py", line 1254, in load_binpersid
    self.append(self.persistent_load(pid))
  File "D:\stable-diffusion-webui\venv\lib\site-packages\torch\serialization.py", line 1142, in persistent_load
    typed_storage = load_tensor(dtype, nbytes, key, _maybe_decode_ascii(location))
  File "D:\stable-diffusion-webui\venv\lib\site-packages\torch\serialization.py", line 1116, in load_tensor
    wrap_storage=restore_location(storage, location),
  File "D:\stable-diffusion-webui\venv\lib\site-packages\torch\serialization.py", line 217, in default_restore_location
    result = fn(storage, location)
  File "D:\stable-diffusion-webui\venv\lib\site-packages\torch\serialization.py", line 182, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "D:\stable-diffusion-webui\venv\lib\site-packages\torch\serialization.py", line 166, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```