### PR TITLE
:truck: Move inpaint crop logic as a function

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -174,7 +174,7 @@ class ControlNetUnit:
     # If hires fix is enabled in A1111, how should this ControlNet unit be applied.
     # The value is ignored if the generation is not using hires fix.
     hr_option: Union[HiResFixOption, int, str] = HiResFixOption.BOTH
-    
+
     # Whether save the detected map of this unit. Setting this option to False prevents saving the
     # detected map or sending detected map along with generated images via API.
     # Currently the option is only accessible in API calls.

--- a/tests/web_api/full_coverage/inpaint_test.py
+++ b/tests/web_api/full_coverage/inpaint_test.py
@@ -180,6 +180,40 @@ class TestInpaintFullCoverage(unittest.TestCase):
             ).exec()
         )
 
+    def test_inpaint_crop(self):
+        self.assertTrue(
+            APITestTemplate(
+                "img2img_inpaint_crop",
+                "img2img",
+                payload_overrides={
+                    "init_images": [girl_img],
+                    "inpaint_full_res": True,
+                    "mask": mask_small_img,
+                },
+                unit_overrides={
+                    "model": "control_v11p_sd15_canny [d14c016b]",
+                    "module": "canny",
+                    "inpaint_crop_input_image": True,
+                },
+            ).exec()
+        )
+        self.assertTrue(
+            APITestTemplate(
+                "img2img_inpaint_no_crop",
+                "img2img",
+                payload_overrides={
+                    "init_images": [girl_img],
+                    "inpaint_full_res": True,
+                    "mask": mask_small_img,
+                },
+                unit_overrides={
+                    "model": "control_v11p_sd15_canny [d14c016b]",
+                    "module": "canny",
+                    "inpaint_crop_input_image": False,
+                },
+            ).exec()
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR moves inpaint crop logic out of `controlnet_main_entry`.