### PR TITLE
:bug: Try fix submodule command not found

### DIFF
--- a/install.py
+++ b/install.py
@@ -15,7 +15,7 @@ hand_refiner_req_file = (
 
 def sync_submodules():
     try:
-        repo = git.Repo(Path(__file__).parent)
+        repo = git.Repo(repo_root)
         repo.submodule_update()
     except Exception as e:
         print(e)

--- a/install.py
+++ b/install.py
@@ -1,6 +1,7 @@
 import launch
-import subprocess
+import git  # git is part of A1111 dependency.
 import pkg_resources
+import os
 from pathlib import Path
 from typing import Tuple, Optional
 
@@ -14,8 +15,8 @@ hand_refiner_req_file = (
 
 def sync_submodules():
     try:
-        subprocess.run(["git", "submodule", "init"], check=True, cwd=repo_root)
-        subprocess.run(["git", "submodule", "update"], check=True, cwd=repo_root)
+        repo = git.Repo(Path(__file__).parent)
+        repo.submodule_update()
     except Exception as e:
         print(e)
         print("Warning: ControlNet failed to sync submodules. Please try run "
@@ -77,4 +78,5 @@ def install_requirements(req_file):
 
 sync_submodules()
 install_requirements(main_req_file)
-install_requirements(hand_refiner_req_file)
+if os.path.exists(hand_refiner_req_file):
+    install_requirements(hand_refiner_req_file)


### PR DESCRIPTION
Closes #2427.

The root cause might be git not finding the submodule script location:
https://stackoverflow.com/questions/54672008/submodule-appears-to-be-a-git-command-but-we-were-not-able-to-execute-it.

Since A1111 has GitPython dependency, this PR makes use of that instead of raw subprocess call on git. This hopefully resolves the issue.

Also even when submodule fail to sync, the extension should still be able to load now.