### PR TITLE
:wrench: Auto disable photopea edit on confirm alert cancel

### DIFF
--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -394,6 +394,10 @@
       const checkbox = gradioApp().querySelector("#setting_controlnet_disable_photopea_edit input[type=checkbox]");
       if (checkbox && !checkbox.checked) {
         checkbox.click();
+        const applyButton = gradioApp().querySelector("#settings_submit");
+        if (applyButton) {
+          applyButton.click();
+        }
       }
     }
     return confirmed;

--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -382,9 +382,21 @@
       localStorage.setItem("ControlNetPhotopeaEditPrompted", "true");
     }
     const promptMsg = "This is the first time you use photopea edit feature. The preprocess results are " +
-    "going to be send to https://photopea.com for edit. You can disable photopea edit in Settings > ControlNet" +
-    " > Disable photopea edit.";
-    return confirm(promptMsg);
+      "going to be send to https://photopea.com for edit.\n" +
+      "- Click OK: proceed.\n" +
+      "- Click Cancel: abort and disable photopea edit feature.";
+    const confirmed = confirm(promptMsg);
+
+    if (!confirmed) {
+      // Hide all edit buttons in current session.
+      gradioApp().querySelectorAll(".cnet-photopea-child-trigger").forEach(button => button.hidden = true);
+      // Check `Disable photopea edit` in Settings.
+      const checkbox = gradioApp().querySelector("#setting_controlnet_disable_photopea_edit input[type=checkbox]");
+      if (checkbox && !checkbox.checked) {
+        checkbox.click();
+      }
+    }
+    return confirmed;
   }
 
   const cnetRegisteredAccordions = new Set();


### PR DESCRIPTION
![1704487323505](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/7b15f0ef-1d59-471c-b11e-96debe2be6ee)

As requested by @w-e-w, I made disabling the feature easier. Now click cancel will automatically check the checkbox in settings tab, and hide all edit buttons in current session.