### PR TITLE
:zap: Real multi-inputs for all IP-Adapters

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -201,7 +201,13 @@ class ControlNetUnit:
 
     def accepts_multiple_inputs(self) -> bool:
         """This unit can accept multiple input images."""
-        return False
+        return self.module in (
+            "ip-adapter_clip_sdxl",
+            "ip-adapter_clip_sdxl_plus_vith",
+            "ip-adapter_clip_sd15",
+            "ip-adapter_face_id",
+            "ip-adapter_face_id_plus",
+        )
 
 
 def to_base64_nparray(encoding: str):

--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -207,6 +207,7 @@ class ControlNetUnit:
             "ip-adapter_clip_sd15",
             "ip-adapter_face_id",
             "ip-adapter_face_id_plus",
+            "instant_id_face_embedding",
         )
 
 

--- a/scripts/controlmodel_ipadapter.py
+++ b/scripts/controlmodel_ipadapter.py
@@ -1,10 +1,35 @@
 import math
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Tuple, Union
 
 import torch
 import torch.nn as nn
-from einops import rearrange
+import numpy as np
+from transformers.models.clip.modeling_clip import CLIPVisionModelOutput
 from scripts.logging import logger
+
+
+class ImageEmbed(NamedTuple):
+    """Image embed for a single image."""
+    cond_emb: torch.Tensor
+    uncond_emb: torch.Tensor
+
+    def eval(self, cond_mark: torch.Tensor) -> torch.Tensor:
+        assert cond_mark.ndim == 4
+        assert self.cond_emb.ndim == self.uncond_emb.ndim == 3
+        assert self.cond_emb.shape[0] == self.uncond_emb.shape[0] == 1
+        cond_mark = cond_mark[:, :, :, 0].to(self.cond_emb)
+        device = cond_mark.device
+        dtype = cond_mark.dtype
+        return (
+            self.cond_emb.to(device=device, dtype=dtype) * cond_mark +
+            self.uncond_emb.to(device=device, dtype=dtype) * (1 - cond_mark)
+        )
+
+    def average_of(*args: List[Tuple[torch.Tensor, torch.Tensor]]) -> "ImageEmbed":
+        conds, unconds = zip(*args)
+        def average_tensors(tensors: List[torch.Tensor]) -> torch.Tensor:
+            return torch.sum(torch.stack(tensors), dim=0) / len(tensors)
+        return ImageEmbed(average_tensors(conds), average_tensors(unconds))
 
 
 class MLPProjModel(torch.nn.Module):
@@ -347,68 +372,48 @@ class IPAdapterModel(torch.nn.Module):
         self.ip_layers = To_KV(state_dict["ip_adapter"])
 
     @torch.inference_mode()
-    def get_image_embeds(self, clip_vision_outputs):
-        self.image_proj_model.to(self.device)
-        clip_vision_outputs = clip_vision_outputs if isinstance(clip_vision_outputs, (list, tuple)) else [clip_vision_outputs]
+    def get_image_embeds(self, clip_vision_output: CLIPVisionModelOutput) -> ImageEmbed:
+        self.image_proj_model.cpu()
+
         if self.is_plus:
-            clip_embeds = torch.cat([
-                clip_vision_output['hidden_states'][-2]
-                for clip_vision_output in clip_vision_outputs
-            ], dim=0).to(device=self.device, dtype=torch.float32)
-
             from annotator.clipvision import clip_vision_h_uc, clip_vision_vith_uc
-            cond = self.image_proj_model(clip_embeds)
-            if self.sdxl_plus:
-                uncond = clip_vision_vith_uc.to(cond)
-            else:
-                uncond = self.image_proj_model(clip_vision_h_uc.to(cond))
-            return cond, uncond
-        else:
-            clip_image_embeds = torch.cat([
-                clip_vision_output['image_embeds']
-                for clip_vision_output in clip_vision_outputs
-            ], dim=0).to(device=self.device, dtype=torch.float32)
-            image_prompt_embeds = self.image_proj_model(clip_image_embeds)
-            uncond_image_prompt_embeds = self.image_proj_model(torch.zeros_like(clip_image_embeds))
-            return image_prompt_embeds, uncond_image_prompt_embeds
+            cond = self.image_proj_model(clip_vision_output['hidden_states'][-2].to(device='cpu', dtype=torch.float32))
+            uncond = clip_vision_vith_uc.to(cond) if self.sdxl_plus else self.image_proj_model(clip_vision_h_uc.to(cond))
+            return ImageEmbed(cond, uncond)
+
+        clip_image_embeds = clip_vision_output['image_embeds'].to(device='cpu', dtype=torch.float32)
+        image_prompt_embeds = self.image_proj_model(clip_image_embeds)
+        # input zero vector for unconditional.
+        uncond_image_prompt_embeds = self.image_proj_model(torch.zeros_like(clip_image_embeds))
+        return ImageEmbed(image_prompt_embeds, uncond_image_prompt_embeds)
 
     @torch.inference_mode()
-    def get_image_embeds_faceid_plus(self, insightface_outputs, clip_vision_outputs, is_v2: bool):
-        self.image_proj_model.to(self.device)
-        faceid_embed_list = insightface_outputs
-        clip_vision_outputs = clip_vision_outputs if isinstance(clip_vision_outputs, (list, tuple)) else [clip_vision_outputs]
-        clip_embed_list = [
-            clip_vision_output['hidden_states'][-2]
-            for clip_vision_output in clip_vision_outputs
-        ]
-        conds = []
-        unconds = []
+    def get_image_embeds_faceid_plus(
+        self,
+        face_embed: torch.Tensor,
+        clip_vision_output: CLIPVisionModelOutput,
+        is_v2: bool
+    ) -> ImageEmbed:
+        face_embed = face_embed.to(self.device, dtype=torch.float32)
         from annotator.clipvision import clip_vision_h_uc
-        for faceid_embed, clip_embed in zip(faceid_embed_list, clip_embed_list):
-            faceid_embed = faceid_embed.to(device=self.device, dtype=torch.float32)
-            clip_embed = clip_embed.to(device=self.device, dtype=torch.float32)
-            conds.append(self.image_proj_model(faceid_embed, clip_embed, shortcut=is_v2))
-            unconds.append(self.image_proj_model(torch.zeros_like(faceid_embed), clip_vision_h_uc.to(clip_embed), shortcut=is_v2))
-
-        return torch.cat(conds, dim=0), torch.cat(unconds, dim=0)
+        clip_embed = clip_vision_output['hidden_states'][-2].to(device=self.device, dtype=torch.float32)
+        return ImageEmbed(
+            self.image_proj_model(face_embed, clip_embed, shortcut=is_v2),
+            self.image_proj_model(torch.zeros_like(face_embed), clip_vision_h_uc.to(clip_embed), shortcut=is_v2),
+        )
 
     @torch.inference_mode()
-    def get_image_embeds_faceid(self, insightface_outputs: List[torch.Tensor]):
+    def get_image_embeds_faceid(self, insightface_output: torch.Tensor) -> ImageEmbed:
         """Get image embeds for non-plus faceid. Multiple inputs are supported."""
         self.image_proj_model.to(self.device)
-        batch_size = len(insightface_outputs)
-        faceid_embeds = torch.cat(insightface_outputs, dim=0).to(self.device, dtype=torch.float32)
-        assert faceid_embeds.ndim == 2
-        image_prompt_embeds = self.image_proj_model(faceid_embeds)
-        uncond_image_prompt_embeds = self.image_proj_model(torch.zeros_like(faceid_embeds))
-
-        c = image_prompt_embeds.size(-1)
-        image_prompt_embeds = image_prompt_embeds.reshape(batch_size, -1, c)
-        uncond_image_prompt_embeds = uncond_image_prompt_embeds.reshape(batch_size, -1, c)
-        return image_prompt_embeds, uncond_image_prompt_embeds
+        faceid_embed = insightface_output.to(self.device, dtype=torch.float32)
+        return ImageEmbed(
+            self.image_proj_model(faceid_embed),
+            self.image_proj_model(torch.zeros_like(faceid_embed)),
+        )
 
     @torch.inference_mode()
-    def get_image_embeds_instantid(self, prompt_image_emb):
+    def get_image_embeds_instantid(self, prompt_image_emb: Union[torch.Tensor, np.ndarray]) -> ImageEmbed:
         """Get image embeds for instantid."""
         image_proj_model_in_features = 512
         if isinstance(prompt_image_emb, torch.Tensor):
@@ -418,7 +423,7 @@ class IPAdapterModel(torch.nn.Module):
 
         prompt_image_emb = prompt_image_emb.to(device=self.device, dtype=torch.float32)
         prompt_image_emb = prompt_image_emb.reshape([1, -1, image_proj_model_in_features])
-        return (
+        return ImageEmbed(
             self.image_proj_model(prompt_image_emb),
             self.image_proj_model(torch.zeros_like(prompt_image_emb)),
         )
@@ -503,19 +508,6 @@ def clear_all_ip_adapter():
     return
 
 
-class ImageEmbed(NamedTuple):
-    """Image embed for a single image."""
-    cond_emb: torch.Tensor
-    uncond_emb: torch.Tensor
-
-    def eval(self, cond_mark: torch.Tensor) -> torch.Tensor:
-        assert cond_mark.ndim == 4
-        assert self.cond_emb.ndim == self.uncond_emb.ndim == 3
-        assert self.cond_emb.shape[0] == self.uncond_emb.shape[0] == 1
-        cond_mark = cond_mark[:, :, :, 0].to(self.cond_emb)
-        return self.cond_emb * cond_mark + self.uncond_emb * (1 - cond_mark)
-
-
 class PlugableIPAdapter(torch.nn.Module):
     def __init__(self, state_dict, model_name: str):
         """
@@ -580,8 +572,24 @@ class PlugableIPAdapter(torch.nn.Module):
         self.cache = {}
         return
 
+    def get_image_emb(self, preprocessor_output) -> ImageEmbed:
+        if self.is_instantid:
+            return self.ipadapter.get_image_embeds_instantid(preprocessor_output)
+        elif self.is_faceid and self.is_plus:
+            # Note: FaceID plus uses both face_embed and clip_embed.
+            # This should be the return value from preprocessor.
+            return self.ipadapter.get_image_embeds_faceid_plus(
+                preprocessor_output.face_embed,
+                preprocessor_output.clip_embed,
+                is_v2=self.is_v2
+            )
+        elif self.is_faceid:
+            return self.ipadapter.get_image_embeds_faceid(preprocessor_output)
+        else:
+            return self.ipadapter.get_image_embeds(preprocessor_output)
+
     @torch.no_grad()
-    def hook(self, model, preprocessor_output, weight, start, end, dtype=torch.float32):
+    def hook(self, model, preprocessor_outputs, weight, start, end, dtype=torch.float32):
         global current_model
         current_model = model
 
@@ -595,31 +603,11 @@ class PlugableIPAdapter(torch.nn.Module):
         self.dtype = dtype
 
         self.ipadapter.to(device, dtype=self.dtype)
-        if self.is_instantid:
-            image_emb, uncond_image_emb = self.ipadapter.get_image_embeds_instantid(preprocessor_output)
-        elif self.is_faceid and self.is_plus:
-            # Note: FaceID plus uses both face_embed and clip_embed.
-            # This should be the return value from preprocessor.
-            assert isinstance(preprocessor_output, (list, tuple))
-            assert len(preprocessor_output) == 2
-            image_emb, uncond_image_emb = self.ipadapter.get_image_embeds_faceid_plus(*preprocessor_output, is_v2=self.is_v2)
-        elif self.is_faceid:
-            assert isinstance(preprocessor_output, (list, tuple))
-            image_emb, uncond_image_emb = self.ipadapter.get_image_embeds_faceid(preprocessor_output)
+        if isinstance(preprocessor_outputs, (list, tuple)):
+            preprocessor_outputs = preprocessor_outputs
         else:
-            image_emb, uncond_image_emb = self.ipadapter.get_image_embeds(preprocessor_output)
-
-<<<<<<< HEAD
-        self.image_emb = ImageEmbed(
-            image_emb.to(device, dtype=self.dtype),
-            uncond_image_emb.to(device, dtype=self.dtype)
-        )
-=======
-        assert self.image_emb.ndim == self.uncond_image_emb.ndim == 3
-        self.image_emb = self.image_emb.to(device, dtype=self.dtype).unsqueeze(0)
-        self.uncond_image_emb = self.uncond_image_emb.to(device, dtype=self.dtype).unsqueeze(0)
->>>>>>> 578f196 (real multi inputs)
-
+            preprocessor_outputs = [preprocessor_outputs]
+        self.image_emb = ImageEmbed.average_of(*[self.get_image_emb(o) for o in preprocessor_outputs])
         # From https://github.com/laksjdjf/IPAdapter-ComfyUI
         if not self.sdxl:
             number = 0  # index of to_kvs
@@ -660,7 +648,6 @@ class PlugableIPAdapter(torch.nn.Module):
     def patch_forward(self, number: int):
         @torch.no_grad()
         def forward(attn_blk, x, q):
-            emb_size = self.image_emb.shape[1]
             batch_size, sequence_length, inner_dim = x.shape
             h = attn_blk.heads
             head_dim = inner_dim // h
@@ -669,11 +656,6 @@ class PlugableIPAdapter(torch.nn.Module):
             if current_sampling_percent < self.p_start or current_sampling_percent > self.p_end:
                 return 0
 
-<<<<<<< HEAD
-=======
-            cond_mark = current_model.cond_mark.to(self.image_emb)
-            cond_uncond_image_emb = self.image_emb * cond_mark + self.uncond_image_emb * (1 - cond_mark)
->>>>>>> 578f196 (real multi inputs)
             k_key = f"{number * 2 + 1}_to_k_ip"
             v_key = f"{number * 2 + 1}_to_v_ip"
             cond_uncond_image_emb = self.image_emb.eval(current_model.cond_mark)
@@ -681,10 +663,7 @@ class PlugableIPAdapter(torch.nn.Module):
             ip_v = self.call_ip(v_key, cond_uncond_image_emb, device=q.device)
 
             ip_k, ip_v = map(
-                lambda t: rearrange(
-                    t, "batch emb key (head head_dim) -> emb batch head key head_dim",
-                    batch=batch_size, emb=emb_size, head=h, head_dim=head_dim,
-                ),
+                lambda t: t.view(batch_size, -1, h, head_dim).transpose(1, 2),
                 (ip_k, ip_v),
             )
             assert ip_k.dtype == ip_v.dtype
@@ -696,7 +675,7 @@ class PlugableIPAdapter(torch.nn.Module):
                 ip_v = ip_v.to(dtype=q.dtype)
 
             ip_out = torch.nn.functional.scaled_dot_product_attention(q, ip_k, ip_v, attn_mask=None, dropout_p=0.0, is_causal=False)
-            ip_out = ip_out.mean(dim=0).transpose(1, 2).reshape(batch_size, -1, h * head_dim)
+            ip_out = ip_out.transpose(1, 2).reshape(batch_size, -1, h * head_dim)
 
             return ip_out * self.weight
         return forward

--- a/scripts/controlmodel_ipadapter.py
+++ b/scripts/controlmodel_ipadapter.py
@@ -3,7 +3,7 @@ from typing import List, NamedTuple
 
 import torch
 import torch.nn as nn
-from transformers.models.clip.modeling_clip import CLIPVisionModelOutput
+from einops import rearrange
 from scripts.logging import logger
 
 
@@ -347,36 +347,56 @@ class IPAdapterModel(torch.nn.Module):
         self.ip_layers = To_KV(state_dict["ip_adapter"])
 
     @torch.inference_mode()
-    def get_image_embeds(self, clip_vision_output: CLIPVisionModelOutput):
-        self.image_proj_model.cpu()
-
+    def get_image_embeds(self, clip_vision_outputs):
+        self.image_proj_model.to(self.device)
+        clip_vision_outputs = clip_vision_outputs if isinstance(clip_vision_outputs, (list, tuple)) else [clip_vision_outputs]
         if self.is_plus:
-            from annotator.clipvision import clip_vision_h_uc, clip_vision_vith_uc
-            cond = self.image_proj_model(clip_vision_output['hidden_states'][-2].to(device='cpu', dtype=torch.float32))
-            uncond = clip_vision_vith_uc.to(cond) if self.sdxl_plus else self.image_proj_model(clip_vision_h_uc.to(cond))
-            return cond, uncond
+            clip_embeds = torch.cat([
+                clip_vision_output['hidden_states'][-2]
+                for clip_vision_output in clip_vision_outputs
+            ], dim=0).to(device=self.device, dtype=torch.float32)
 
-        clip_image_embeds = clip_vision_output['image_embeds'].to(device='cpu', dtype=torch.float32)
-        image_prompt_embeds = self.image_proj_model(clip_image_embeds)
-        # input zero vector for unconditional.
-        uncond_image_prompt_embeds = self.image_proj_model(torch.zeros_like(clip_image_embeds))
-        return image_prompt_embeds, uncond_image_prompt_embeds
+            from annotator.clipvision import clip_vision_h_uc, clip_vision_vith_uc
+            cond = self.image_proj_model(clip_embeds)
+            if self.sdxl_plus:
+                uncond = clip_vision_vith_uc.to(cond)
+            else:
+                uncond = self.image_proj_model(clip_vision_h_uc.to(cond))
+            return cond, uncond
+        else:
+            clip_image_embeds = torch.cat([
+                clip_vision_output['image_embeds']
+                for clip_vision_output in clip_vision_outputs
+            ], dim=0).to(device=self.device, dtype=torch.float32)
+            image_prompt_embeds = self.image_proj_model(clip_image_embeds)
+            uncond_image_prompt_embeds = self.image_proj_model(torch.zeros_like(clip_image_embeds))
+            return image_prompt_embeds, uncond_image_prompt_embeds
 
     @torch.inference_mode()
-    def get_image_embeds_faceid_plus(self, face_embed, clip_vision_output: CLIPVisionModelOutput, is_v2: bool):
-        face_embed = face_embed.to(self.device, dtype=torch.float32)
+    def get_image_embeds_faceid_plus(self, insightface_outputs, clip_vision_outputs, is_v2: bool):
+        self.image_proj_model.to(self.device)
+        faceid_embed_list = insightface_outputs
+        clip_vision_outputs = clip_vision_outputs if isinstance(clip_vision_outputs, (list, tuple)) else [clip_vision_outputs]
+        clip_embed_list = [
+            clip_vision_output['hidden_states'][-2]
+            for clip_vision_output in clip_vision_outputs
+        ]
+        conds = []
+        unconds = []
         from annotator.clipvision import clip_vision_h_uc
-        clip_embed = clip_vision_output['hidden_states'][-2].to(device=self.device, dtype=torch.float32)
-        return (
-            self.image_proj_model(face_embed, clip_embed, shortcut=is_v2),
-            self.image_proj_model(torch.zeros_like(face_embed), clip_vision_h_uc.to(clip_embed), shortcut=is_v2),
-        )
+        for faceid_embed, clip_embed in zip(faceid_embed_list, clip_embed_list):
+            faceid_embed = faceid_embed.to(device=self.device, dtype=torch.float32)
+            clip_embed = clip_embed.to(device=self.device, dtype=torch.float32)
+            conds.append(self.image_proj_model(faceid_embed, clip_embed, shortcut=is_v2))
+            unconds.append(self.image_proj_model(torch.zeros_like(faceid_embed), clip_vision_h_uc.to(clip_embed), shortcut=is_v2))
+
+        return torch.cat(conds, dim=0), torch.cat(unconds, dim=0)
 
     @torch.inference_mode()
     def get_image_embeds_faceid(self, insightface_outputs: List[torch.Tensor]):
         """Get image embeds for non-plus faceid. Multiple inputs are supported."""
+        self.image_proj_model.to(self.device)
         batch_size = len(insightface_outputs)
-
         faceid_embeds = torch.cat(insightface_outputs, dim=0).to(self.device, dtype=torch.float32)
         assert faceid_embeds.ndim == 2
         image_prompt_embeds = self.image_proj_model(faceid_embeds)
@@ -589,10 +609,16 @@ class PlugableIPAdapter(torch.nn.Module):
         else:
             image_emb, uncond_image_emb = self.ipadapter.get_image_embeds(preprocessor_output)
 
+<<<<<<< HEAD
         self.image_emb = ImageEmbed(
             image_emb.to(device, dtype=self.dtype),
             uncond_image_emb.to(device, dtype=self.dtype)
         )
+=======
+        assert self.image_emb.ndim == self.uncond_image_emb.ndim == 3
+        self.image_emb = self.image_emb.to(device, dtype=self.dtype).unsqueeze(0)
+        self.uncond_image_emb = self.uncond_image_emb.to(device, dtype=self.dtype).unsqueeze(0)
+>>>>>>> 578f196 (real multi inputs)
 
         # From https://github.com/laksjdjf/IPAdapter-ComfyUI
         if not self.sdxl:
@@ -634,6 +660,7 @@ class PlugableIPAdapter(torch.nn.Module):
     def patch_forward(self, number: int):
         @torch.no_grad()
         def forward(attn_blk, x, q):
+            emb_size = self.image_emb.shape[1]
             batch_size, sequence_length, inner_dim = x.shape
             h = attn_blk.heads
             head_dim = inner_dim // h
@@ -642,6 +669,11 @@ class PlugableIPAdapter(torch.nn.Module):
             if current_sampling_percent < self.p_start or current_sampling_percent > self.p_end:
                 return 0
 
+<<<<<<< HEAD
+=======
+            cond_mark = current_model.cond_mark.to(self.image_emb)
+            cond_uncond_image_emb = self.image_emb * cond_mark + self.uncond_image_emb * (1 - cond_mark)
+>>>>>>> 578f196 (real multi inputs)
             k_key = f"{number * 2 + 1}_to_k_ip"
             v_key = f"{number * 2 + 1}_to_v_ip"
             cond_uncond_image_emb = self.image_emb.eval(current_model.cond_mark)
@@ -649,7 +681,10 @@ class PlugableIPAdapter(torch.nn.Module):
             ip_v = self.call_ip(v_key, cond_uncond_image_emb, device=q.device)
 
             ip_k, ip_v = map(
-                lambda t: t.view(batch_size, -1, h, head_dim).transpose(1, 2),
+                lambda t: rearrange(
+                    t, "batch emb key (head head_dim) -> emb batch head key head_dim",
+                    batch=batch_size, emb=emb_size, head=h, head_dim=head_dim,
+                ),
                 (ip_k, ip_v),
             )
             assert ip_k.dtype == ip_v.dtype
@@ -661,7 +696,7 @@ class PlugableIPAdapter(torch.nn.Module):
                 ip_v = ip_v.to(dtype=q.dtype)
 
             ip_out = torch.nn.functional.scaled_dot_product_attention(q, ip_k, ip_v, attn_mask=None, dropout_p=0.0, is_causal=False)
-            ip_out = ip_out.transpose(1, 2).reshape(batch_size, -1, h * head_dim)
+            ip_out = ip_out.mean(dim=0).transpose(1, 2).reshape(batch_size, -1, h * head_dim)
 
             return ip_out * self.weight
         return forward

--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -649,7 +649,7 @@ class UnetHook(nn.Module):
             for param in outer.control_params:
                 if not isinstance(param.used_hint_cond, torch.Tensor):
                     continue
-                if param.used_hint_cond.shape[1] != 4:
+                if param.used_hint_cond.ndim < 2 or param.used_hint_cond.shape[1] != 4:
                     continue
                 if x.shape[1] != 9:
                     continue

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -381,16 +381,23 @@ clip_encoder = {
 }
 
 
-def clip(img, res=512, config='clip_vitl', low_vram=False, **kwargs):
-    img = HWC3(img)
-    global clip_encoder
-    if clip_encoder[config] is None:
-        from annotator.clipvision import ClipVisionDetector
-        if low_vram:
-            logger.info("Loading CLIP model on CPU.")
-        clip_encoder[config] = ClipVisionDetector(config, low_vram)
-    result = clip_encoder[config](img)
-    return result, False
+def clip(imgs: Union[Tuple[np.ndarray], np.ndarray], config='clip_vitl', low_vram=False, **kwargs):
+    imgs = imgs if isinstance(imgs, tuple) else (imgs,)
+    result = []
+    for img in imgs:
+        img = HWC3(img)
+        global clip_encoder
+        if clip_encoder[config] is None:
+            from annotator.clipvision import ClipVisionDetector
+            if low_vram:
+                logger.info("Loading CLIP model on CPU.")
+            clip_encoder[config] = ClipVisionDetector(config, low_vram)
+        result.append(clip_encoder[config](img))
+
+    if len(result) == 1:
+        return result[0], False
+    else:
+        return result, False
 
 
 def unload_clip(config='clip_vitl'):
@@ -823,12 +830,11 @@ g_insight_face_model = InsightFaceModel()
 g_insight_face_instant_id_model = InsightFaceModel(face_analysis_model_name="antelopev2")
 
 
-def face_id_plus(img, low_vram=False, **kwargs):
+def face_id_plus(imgs: Union[Tuple[np.ndarray], np.ndarray], low_vram=False, **kwargs):
     """ FaceID plus uses both face_embeding from insightface and clip_embeding from clip. """
-    face_embed, _ = g_insight_face_model.run_model(img)
-    clip_embed, _ = clip(img, config='clip_h', low_vram=low_vram)
-    assert len(face_embed) > 0
-    return (face_embed[0], clip_embed), False
+    face_embed, _ = g_insight_face_model.run_model(imgs)
+    clip_embed, _ = clip(imgs, config='clip_h', low_vram=low_vram)
+    return (face_embed, clip_embed), False
 
 
 class HandRefinerModel:

--- a/tests/web_api/full_coverage/template.py
+++ b/tests/web_api/full_coverage/template.py
@@ -163,7 +163,9 @@ def expect_same_image(img1, img2, diff_img_path: str) -> bool:
         # Save the diff_highlighted image to inspect the differences
         cv2.imwrite(diff_img_path, diff_highlighted)
 
-    return similar
+    matching_pixels = np.isclose(img1, img2, rtol=0.5, atol=1)
+    similar_in_general = (matching_pixels.sum() / matching_pixels.size()) >= 0.95
+    return similar_in_general
 
 
 default_unit = {

--- a/tests/web_api/full_coverage/template.py
+++ b/tests/web_api/full_coverage/template.py
@@ -164,7 +164,7 @@ def expect_same_image(img1, img2, diff_img_path: str) -> bool:
         cv2.imwrite(diff_img_path, diff_highlighted)
 
     matching_pixels = np.isclose(img1, img2, rtol=0.5, atol=1)
-    similar_in_general = (matching_pixels.sum() / matching_pixels.size()) >= 0.95
+    similar_in_general = (matching_pixels.sum() / matching_pixels.size) >= 0.95
     return similar_in_general
 
 


### PR DESCRIPTION
Relands https://github.com/Mikubill/sd-webui-controlnet/pull/2578.

With multiple inputs, the projected embedding for all inputs are averaged. This causes slight generation difference comparing to the current multi-units approach, because of floating point precision.

Current multi-unit approach:
![multi_inputs_AdapterSetting(module='ip-adapter_face_id', model='ip-adapter-faceid_sd15  0a1757e9 ', lora='ip-adapter-faceid_sd15_lora')_no_neg_0](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/7ea170d8-712f-4fbd-a73c-104df0f44195)

Real multi-inputs apparoch:
![real_multi_AdapterSetting(module='ip-adapter_face_id', model='ip-adapter-faceid_sd15  0a1757e9 ', lora='ip-adapter-faceid_sd15_lora')_no_neg_0](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/f766b4c8-d286-403e-839e-a232f9e0d222)

You can observe some subtle difference here and there, but overall image quality is preserved. You can still use the multi-unit approach in the API as demonstrated in tests.