### PR TITLE
:wrench: Increase default model cache size to 2

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1268,7 +1268,7 @@ def on_ui_settings():
     shared.opts.add_option("control_net_unit_count", shared.OptionInfo(
         3, "Multi-ControlNet: ControlNet unit number (requires restart)", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}, section=section))
     shared.opts.add_option("control_net_model_cache_size", shared.OptionInfo(
-        1, "Model cache size (requires restart)", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}, section=section))
+        2, "Model cache size (requires restart)", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}, section=section))
     shared.opts.add_option("control_net_inpaint_blur_sigma", shared.OptionInfo(
         7, "ControlNet inpainting Gaussian blur sigma", gr.Slider, {"minimum": 0, "maximum": 64, "step": 1}, section=section))
     shared.opts.add_option("control_net_no_detectmap", shared.OptionInfo(


### PR DESCRIPTION
Context: https://github.com/Mikubill/sd-webui-controlnet/discussions/2589#discussioncomment-8273701.

Now we have instant id, which always use 2 models at the same time. It is reasonable to to increase the default model cache size to 2, because cache size = 1 means loading model on each generation for instant id.