### PR TITLE
:bug: Fix IP-Adapter face id plus v2

### DIFF
--- a/scripts/controlnet_model_guess.py
+++ b/scripts/controlnet_model_guess.py
@@ -108,7 +108,7 @@ def state_dict_prefix_replace(state_dict, replace_prefix):
     return state_dict
 
 
-def build_model_by_guess(state_dict, unet, model_path):
+def build_model_by_guess(state_dict, unet, model_path: str):
     if "lora_controlnet" in state_dict:
         is_sdxl = "input_blocks.11.0.in_layers.0.weight" not in state_dict
         logger.info(f"Using ControlNet lora ({'SDXL' if is_sdxl else 'SD15'})")
@@ -241,7 +241,7 @@ def build_model_by_guess(state_dict, unet, model_path):
         return network
 
     if 'ip_adapter' in state_dict:
-        network = PlugableIPAdapter(state_dict)
+        network = PlugableIPAdapter(state_dict, is_v2='v2' in model_path)
         network.to('cpu')
         return network
 


### PR DESCRIPTION
Users have reported that faceid v2 is broken. The PR fixes the implementation. You should see log
`ControlNet - INFO - IP-Adapter faceid plus v2 detected.` when you use v2 model.