### PR TITLE
:bug: Uncache ip-adapter models

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -333,7 +333,8 @@ class Script(scripts.Script, metaclass=(
 
     @staticmethod
     def load_control_model(p, unet, model):
-        if model in Script.model_cache:
+        # ip-adapter model contains embedding data, so each model is unique.
+        if 'ip-adapter' not in model and model in Script.model_cache:
             logger.info(f"Loading model from cache: {model}")
             return Script.model_cache[model]
 


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2469.
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2245.

Previously, it was assumed that model only contains state_dict loaded from model file. However, ip-adapter models also contain input image embedding, weight, and many other values, so ip-adapter models should not be cached.

This is a dirty fix. Later we should have a flag on model object specifying whether the model should be cached or not.

After the fix with example inputs used in #2469:
2 ipadapter units:
1girl (weight = 0.2)
tiger (weight = 0.5)

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/9ba8737c-0bda-4eaa-801e-3a8ccf2589f2)
