### PR TITLE
:sparkles: Support multi-inputs

### DIFF
--- a/scripts/batch_hijack.py
+++ b/scripts/batch_hijack.py
@@ -198,10 +198,11 @@ def get_cn_batches(p: processing.StableDiffusionProcessing) -> Tuple[bool, List[
     batches = [[] for _ in range(cn_batch_size)]
     for i in range(cn_batch_size):
         for unit in units:
-            if getattr(unit, 'input_mode', InputMode.SIMPLE) == InputMode.SIMPLE:
-                batches[i].append(unit.image)
-            else:
+            input_mode = getattr(unit, 'input_mode', InputMode.SIMPLE)
+            if input_mode == InputMode.BATCH:
                 batches[i].append(unit.batch_images[i])
+            else:
+                batches[i].append(unit.image)
 
     return any_unit_is_batch, batches, output_dir, input_file_names
 

--- a/scripts/batch_hijack.py
+++ b/scripts/batch_hijack.py
@@ -1,11 +1,10 @@
 import os
 from copy import copy
-from enum import Enum
 from typing import Tuple, List
 
 from modules import img2img, processing, shared, script_callbacks
 from scripts import external_code
-
+from scripts.enums import InputMode
 
 class BatchHijack:
     def __init__(self):
@@ -173,11 +172,6 @@ def unhijack_function(module, name, new_name):
     if hasattr(module, new_name):
         setattr(module, name, getattr(module, new_name))
         delattr(module, new_name)
-
-
-class InputMode(Enum):
-    SIMPLE = "simple"
-    BATCH = "batch"
 
 
 def get_cn_batches(p: processing.StableDiffusionProcessing) -> Tuple[bool, List[List[str]], str, List[str]]:

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -151,7 +151,7 @@ def prepare_mask(
     mask = mask.convert("L")
     if getattr(p, "inpainting_mask_invert", False):
         mask = ImageOps.invert(mask)
-    
+
     if hasattr(p, 'mask_blur_x'):
         if getattr(p, "mask_blur_x", 0) > 0:
             np_mask = np.array(mask)
@@ -166,7 +166,7 @@ def prepare_mask(
     else:
         if getattr(p, "mask_blur", 0) > 0:
             mask = mask.filter(ImageFilter.GaussianBlur(p.mask_blur))
-    
+
     return mask
 
 
@@ -548,12 +548,13 @@ class Script(scripts.Script, metaclass=(
             remote_unit = Script.parse_remote_call(p, Script.get_default_ui_unit(), 0)
             if remote_unit.enabled:
                 units.append(remote_unit)
-        
+
         enabled_units = [
-            copy(local_unit)
+            unit
             for idx, unit in enumerate(units)
             for local_unit in (Script.parse_remote_call(p, unit, idx),)
             if local_unit.enabled
+            for unit in local_unit.unfold_merged()
         ]
         Infotext.write_infotext(enabled_units, p)
         return enabled_units
@@ -1050,13 +1051,13 @@ class Script(scripts.Script, metaclass=(
         if getattr(shared.cmd_opts, 'controlnet_tracemalloc', False):
             tracemalloc.start()
             setattr(self, "malloc_begin", tracemalloc.take_snapshot())
-            
+
         self.controlnet_main_entry(p)
         if getattr(shared.cmd_opts, 'controlnet_tracemalloc', False):
             logger.info("After hook malloc:")
             for stat in tracemalloc.take_snapshot().compare_to(self.malloc_begin, "lineno")[:10]:
                 logger.info(stat)
-            
+
         if len(self.enabled_units) > 0:
             logger.info(f'ControlNet Hooked - Time = {time.time() - t}')
 

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -549,13 +549,14 @@ class Script(scripts.Script, metaclass=(
             if remote_unit.enabled:
                 units.append(remote_unit)
 
-        enabled_units = [
-            unit
-            for idx, unit in enumerate(units)
-            for local_unit in (Script.parse_remote_call(p, unit, idx),)
-            if local_unit.enabled
-            for unit in local_unit.unfold_merged()
-        ]
+        enabled_units = []
+        for idx, unit in enumerate(units):
+            local_unit = Script.parse_remote_call(p, unit, idx)
+            if not local_unit.enabled:
+                continue
+            for unfolded_unit in local_unit.unfold_merged():
+                enabled_units.append(unfolded_unit)
+
         Infotext.write_infotext(enabled_units, p)
         return enabled_units
 

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -554,8 +554,10 @@ class Script(scripts.Script, metaclass=(
             local_unit = Script.parse_remote_call(p, unit, idx)
             if not local_unit.enabled:
                 continue
-            for unfolded_unit in local_unit.unfold_merged():
-                enabled_units.append(unfolded_unit)
+            if hasattr(local_unit, "unfold_merged"):
+                enabled_units.extend(local_unit.unfold_merged())
+            else:
+                enabled_units.append(copy(local_unit))
 
         Infotext.write_infotext(enabled_units, p)
         return enabled_units

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -164,6 +164,8 @@ class UiControlNetUnit(external_code.ControlNetUnit):
         for image in read_image_dir(self.merge_image_dir):
             unit = copy(self)
             unit.image = image
+            unit.input_mode = InputMode.SIMPLE
+            result.append(unit)
         if not result:
             logger.warn(f"No image detected in '{self.merge_image_dir}'.")
         return result

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -91,3 +91,14 @@ class HiResFixOption(Enum):
         else:
             assert isinstance(value, HiResFixOption)
             return value
+
+
+class InputMode(Enum):
+    # Single image to a single ControlNet unit.
+    SIMPLE = "simple"
+    # Input is a directory. N generations. Each generation takes 1 input image
+    # from the directory.
+    BATCH = "batch"
+    # Input is a directory. 1 generation. Each generation takes N input image
+    # from the directory.
+    MERGE = "merge"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -165,5 +165,5 @@ def read_image_dir(img_dir: str, suffixes=('.png', '.jpg', '.jpeg', '.webp')) ->
             try:
                 images.append(read_image(img_path))
             except IOError:
-                print(f"Error opening {img_path}")
+                logger.error(f"Error opening {img_path}")
     return images

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -5,9 +5,10 @@ import time
 import base64
 import numpy as np
 import safetensors.torch
+import cv2
 import logging
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List
 from modules.safe import unsafe_torch_load
 from scripts.logging import logger
 
@@ -145,3 +146,24 @@ def get_unique_axis0(data):
     unique_idxs[:1] = True
     unique_idxs[1:] = np.any(arr[:-1, :] != arr[1:, :], axis=-1)
     return arr[unique_idxs]
+
+
+def read_image(img_path: str) -> str:
+    """Read image from specified path and return a base64 string."""
+    img = cv2.imread(img_path)
+    _, bytes = cv2.imencode(".png", img)
+    encoded_image = base64.b64encode(bytes).decode("utf-8")
+    return encoded_image
+
+
+def read_image_dir(img_dir: str, suffixes=('.png', '.jpg', '.jpeg', '.webp')) -> List[str]:
+    """Try read all images in given img_dir."""
+    images = []
+    for filename in os.listdir(img_dir):
+        if filename.endswith(suffixes):
+            img_path = os.path.join(img_dir, filename)
+            try:
+                images.append(read_image(img_path))
+            except IOError:
+                print(f"Error opening {img_path}")
+    return images


### PR DESCRIPTION
Related discussion: https://github.com/Mikubill/sd-webui-controlnet/issues/2478#issuecomment-1894173725.

User has requested that we provide a way to easily input the whole directory of images into a unit. This PR partially does that by providing the `Multi-Inputs` tab.

Now you can specify a directory with N images. N ControlNet units will be added on generation each unit accepting 1 image from the dir. This is also the prework of implementing IPAdapter portrait: https://github.com/tencent-ailab/IP-Adapter/commit/2397f7c3735c89cd2c9da3229d95d99673f36464.

![1705807774664](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/1f9461b1-1af7-4a2f-8c82-2cfb33420edb)
