### PR TITLE
:wrench: Explicit error on ipadapter invalid preprocessor/model pair

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -854,6 +854,14 @@ class Script(scripts.Script, metaclass=(
             Script.bound_check_params(unit)
             Script.check_sd_version_compatible(unit)
             if (
+                "ip-adapter" in unit.module and
+                not global_state.ip_adapter_pairing_model[unit.module](unit.model)
+            ):
+                logger.error(f"Invalid pair of IP-Adapter preprocessor({unit.module}) and model({unit.model}).\n"
+                             + global_state.ip_adapter_pairing_logic_text)
+                continue
+
+            if (
                 'inpaint_only' == unit.module and
                 issubclass(type(p), StableDiffusionProcessingImg2Img) and
                 p.image_mask is not None

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -858,6 +858,7 @@ class Script(scripts.Script, metaclass=(
                 not global_state.ip_adapter_pairing_model[unit.module](unit.model)
             ):
                 logger.error(f"Invalid pair of IP-Adapter preprocessor({unit.module}) and model({unit.model}).\n"
+                             "Please follow following pairing logic:\n"
                              + global_state.ip_adapter_pairing_logic_text)
                 continue
 

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -330,3 +330,22 @@ def select_control_type(
         default_option,
         default_model
     )
+
+
+ip_adapter_pairing_model = {
+    "ip-adapter_clip_sdxl": lambda model: "faceid" not in model and "vit" not in model,
+    "ip-adapter_clip_sdxl_plus_vith": lambda model: "faceid" not in model and "vit" in model,
+    "ip-adapter_clip_sd15": lambda model: "faceid" not in model,
+    "ip-adapter_face_id": lambda model: "faceid" in model and "plus" not in model,
+    "ip-adapter_face_id_plus": lambda model: "faceid" in model and "plus" in model,
+}
+
+ip_adapter_pairing_logic_text = """
+{
+    "ip-adapter_clip_sdxl": lambda model: "faceid" not in model and "vit" not in model,
+    "ip-adapter_clip_sdxl_plus_vith": lambda model: "faceid" not in model and "vit" in model,
+    "ip-adapter_clip_sd15": lambda model: "faceid" not in model,
+    "ip-adapter_face_id": lambda model: "faceid" in model and "plus" not in model,
+    "ip-adapter_face_id_plus": lambda model: "faceid" in model and "plus" in model,
+}
+"""


### PR DESCRIPTION
Related issue: https://github.com/Mikubill/sd-webui-controlnet/issues/2546

Many users have difficulties interpret error on wrong preprocessor/model pair. This PR makes error log more explicit.

Sample output:
```
2024-01-22 19:22:30,880 - ControlNet - ERROR - Invalid pair of IP-Adapter preprocessor(ip-adapter_clip_sd15) and model(ip-adapter-faceid-plus_sd15 [d86a490f]).

{
    "ip-adapter_clip_sdxl": lambda model: "faceid" not in model and "vit" not in model,
    "ip-adapter_clip_sdxl_plus_vith": lambda model: "faceid" not in model and "vit" in model,
    "ip-adapter_clip_sd15": lambda model: "faceid" not in model,
    "ip-adapter_face_id": lambda model: "faceid" in model and "plus" not in model,
    "ip-adapter_face_id_plus": lambda model: "faceid" in model and "plus" in model,
}
```