### PR TITLE
:wrench: Loosen is_compatible SD version check

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -681,27 +681,27 @@ class Script(scripts.Script, metaclass=(
     @staticmethod
     def check_sd_version_compatible(unit: external_code.ControlNetUnit) -> None:
         """
-        Checks whether the given ControlNet unit has model compatible with the currently 
+        Checks whether the given ControlNet unit has model compatible with the currently
         active sd model. An exception is thrown if ControlNet unit is detected to be
         incompatible.
         """
         sd_version = global_state.get_sd_version()
         assert sd_version != StableDiffusionVersion.UNKNOWN
-        
+
         if "revision" in unit.module.lower() and sd_version != StableDiffusionVersion.SDXL:
             raise Exception(f"Preprocessor 'revision' only supports SDXL. Current SD base model is {sd_version}.")
-        
+
         # No need to check if the ControlModelType does not require model to be present.
         if unit.model is None or unit.model.lower() == "none":
             return
 
         cnet_sd_version = StableDiffusionVersion.detect_from_model_name(unit.model)
-        
+
         if cnet_sd_version == StableDiffusionVersion.UNKNOWN:
             logger.warn(f"Unable to determine version for ControlNet model '{unit.model}'.")
             return
 
-        if sd_version != cnet_sd_version:
+        if not sd_version.is_compatible_with(cnet_sd_version):
             raise Exception(f"ControlNet model {unit.model}({cnet_sd_version}) is not compatible with sd model({sd_version})")
 
     def controlnet_main_entry(self, p):

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -31,9 +31,16 @@ class StableDiffusionVersion(Enum):
             return 12
         else:
             return 9 # SDXL
-            
+
     def controlnet_layer_num(self) -> int:
         return self.encoder_block_num() + 1
+
+    def is_compatible_with(self, other: "StableDiffusionVersion") -> bool:
+        """ Incompatible only when one of version is SDXL and other is not. """
+        return (
+            any(v == StableDiffusionVersion.UNKNOWN for v in [self, other]) or
+            sum(v == StableDiffusionVersion.SDXL for v in [self, other]) != 1
+        )
 
 
 class ControlModelType(Enum):


### PR DESCRIPTION
Closes #2487.

This PR allows SD1x and SD2x to be treated as compatible.