### PR TITLE
Update api example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Note that this feature is only available in the gradio user interface. Call the 
 
 This extension can accept txt2img or img2img tasks via API or external extension call. Note that you may need to enable `Allow other scripts to control this extension` in settings for external calls.
 
-To use the API: start WebUI with argument `--api` and go to `http://webui-address/docs` for documents or checkout [examples](https://github.com/Mikubill/sd-webui-controlnet/blob/main/example/api_txt2img.ipynb).
+To use the API: start WebUI with argument `--api` and go to `http://webui-address/docs` for documents or checkout [examples](https://github.com/Mikubill/sd-webui-controlnet/blob/main/example/txt2img_example/api_txt2img.py).
 
 To use external call: Checkout [Wiki](https://github.com/Mikubill/sd-webui-controlnet/wiki/API)
 


### PR DESCRIPTION
README.md was pointing to location of old notebook style example file for the api examples which no longer exist. Updated link to location of the .py example currently present