### PR TITLE
🐛 Properly cache ip-adapter models

### DIFF
--- a/scripts/controlmodel_ipadapter.py
+++ b/scripts/controlmodel_ipadapter.py
@@ -501,7 +501,7 @@ class PlugableIPAdapter(torch.nn.Module):
         self.disable_memory_management = True
         self.dtype = None
         self.weight = 1.0
-        self.cache = {}
+        self.cache = None
         self.p_start = 0.0
         self.p_end = 1.0
         return

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -62,6 +62,17 @@ class ControlModelType(Enum):
     IPAdapter = "IPAdapter, Hu Ye"
     Controlllite = "Controlllite, Kohya"
 
+    def allow_context_sharing(self) -> bool:
+        """Returns whether this control model type allows the same PlugableControlModel
+        object map to multiple ControlNetUnit.
+        Both IPAdapter and Controlllite have unit specific input (clip/image) stored
+        on the model object during inference. Sharing the context means that the input
+        set earlier gets lost.
+        """
+        return self not in (
+            ControlModelType.IPAdapter,
+            ControlModelType.Controlllite,
+        )
 
 # Written by Lvmin
 class AutoMachine(Enum):


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2579.

Controlllite also have same issue that it cannot be cached, because model object contains input image information. To make things worse, Controlllite has image information stored at lowest level nn.Module, so major change is needed. Filed #2585 for tracking.