### PR TITLE
Real multi-inputs ControlNet unit

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -199,6 +199,10 @@ class ControlNetUnit:
 
         return vars(self) == vars(other)
 
+    def accepts_multiple_inputs(self) -> bool:
+        """This unit can accept multiple input images."""
+        return self.module == "ip-adapter_face_id"
+
 
 def to_base64_nparray(encoding: str):
     """

--- a/scripts/controlmodel_ipadapter.py
+++ b/scripts/controlmodel_ipadapter.py
@@ -588,12 +588,15 @@ class PlugableIPAdapter(torch.nn.Module):
             if current_sampling_percent < self.p_start or current_sampling_percent > self.p_end:
                 return 0
 
-            cond_mark = current_model.cond_mark[:, :, :, 0].to(self.image_emb)
-            cond_uncond_image_emb = self.image_emb * cond_mark + self.uncond_image_emb * (1 - cond_mark)
+            cond_mark = current_model.cond_mark.flatten().tolist()
             k_key = f"{number * 2 + 1}_to_k_ip"
             v_key = f"{number * 2 + 1}_to_v_ip"
-            ip_k = self.call_ip(k_key, cond_uncond_image_emb, device=q.device)
-            ip_v = self.call_ip(v_key, cond_uncond_image_emb, device=q.device)
+            k_cond = self.call_ip(k_key, self.image_emb, device=q.device)
+            k_uncond = self.call_ip(k_key, self.uncond_image_emb, device=q.device)
+            v_cond = self.call_ip(v_key, self.image_emb, device=q.device)
+            v_uncond = self.call_ip(v_key, self.uncond_image_emb, device=q.device)
+            ip_k = torch.cat([(k_cond, k_uncond)[int(i)] for i in cond_mark], dim=0)
+            ip_v = torch.cat([(v_cond, v_uncond)[int(i)] for i in cond_mark], dim=0)
 
             ip_k, ip_v = map(
                 lambda t: t.view(batch_size, -1, h, head_dim).transpose(1, 2),

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -672,7 +672,7 @@ class Script(scripts.Script, metaclass=(
                 shared.state.interrupted = True
             raise ValueError("controlnet is enabled but no input image is given")
 
-        assert isinstance(input_image, np.ndarray)
+        assert isinstance(input_image, (np.ndarray, list))
         return input_image, resize_mode
 
     @staticmethod
@@ -883,6 +883,8 @@ class Script(scripts.Script, metaclass=(
             input_image, resize_mode = Script.choose_input_image(p, unit, idx)
             if isinstance(input_image, list):
                 assert unit.accepts_multiple_inputs()
+                # preprocessor function is cached, so all arguments must be hashable.
+                input_image = tuple(input_image)
             else:
                 input_image = Script.try_crop_image_with_a1111_mask(p, unit, input_image, resize_mode)
                 input_image = np.ascontiguousarray(input_image.copy()).copy() # safe numpy
@@ -934,7 +936,7 @@ class Script(scripts.Script, metaclass=(
                 store_detected_map(detected_map, unit.module)
             else:
                 control = detected_map
-                for img in (input_image if isinstance(input_image, list) else [input_image]):
+                for img in (input_image if isinstance(input_image, (list, tuple)) else [input_image]):
                     store_detected_map(img, unit.module)
 
             if control_model_type == ControlModelType.T2I_StyleAdapter:

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -165,10 +165,6 @@ class UiControlNetUnit(external_code.ControlNetUnit):
         self.output_dir = output_dir
         self.loopback = loopback
 
-    def accepts_multiple_inputs(self) -> bool:
-        """This unit can accept multiple input images."""
-        return self.module == "ip-adapter_face_id"
-
     def unfold_merged(self) -> List[external_code.ControlNetUnit]:
         """Unfolds a merged unit to multiple units. Keeps the unit merged for
         preprocessors that can accept multiple input images.

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -176,9 +176,9 @@ class UiControlNetUnit(external_code.ControlNetUnit):
         if self.input_mode != InputMode.MERGE:
             return [copy(self)]
 
-        # if self.accepts_multiple_inputs():
-        #     self.input_mode = InputMode.SIMPLE
-        #     return [copy(self)]
+        if self.accepts_multiple_inputs():
+            self.input_mode = InputMode.SIMPLE
+            return [copy(self)]
 
         assert isinstance(self.image, list)
         result = []

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -677,9 +677,9 @@ class InsightFaceModel:
             )
             self.model.prepare(ctx_id=0, det_size=(640, 640))
 
-    def run_model(self, imgs: Union[List[np.ndarray], np.ndarray], **kwargs):
+    def run_model(self, imgs: Union[Tuple[np.ndarray], np.ndarray], **kwargs):
         self.load_model()
-        imgs = imgs if isinstance(imgs, list) else [imgs]
+        imgs = imgs if isinstance(imgs, tuple) else (imgs,)
         faceid_embeds = []
         for i, img in enumerate(imgs):
             img = HWC3(img)

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -686,6 +686,7 @@ class InsightFaceModel:
             faces = self.model.get(img)
             if not faces:
                 logger.warn(f"Insightface: No face found in image {i}.")
+                continue
             if len(faces) > 1:
                 logger.warn("Insightface: More than one face is detected in the image. "
                             f"Only the first one will be used {i}.")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -69,7 +69,11 @@ def ndarray_lru_cache(max_size: int = 128, typed: bool = False):
             """The decorated function that delegates the original function."""
 
             def convert_item(item: Any):
-                return HashableNpArray(item) if isinstance(item, np.ndarray) else item
+                if isinstance(item, np.ndarray):
+                    return HashableNpArray(item)
+                if isinstance(item, tuple):
+                    return tuple(convert_item(i) for i in item)
+                return item
 
             args = [convert_item(arg) for arg in args]
             kwargs = {k: convert_item(arg) for k, arg in kwargs.items()}

--- a/tests/web_api/full_coverage/ipadapter_test.py
+++ b/tests/web_api/full_coverage/ipadapter_test.py
@@ -101,57 +101,59 @@ class TestIPAdapterFullCoverage(unittest.TestCase):
 
     def test_face_id_multi_inputs(self):
         for module, model, lora in self.settings:
-            name = "multi_inputs" + str((module, model, lora))
-            with self.subTest(name=name):
-                self.assertTrue(
-                    APITestTemplate(
-                        name=name,
-                        gen_type="txt2img",
-                        payload_overrides={
-                            "prompt": base_prompt,
-                            "negative_prompt": general_negative_prompt,
-                            "steps": 20,
-                            "width": 512,
-                            "height": 512,
-                        },
-                        unit_overrides=[openpose_unit]
-                        + [
-                            {
-                                "image": img,
-                                "module": module,
-                                "model": model,
-                                "weight": 1 / len(portrait_imgs),
-                            }
-                            for img in portrait_imgs
-                        ],
-                    ).exec()
-                )
+            for i, negative_prompt in enumerate((general_negative_prompt, "", "bad")):
+                name = "multi_inputs" + str((module, model, lora, i))
+                with self.subTest(name=name):
+                    self.assertTrue(
+                        APITestTemplate(
+                            name=name,
+                            gen_type="txt2img",
+                            payload_overrides={
+                                "prompt": base_prompt,
+                                "negative_prompt": negative_prompt,
+                                "steps": 20,
+                                "width": 512,
+                                "height": 512,
+                            },
+                            unit_overrides=[openpose_unit]
+                            + [
+                                {
+                                    "image": img,
+                                    "module": module,
+                                    "model": model,
+                                    "weight": 1 / len(portrait_imgs),
+                                }
+                                for img in portrait_imgs
+                            ],
+                        ).exec()
+                    )
 
     def test_face_id_real_multi_inputs(self):
         for module, model, lora in (sd15_face_id, sd15_face_id_portrait):
-            name = "real_multi_inputs" + str((module, model, lora))
-            with self.subTest(name=name):
-                self.assertTrue(
-                    APITestTemplate(
-                        name=name,
-                        gen_type="txt2img",
-                        payload_overrides={
-                            "prompt": base_prompt,
-                            "negative_prompt": general_negative_prompt,
-                            "steps": 20,
-                            "width": 512,
-                            "height": 512,
-                        },
-                        unit_overrides=[
-                            openpose_unit,
-                            {
-                                "image": [{"image": img} for img in portrait_imgs],
-                                "module": module,
-                                "model": model,
+            for i, negative_prompt in enumerate((general_negative_prompt, "", "bad")):
+                name = "real_multi_inputs" + str((module, model, lora, i))
+                with self.subTest(name=name):
+                    self.assertTrue(
+                        APITestTemplate(
+                            name=name,
+                            gen_type="txt2img",
+                            payload_overrides={
+                                "prompt": base_prompt,
+                                "negative_prompt": negative_prompt,
+                                "steps": 20,
+                                "width": 512,
+                                "height": 512,
                             },
-                        ],
-                    ).exec()
-                )
+                            unit_overrides=[
+                                openpose_unit,
+                                {
+                                    "image": [{"image": img} for img in portrait_imgs],
+                                    "module": module,
+                                    "model": model,
+                                },
+                            ],
+                        ).exec()
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/web_api/full_coverage/ipadapter_test.py
+++ b/tests/web_api/full_coverage/ipadapter_test.py
@@ -114,7 +114,8 @@ class TestIPAdapterFullCoverage(unittest.TestCase):
                             "width": 512,
                             "height": 512,
                         },
-                        unit_overrides=[openpose_unit] + [
+                        unit_overrides=[openpose_unit]
+                        + [
                             {
                                 "image": img,
                                 "module": module,
@@ -122,7 +123,33 @@ class TestIPAdapterFullCoverage(unittest.TestCase):
                                 "weight": 1 / len(portrait_imgs),
                             }
                             for img in portrait_imgs
-                        ]
+                        ],
+                    ).exec()
+                )
+
+    def test_face_id_real_multi_inputs(self):
+        for module, model, lora in (sd15_face_id, sd15_face_id_portrait):
+            name = "real_multi_inputs" + str((module, model, lora))
+            with self.subTest(name=name):
+                self.assertTrue(
+                    APITestTemplate(
+                        name=name,
+                        gen_type="txt2img",
+                        payload_overrides={
+                            "prompt": base_prompt,
+                            "negative_prompt": general_negative_prompt,
+                            "steps": 20,
+                            "width": 512,
+                            "height": 512,
+                        },
+                        unit_overrides=[
+                            openpose_unit,
+                            {
+                                "image": [{"image": img} for img in portrait_imgs],
+                                "module": module,
+                                "model": model,
+                            },
+                        ],
                     ).exec()
                 )
 


### PR DESCRIPTION
Previous multi-inputs support https://github.com/Mikubill/sd-webui-controlnet/pull/2525 essentially unfolds the multi-input unit into multiple units, and do processing, which is not very efficient.

This PR implements the real multi-inputs ControlNet unit, which allow multiple input images to be passed together to FaceID preprocessor in one pass.

In API, a new syntax is introduced to support this. The simple list syntax has been taken (first item image, second item mask), so we have to do extra workaround.
```python
{"image": [{"image": img} for img in imgs]}
```

## Result comparison
faceid portrait multiple units
![multi_inputs('ip-adapter_face_id', 'ip-adapter-faceid-portrait_sd15  b2609049 ', None)_0](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/0f2002b2-bb29-4e65-ac3d-40b320fb7883)

faceid portrait single unit multiple inputs
![real_multi_inputs('ip-adapter_face_id', 'ip-adapter-faceid-portrait_sd15  b2609049 ', None)_0](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/5df0e9f9-2106-4f94-afcf-f5264005eff4)

There are some slight differences. This can be attributed to floating point calculation loss. I think the performance is equivalent. Please file an issue if you have observed any abnormal results after we switch to real multi-inputs arch.