### PR TITLE
:sparkles: Hand refiner preprocessor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "annotator/hand_refiner_portable"]
+	path = annotator/hand_refiner_portable
+	url = https://github.com/huchenlei/HandRefinerPortable

--- a/install.py
+++ b/install.py
@@ -1,12 +1,18 @@
 import launch
+import subprocess
 import pkg_resources
 from pathlib import Path
 from typing import Tuple, Optional
+    
 
-main_req_file = Path(__file__).parent / "requirements.txt"
-hand_refiner_req_file = (
-    Path(__file__).parent / "annotator" / "hand_refiner_portable" / "requirements.txt"
-)
+repo_root = Path(__file__).parent
+main_req_file = repo_root / "requirements.txt"
+hand_refiner_req_file = repo_root / "annotator" / "hand_refiner_portable" / "requirements.txt"
+
+
+def sync_submodules():
+    subprocess.run(['git', 'submodule', 'init'], check=True, cwd=repo_root)
+    subprocess.run(['git', 'submodule', 'update'], check=True, cwd=repo_root)
 
 
 def comparable_version(version: str) -> Tuple:
@@ -55,5 +61,6 @@ def install_requirements(req_file):
                 )
 
 
+sync_submodules()
 install_requirements(main_req_file)
 install_requirements(hand_refiner_req_file)

--- a/install.py
+++ b/install.py
@@ -1,14 +1,17 @@
 import launch
-import os
 import pkg_resources
+from pathlib import Path
 from typing import Tuple, Optional
 
-req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
+main_req_file = Path(__file__).parent / "requirements.txt"
+hand_refiner_req_file = (
+    Path(__file__).parent / "annotator" / "hand_refiner_portable" / "requirements.txt"
+)
 
 
 def comparable_version(version: str) -> Tuple:
-    return tuple(version.split('.'))
-    
+    return tuple(version.split("."))
+
 
 def get_installed_version(package: str) -> Optional[str]:
     try:
@@ -17,22 +20,40 @@ def get_installed_version(package: str) -> Optional[str]:
         return None
 
 
-with open(req_file) as file:
-    for package in file:
-        try:
-            package = package.strip()
-            if '==' in package:
-                package_name, package_version = package.split('==')
-                installed_version = get_installed_version(package_name)
-                if installed_version != package_version:
-                    launch.run_pip(f"install -U {package}", f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}")
-            elif '>=' in package:
-                package_name, package_version = package.split('>=')
-                installed_version = get_installed_version(package_name)
-                if not installed_version or comparable_version(installed_version) < comparable_version(package_version):
-                    launch.run_pip(f"install -U {package}", f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}")
-            elif not launch.is_installed(package):
-                launch.run_pip(f"install {package}", f"sd-webui-controlnet requirement: {package}")
-        except Exception as e:
-            print(e)
-            print(f'Warning: Failed to install {package}, some preprocessors may not work.')
+def install_requirements(req_file):
+    with open(req_file) as file:
+        for package in file:
+            try:
+                package = package.strip()
+                if "==" in package:
+                    package_name, package_version = package.split("==")
+                    installed_version = get_installed_version(package_name)
+                    if installed_version != package_version:
+                        launch.run_pip(
+                            f"install -U {package}",
+                            f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}",
+                        )
+                elif ">=" in package:
+                    package_name, package_version = package.split(">=")
+                    installed_version = get_installed_version(package_name)
+                    if not installed_version or comparable_version(
+                        installed_version
+                    ) < comparable_version(package_version):
+                        launch.run_pip(
+                            f"install -U {package}",
+                            f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}",
+                        )
+                elif not launch.is_installed(package):
+                    launch.run_pip(
+                        f"install {package}",
+                        f"sd-webui-controlnet requirement: {package}",
+                    )
+            except Exception as e:
+                print(e)
+                print(
+                    f"Warning: Failed to install {package}, some preprocessors may not work."
+                )
+
+
+install_requirements(main_req_file)
+install_requirements(hand_refiner_req_file)

--- a/install.py
+++ b/install.py
@@ -3,16 +3,18 @@ import subprocess
 import pkg_resources
 from pathlib import Path
 from typing import Tuple, Optional
-    
+
 
 repo_root = Path(__file__).parent
 main_req_file = repo_root / "requirements.txt"
-hand_refiner_req_file = repo_root / "annotator" / "hand_refiner_portable" / "requirements.txt"
+hand_refiner_req_file = (
+    repo_root / "annotator" / "hand_refiner_portable" / "requirements.txt"
+)
 
 
 def sync_submodules():
-    subprocess.run(['git', 'submodule', 'init'], check=True, cwd=repo_root)
-    subprocess.run(['git', 'submodule', 'update'], check=True, cwd=repo_root)
+    subprocess.run(["git", "submodule", "init"], check=True, cwd=repo_root)
+    subprocess.run(["git", "submodule", "update"], check=True, cwd=repo_root)
 
 
 def comparable_version(version: str) -> Tuple:

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -54,7 +54,7 @@ cn_preprocessor_modules = {
     "depth": midas,
     "depth_leres": functools.partial(leres, boost=False),
     "depth_leres++": functools.partial(leres, boost=True),
-    "depth_hand_refiner": hand_refiner,
+    "depth_hand_refiner": g_hand_refiner_model.run_model,
     "hed": hed,
     "hed_safe": hed_safe,
     "mediapipe_face": mediapipe_face,
@@ -139,7 +139,7 @@ cn_preprocessor_unloadable = {
     "lineart_anime_denoise": unload_lineart_anime_denoise,
     "inpaint_only+lama": unload_lama_inpaint,
     "anime_face_segment": unload_anime_face_segment,
-    "depth_hand_refiner": unload_hand_refiner,
+    "depth_hand_refiner": g_hand_refiner_model.unload,
 }
 
 preprocessor_aliases = {

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -54,6 +54,7 @@ cn_preprocessor_modules = {
     "depth": midas,
     "depth_leres": functools.partial(leres, boost=False),
     "depth_leres++": functools.partial(leres, boost=True),
+    "depth_hand_refiner": hand_refiner,
     "hed": hed,
     "hed_safe": hed_safe,
     "mediapipe_face": mediapipe_face,
@@ -138,6 +139,7 @@ cn_preprocessor_unloadable = {
     "lineart_anime_denoise": unload_lineart_anime_denoise,
     "inpaint_only+lama": unload_lama_inpaint,
     "anime_face_segment": unload_anime_face_segment,
+    "depth_hand_refiner": unload_hand_refiner,
 }
 
 preprocessor_aliases = {

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -670,7 +670,7 @@ def hand_refiner(img, res=512, **kwargs):
             model_hand_refiner = MeshGraphormerDetector.from_pretrained(
                 "hr16/ControlNet-HandRefiner-pruned", 
                 cache_dir=os.path.join(models_path, "hand_refiner"),
-                device="cuda",
+                device="cpu",
             )
 
         depth_map, mask, info = model_hand_refiner(

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -3,7 +3,6 @@ import cv2
 import numpy as np
 
 from annotator.util import HWC3
-from annotator.annotator_path import models_path
 from typing import Callable, Tuple
 
 from modules.safe import Extra
@@ -662,6 +661,7 @@ class HandRefinerModel:
             # Add submodule hand_refiner to sys.path so that it can be discovered correctly.
             import sys
             from pathlib import Path
+            from annotator.annotator_path import models_path
             hand_refiner_path = str(Path(__file__).parent.parent / 'annotator' / 'hand_refiner_portable')
             if hand_refiner_path not in sys.path:
                 sys.path.append(hand_refiner_path)


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2382.

Thanks [Fannovel16](https://github.com/Fannovel16) for his hard work extracting dependencies out for [hand refiner](https://github.com/wenquanlu/HandRefiner) in https://github.com/Fannovel16/comfyui_controlnet_aux/blob/main/src/controlnet_aux.

This PR adds a hand refiner portable submodule that does not need further build/instsall operations. This PR is the first step as discussed in #2382: Adding `depth_hand_refiner` to preprocessor list.

Now you can manually draw the inpaint mask on hands and use a depth ControlNet unit to fix hands with following steps:
## Step 1: Generate an image with bad hand.
![00009-603936670](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/5fb0c91e-df9d-45af-bc96-3a1659c6ad4b)

## Step 2: Switch to img2img inpaint. Draw inpaint mask on hands.
![1704329180304](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/bb821cf3-fb4b-4fa1-ba89-e709421291e6)

## Step 3: Enable ControlNet unit and select `depth_hand_refiner` preprocessor.
![1704329221720](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/2a26f16f-47ef-4c17-bd4b-d72c6746bb20)

## Step 4: Generate
![1704329401241](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/af72ba3a-3a87-4926-8397-7f48f8a77e0f)


TODOs:
- [x] Sync submodule on startup
- [x] Unload module
- [x] Support running on CPU
- [x] Add dependency install script
- [x] Add instructions