### PR TITLE
alternative photopea popup warning

### DIFF
--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -375,32 +375,19 @@
     }
   }
 
-  function firstTimeUserPrompt() {
-    if (localStorage.getItem("ControlNetPhotopeaEditPrompted")) {
-      return true;
-    } else {
-      localStorage.setItem("ControlNetPhotopeaEditPrompted", "true");
-    }
-    const promptMsg = "This is the first time you use photopea edit feature. The preprocess results are " +
-      "going to be send to https://photopea.com for edit.\n" +
-      "- Click OK: proceed.\n" +
-      "- Click Cancel: abort and disable photopea edit feature.";
-    const confirmed = confirm(promptMsg);
+  let photopeaPopupPopupShown = false;
 
-    if (!confirmed) {
-      // Hide all edit buttons in current session.
-      gradioApp().querySelectorAll(".cnet-photopea-child-trigger").forEach(button => button.hidden = true);
-      // Check `Disable photopea edit` in Settings.
-      const checkbox = gradioApp().querySelector("#setting_controlnet_disable_photopea_edit input[type=checkbox]");
-      if (checkbox && !checkbox.checked) {
-        checkbox.click();
-        const applyButton = gradioApp().querySelector("#settings_submit");
-        if (applyButton) {
-          applyButton.click();
-        }
-      }
+  function firstTimeUserPrompt() {
+    if (opts.controlnet_disable_photopea_popup){
+      const photopeaPopupMsg = "you are about to connect to https://photopea.com\n" +
+        "- Click OK: proceed.\n" +
+        "- Click Cancel: abort.\n" +
+        "Photopea integration can be disabled in Settings > ControlNet > Disable photopea edit.\n" +
+        "This popup can be disabled in Settings > ControlNet > Photopea popup warning.";
+      if (photopeaPopupPopupShown || confirm(photopeaPopupMsg)) photopeaPopupPopupShown = true;
+      else return false;
     }
-    return confirmed;
+    return true;
   }
 
   const cnetRegisteredAccordions = new Set();

--- a/javascript/photopea.js
+++ b/javascript/photopea.js
@@ -375,16 +375,16 @@
     }
   }
 
-  let photopeaPopupPopupShown = false;
+  let photopeaWarningShown = false;
 
   function firstTimeUserPrompt() {
-    if (opts.controlnet_disable_photopea_popup){
+    if (opts.controlnet_photopea_warning){
       const photopeaPopupMsg = "you are about to connect to https://photopea.com\n" +
         "- Click OK: proceed.\n" +
         "- Click Cancel: abort.\n" +
         "Photopea integration can be disabled in Settings > ControlNet > Disable photopea edit.\n" +
         "This popup can be disabled in Settings > ControlNet > Photopea popup warning.";
-      if (photopeaPopupPopupShown || confirm(photopeaPopupMsg)) photopeaPopupPopupShown = true;
+      if (photopeaWarningShown || confirm(photopeaPopupMsg)) photopeaWarningShown = true;
       else return false;
     }
     return true;

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1231,6 +1231,8 @@ def on_ui_settings():
         False, "Disable openpose edit", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_disable_photopea_edit", shared.OptionInfo(
         False, "Disable photopea edit", gr.Checkbox, {"interactive": True}, section=section))
+    shared.opts.add_option("controlnet_disable_photopea_popup", shared.OptionInfo(
+        True, "Photopea popup warning", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_ignore_noninpaint_mask", shared.OptionInfo(
         False, "Ignore mask on ControlNet input image if control type is not inpaint", 
         gr.Checkbox, {"interactive": True}, section=section))

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1231,7 +1231,7 @@ def on_ui_settings():
         False, "Disable openpose edit", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_disable_photopea_edit", shared.OptionInfo(
         False, "Disable photopea edit", gr.Checkbox, {"interactive": True}, section=section))
-    shared.opts.add_option("controlnet_disable_photopea_popup", shared.OptionInfo(
+    shared.opts.add_option("controlnet_photopea_warning", shared.OptionInfo(
         True, "Photopea popup warning", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("controlnet_ignore_noninpaint_mask", shared.OptionInfo(
         False, "Ignore mask on ControlNet input image if control type is not inpaint", 


### PR DESCRIPTION
@huchenlei see how you like this approach, feel free to make modifications

---

## alternative photopea popup warning

add a new setting `Photopea popup warning` this controls if you pop up is shown before reuning photopea, default enabled

provides a middle ground for users that may wish to use photpea form time to time doesn't want to accidentally use it

>sadly no multi-user diffrent config support

## behavior
when `Photopea popup warning` is enable
pop up will be shown on the first time that a user tries to use photopea

if the user choose cancel nothing happens..... well it cancels and nothing else happes
if the user clicks on the photopea again the cycle repeats

if the user choose OK photopea is loaded
the value is set so that the pop-up doesn't show up again for for THIS browser session (until the page reloads)

---

if the user disables `Photopea popup warning` then photopea is loaded immediately agter clicking the icon

---

if `Photopea integration` is disabled, .... Photopea doesn't exist and none of the above will happen


https://github.com/Mikubill/sd-webui-controlnet/assets/40751091/99993c1a-f88d-4a97-9ef4-ae29e1ee03cb