### PR TITLE
:wrench: Fix crop input image checkbox visibility

### DIFF
--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -324,7 +324,7 @@ class ControlNetUiGroup(object):
                 visible=False,
             )
 
-        with gr.Row(elem_classes="controlnet_img2img_options"):            
+        with gr.Row(elem_classes="controlnet_img2img_options"):
             if is_img2img:
                 self.upload_independent_img_in_img2img = gr.Checkbox(
                     label="Upload independent control image",
@@ -850,35 +850,33 @@ class ControlNetUiGroup(object):
             ],
             show_progress=False
         )
-    
+
     def register_shift_crop_input_image(self):
         is_inpaint_tab = gr.State(False)
-        
-        def shift_crop_input_image(is_inpaint: bool, inpaint_area: int, independent_control_image: bool):
-            logger.info(str((is_inpaint, inpaint_area, independent_control_image)))
+
+        def shift_crop_input_image(is_inpaint: bool, inpaint_area: int):
             # Note: inpaint_area (0: Whole picture, 1: Only masked)
-            return gr.update(visible=is_inpaint and inpaint_area == 1 and independent_control_image)
+            # By default set value to True, as most preprocessors need cropped result.
+            return gr.update(value=True, visible=is_inpaint and inpaint_area == 1)
 
         gradio_kwargs = dict(
             fn=shift_crop_input_image,
             inputs=[
-                is_inpaint_tab, 
+                is_inpaint_tab,
                 ControlNetUiGroup.img2img_inpaint_area,
-                self.upload_independent_img_in_img2img,
             ],
             outputs=[self.inpaint_crop_input_image],
             show_progress=False,
         )
-        
+
         for elem in ControlNetUiGroup.img2img_inpaint_tabs:
             elem.select(fn=lambda: True, inputs=[], outputs=[is_inpaint_tab])
             elem.select(**gradio_kwargs)
-            
+
         for elem in ControlNetUiGroup.img2img_non_inpaint_tabs:
             elem.select(fn=lambda: False, inputs=[], outputs=[is_inpaint_tab])
             elem.select(**gradio_kwargs)
-            
-        self.upload_independent_img_in_img2img.change(**gradio_kwargs)
+
         ControlNetUiGroup.img2img_inpaint_area.change(**gradio_kwargs)
 
     def register_callbacks(self, is_img2img: bool):
@@ -1125,8 +1123,8 @@ class ControlNetUiGroup(object):
                     outputs=[g.loopback for g in ui_groups],
                     show_progress=False,
                 )
-                
-    
+
+
     @staticmethod
     def on_after_component(component, **_kwargs):
         elem_id = getattr(component, "elem_id", None)
@@ -1170,15 +1168,15 @@ class ControlNetUiGroup(object):
         if elem_id == "img2img_height":
             ControlNetUiGroup.img2img_h_slider = component
             return
-        
+
         if elem_id in (
             "img2img_img2img_tab",
-            "img2img_img2img_sketch_tab",            
+            "img2img_img2img_sketch_tab",
             "img2img_batch_tab",
         ):
             ControlNetUiGroup.img2img_non_inpaint_tabs.append(component)
             return
-        
+
         if elem_id in (
             "img2img_inpaint_tab",
             "img2img_inpaint_sketch_tab",


### PR DESCRIPTION
Closes #2402.
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2403.

This PR makes `Crop input image based on A1111 mask` checkbox show regardless of `Use independent control image` checkbox's state.

This PR also makes the checkbox checked by default, which performs the crop by default (Original behaviour).