### PR TITLE
Use pip for HandRefinerPortable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "annotator/hand_refiner_portable"]
-	path = annotator/hand_refiner_portable
-	url = https://github.com/huchenlei/HandRefinerPortable

--- a/install.py
+++ b/install.py
@@ -1,7 +1,5 @@
 import launch
-import git  # git is part of A1111 dependency.
 import pkg_resources
-import os
 import sys
 import platform
 import requests
@@ -12,21 +10,6 @@ from typing import Tuple, Optional
 
 repo_root = Path(__file__).parent
 main_req_file = repo_root / "requirements.txt"
-hand_refiner_req_file = (
-    repo_root / "annotator" / "hand_refiner_portable" / "requirements.txt"
-)
-
-
-def sync_submodules():
-    try:
-        repo = git.Repo(repo_root)
-        repo.submodule_update()
-    except Exception as e:
-        print(e)
-        print(
-            "Warning: ControlNet failed to sync submodules. Please try run "
-            "`git submodule init` and `git submodule update` manually."
-        )
 
 
 def comparable_version(version: str) -> Tuple:
@@ -142,8 +125,5 @@ def try_install_insight_face():
         )
 
 
-sync_submodules()
 install_requirements(main_req_file)
-if os.path.exists(hand_refiner_req_file):
-    install_requirements(hand_refiner_req_file)
 try_install_insight_face()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-mediapipe
-svglib
 fvcore
+handrefinerportable@git+https://github.com/huchenlei/HandRefinerPortable.git
+mediapipe
 onnxruntime
 opencv-python>=4.8.0
+svglib

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -712,15 +712,8 @@ class HandRefinerModel:
     
     def load_model(self):
         if self.model is None:
-            # Add submodule hand_refiner to sys.path so that it can be discovered correctly.
-            import sys
-            from pathlib import Path
             from annotator.annotator_path import models_path
-            hand_refiner_path = str(Path(__file__).parent.parent / 'annotator' / 'hand_refiner_portable')
-            if hand_refiner_path not in sys.path:
-                sys.path.append(hand_refiner_path)
-            
-            from annotator.hand_refiner_portable.hand_refiner import MeshGraphormerDetector
+            from hand_refiner import MeshGraphormerDetector  # installed via hand_refiner_portable
             with Extra(self.torch_handler):
                 self.model = MeshGraphormerDetector.from_pretrained(
                     "hr16/ControlNet-HandRefiner-pruned", 


### PR DESCRIPTION
After https://github.com/huchenlei/HandRefinerPortable/pull/2 is merged (making that repository Pip installable), this PR changes sd-webui-controlnet to not use a Git submodule for it anymore.

This was discussed with @w-e-w and @huchenlei on the A1111 discord.

This will not clean up any previously cloned submodule (nor deinit submodules), though.

Because we have removed submodule `hand_refiner_portable`, there should no longer be any issue of renaming dir. We suspect previously it was `git submodule update` holding some resources, which cause `os.rename` to fail with PermissionError.
- Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2482
- Closes https://github.com/Mikubill/sd-webui-controlnet/discussions/2488