### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fvcore
-handrefinerportable@git+https://github.com/huchenlei/HandRefinerPortable.git
+hatchling
+handrefinerportable@git+https://github.com/huchenlei/HandRefinerPortable.git 
 mediapipe
 onnxruntime
 opencv-python>=4.8.0


### PR DESCRIPTION
Warning: Failed to install handrefinerportable@git+https://github.com/huchenlei/HandRefinerPortable.git, some preprocessors may not work.
ModuleNotFoundError: No module named 'hatchling'
#2498