### PR TITLE
Fix editor window size with SD.Next

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,6 +15,8 @@
     /* Enable scroll if needed */
     background-color: rgba(0, 0, 0, 0.4);
     /* Black with opacity */
+    max-width: none !important;
+    /* Fix sizing with SD.Next (vladmandic/automatic#2594)
 }
 
 .cnet-modal-content {
@@ -30,6 +32,8 @@
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
     animation-name: animatetop;
     animation-duration: 0.4s;
+    max-width: none !important;
+    /* Fix sizing with SD.Next (vladmandic/automatic#2594)
 }
 
 .cnet-modal-content iframe {


### PR DESCRIPTION
Default themes in SD.Next enforce a maximum width for the column where the editor window opens, thus constraining it to a very small size.

Override `max-width` so that it is not affected by it. Fixes vladmandic/automatic#2594.