### PR TITLE
:wrench: Add option to run CLIP preprocessor on CPU

### DIFF
--- a/annotator/clipvision/__init__.py
+++ b/annotator/clipvision/__init__.py
@@ -86,13 +86,16 @@ clip_vision_vith_uc = torch.load(clip_vision_vith_uc, map_location=torch.device(
 
 
 class ClipVisionDetector:
-    def __init__(self, config):
+    def __init__(self, config, low_vram: bool):
         assert config in downloads
         self.download_link = downloads[config]
         self.model_path = os.path.join(models_path, 'clip_vision')
         self.file_name = config + '.pth'
         self.config = configs[config]
-        self.device = devices.get_device_for("controlnet")
+        self.device = (
+            torch.device("cpu") if low_vram else
+            devices.get_device_for("controlnet")
+        )
         os.makedirs(self.model_path, exist_ok=True)
         file_path = os.path.join(self.model_path, self.file_name)
         if not os.path.exists(file_path):

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -98,6 +98,7 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
         ),
         controlnet_threshold_a: float = Body(64, title="Controlnet Threshold a"),
         controlnet_threshold_b: float = Body(64, title="Controlnet Threshold b"),
+        low_vram: bool = Body(False, title="Low vram"),
     ):
         controlnet_module = global_state.reverse_preprocessor_aliases.get(
             controlnet_module, controlnet_module
@@ -137,6 +138,7 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
                     thr_a=controlnet_threshold_a,
                     thr_b=controlnet_threshold_b,
                     json_pose_callback=json_acceptor.accept,
+                    low_vram=low_vram,
                 )[0]
             )
 

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -757,6 +757,10 @@ class ControlNetUiGroup(object):
                 res=pres,
                 thr_a=pthr_a,
                 thr_b=pthr_b,
+                low_vram=(
+                    ("clip" in module or module == "ip-adapter_face_id_plus") and
+                    shared.opts.data.get("controlnet_clip_detector_on_cpu", False)
+                ),
                 json_pose_callback=json_acceptor.accept
                 if is_openpose(module)
                 else None,

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -350,12 +350,14 @@ clip_encoder = {
 }
 
 
-def clip(img, res=512, config='clip_vitl', **kwargs):
+def clip(img, res=512, config='clip_vitl', low_vram=False, **kwargs):
     img = HWC3(img)
     global clip_encoder
     if clip_encoder[config] is None:
         from annotator.clipvision import ClipVisionDetector
-        clip_encoder[config] = ClipVisionDetector(config)
+        if low_vram:
+            logger.info("Loading CLIP model on CPU.")
+        clip_encoder[config] = ClipVisionDetector(config, low_vram)
     result = clip_encoder[config](img)
     return result, False
 
@@ -693,10 +695,10 @@ class InsightFaceModel:
 g_insight_face_model = InsightFaceModel()
 
 
-def face_id_plus(img, **kwargs):
+def face_id_plus(img, low_vram=False, **kwargs):
     """ FaceID plus uses both face_embeding from insightface and clip_embeding from clip. """
     face_embed, _ = g_insight_face_model.run_model(img)
-    clip_embed, _ = clip(img, config='clip_h')
+    clip_embed, _ = clip(img, config='clip_h', low_vram=low_vram)
     return (face_embed, clip_embed), False
 
 


### PR DESCRIPTION
Users with limited vram have reported issue running CLIP preprocessor alongside with ControlNet (https://github.com/Mikubill/sd-webui-controlnet/discussions/2472#discussioncomment-8165388). This PR offers the option to let users load/run CLIP preprocessor model on CPU.

![1705627128175](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/8f2dfaa0-70b9-4233-9dfa-92fbaf5585c3)
