### PR TITLE
Devices xpu and mps

### DIFF
--- a/annotator/clipvision/__init__.py
+++ b/annotator/clipvision/__init__.py
@@ -79,10 +79,11 @@ downloads = {
 
 
 clip_vision_h_uc = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'clip_vision_h_uc.data')
-clip_vision_h_uc = torch.load(clip_vision_h_uc,  map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))['uc']
+clip_vision_h_uc = torch.load(clip_vision_h_uc,  map_location=torch.device(devices.get_optimal_device_name()))['uc']
 
 clip_vision_vith_uc = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'clip_vision_vith_uc.data')
-clip_vision_vith_uc = torch.load(clip_vision_vith_uc, map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))['uc']
+clip_vision_vith_uc = torch.load(clip_vision_vith_uc, map_location=torch.device(devices.get_optimal_device_name()))['uc']
+
 
 
 class ClipVisionDetector:

--- a/annotator/lama/saicinpainting/training/losses/segmentation.py
+++ b/annotator/lama/saicinpainting/training/losses/segmentation.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from modules import devices
 
 from .constants import weights as constant_weights
 
@@ -16,7 +17,7 @@ class CrossEntropy2d(nn.Module):
         self.ignore_label = ignore_label
         self.weights = weights
         if self.weights is not None:
-            device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+            device = torch.device(devices.get_optimal_device_name())
             self.weights = torch.FloatTensor(constant_weights[weights]).to(device)
 
     def forward(self, predict, target):

--- a/annotator/zoe/zoedepth/models/base_models/midas_repo/run.py
+++ b/annotator/zoe/zoedepth/models/base_models/midas_repo/run.py
@@ -9,6 +9,7 @@ import argparse
 import time
 
 import numpy as np
+from modules import devices
 
 from imutils.video import VideoStream
 from midas.model_loader import default_models, load_model
@@ -120,7 +121,7 @@ def run(input_path, output_path, model_path, model_type="dpt_beit_large_512", op
     print("Initialize")
 
     # select device
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(devices.get_optimal_device_name())
     print("Device: %s" % device)
 
     model, transform, net_w, net_h = load_model(device, model_path, model_type, optimize, height, square)


### PR DESCRIPTION
Obtain the current system compatible drivers through the built-in devices, support XPU or MPS, and speed up calculations.

The place where the model was loaded was not changed to avoid problems with the load model, only the annotator was changed

code:
```python
torch.device('cuda' if torch.cuda.is_available() else 'cpu'))  replace  torch.device(devices.get_optimal_device_name()))

def get_optimal_device_name():
    if torch.cuda.is_available():
        return get_cuda_device_string()
    if has_mps():
        return "mps"

    if has_xpu():
        return xpu_specific.get_xpu_device_string()
    return "cpu"
```