### PR TITLE
Update model dropdown choices when sd checkpoint change

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -238,14 +238,12 @@ class Script(scripts.Script, metaclass=(
 
     def uigroup(self, tabname: str, is_img2img: bool, elem_id_tabname: str, photopea: Optional[Photopea]) -> Tuple[ControlNetUiGroup, gr.State]:
         group = ControlNetUiGroup(
+            is_img2img,
             Script.get_default_ui_unit(),
             self.preprocessor,
             photopea,
         )
-        group.render(tabname, elem_id_tabname, is_img2img)
-        group.register_callbacks(is_img2img)
-        unit_state = group.render_and_register_unit(tabname, is_img2img)
-        return group, unit_state
+        return group, group.render(tabname, elem_id_tabname)
 
     def ui_batch_options(self, is_img2img: bool, elem_id_tabname: str):
         batch_option = gr.Radio(
@@ -302,7 +300,7 @@ class Script(scripts.Script, metaclass=(
                 if max_models > 1:
                     with gr.Tabs(elem_id=f"{elem_id_tabname}_tabs"):
                         for i in range(max_models):
-                            with gr.Tab(f"ControlNet Unit {i}", 
+                            with gr.Tab(f"ControlNet Unit {i}",
                                         elem_classes=['cnet-unit-tab']):
                                 group, state = self.uigroup(f"ControlNet-{i}", is_img2img, elem_id_tabname, photopea)
                                 ui_groups.append(group)
@@ -315,8 +313,6 @@ class Script(scripts.Script, metaclass=(
                 with gr.Accordion(f"Batch Options", open=False, elem_id="controlnet_batch_options"):
                     self.ui_batch_options(is_img2img, elem_id_tabname)
 
-        ControlNetUiGroup.register_input_mode_sync(ui_groups)
-
         for i, ui_group in enumerate(ui_groups):
             infotext.register_unit(i, ui_group)
         if shared.opts.data.get("control_net_sync_field_args", True):
@@ -324,7 +320,7 @@ class Script(scripts.Script, metaclass=(
             self.paste_field_names = infotext.paste_field_names
 
         return tuple(controls)
-    
+
     @staticmethod
     def clear_control_model_cache():
         Script.model_cache.clear()

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -108,6 +108,7 @@ class ControlNetUiGroup(object):
     img2img_non_inpaint_tabs = []
     img2img_inpaint_area = None
     txt2img_enable_hr = None
+    setting_sd_model_checkpoint = None
 
     def __init__(
         self,
@@ -690,12 +691,14 @@ class ControlNetUiGroup(object):
                     ),
                 ]
 
-        self.type_filter.change(
-            filter_selected,
+        update_args = dict(
+            fn=filter_selected,
             inputs=[self.type_filter],
             outputs=[self.module, self.model],
             show_progress=False
         )
+        self.type_filter.change(**update_args)
+        ControlNetUiGroup.setting_sd_model_checkpoint.change(**update_args)
 
     def register_run_annotator(self, is_img2img: bool):
         def run_annotator(image, module, pres, pthr_a, pthr_b, t2i_w, t2i_h, pp, rm):
@@ -1262,3 +1265,9 @@ class ControlNetUiGroup(object):
 
         if elem_id == "txt2img_hr-checkbox":
             ControlNetUiGroup.txt2img_enable_hr = component
+            return
+
+        if elem_id == "setting_sd_model_checkpoint":
+            print("Setting sd_model_checkpoint")
+            ControlNetUiGroup.setting_sd_model_checkpoint = component
+            return

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -1181,6 +1181,7 @@ class ControlNetUiGroup(object):
         self.register_shift_upload_mask()
         self.register_create_canvas()
         self.register_sync_batch_dir()
+        self.register_clear_preview()
         self.openpose_editor.register_callbacks(
             self.generated_image,
             self.use_preview_as_input,


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2494.
Closes #2270.

This PR adds the callback when sd checkpoint config. When it changes, model choices will be updated to match the current sd version.

This PR also does a large refactoring to delay register of callbacks after all A1111 component that we use/care have been initialized.

Local testing has verified that following features are still are working:
- [x] loopback checkbox visibility
- [x] batch dir sync
- [x] hr_option visibility
- [x] crop input image visibility
- [x] setting sd model checkpoint
- [x] send dimensions
