### PR TITLE
:fire: Remove hand_refiner_portable submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ tests/web_api/full_coverage/expectations/
 
 # Presets
 presets/
+
+# Ignore existing dir of hand refiner if exists.
+annotator/hand_refiner_portable


### PR DESCRIPTION
This PR removes submodule `hand_refiner_portable` completely.

This PR also prevents reinstalling pip package `handrefinerportable` on every A1111 startup.