### PR TITLE
:bug: Fix outpaint

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -645,8 +645,6 @@ class Script(scripts.Script, metaclass=(
             raise ValueError("controlnet is enabled but no input image is given")
 
         assert isinstance(input_image, np.ndarray)
-        if 'inpaint' in unit.module and input_image.shape[2] != 4:
-            raise ValueError("No mask detected for ControlNet inpaint")
         return input_image, resize_mode
 
     @staticmethod


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2480.

That check for mask probably need to be after outpaint expanded the canvas. For now, I will just remove the check.