### PR TITLE
Compatibility fixes for WebUI < v1.5.0

### DIFF
--- a/annotator/clipvision/__init__.py
+++ b/annotator/clipvision/__init__.py
@@ -9,6 +9,7 @@ from transformers import CLIPVisionModelWithProjection, CLIPVisionConfig, CLIPIm
 try:
     from modules.modelloader import load_file_from_url
 except ImportError:
+    # backward compability for webui < 1.5.0
     from basicsr.utils.download_util import load_file_from_url
 
 config_clip_g = {

--- a/annotator/clipvision/__init__.py
+++ b/annotator/clipvision/__init__.py
@@ -3,10 +3,13 @@ import cv2
 import torch
 
 from modules import devices
-from modules.modelloader import load_file_from_url
 from annotator.annotator_path import models_path
 from transformers import CLIPVisionModelWithProjection, CLIPVisionConfig, CLIPImageProcessor
 
+try:
+    from modules.modelloader import load_file_from_url
+except ImportError:
+    from basicsr.utils.download_util import load_file_from_url
 
 config_clip_g = {
   "attention_dropout": 0.0,

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -276,7 +276,7 @@ def get_sd_version() -> StableDiffusionVersion:
         else:
             return StableDiffusionVersion.UNKNOWN
 
-    # backward compability with webui < 1.5.0
+    # backward compability for webui < 1.5.0
     else:
         if hasattr(shared.sd_model, 'conditioner'):
             return StableDiffusionVersion.SDXL
@@ -284,7 +284,7 @@ def get_sd_version() -> StableDiffusionVersion:
             return StableDiffusionVersion.SD2x
         else:
             return StableDiffusionVersion.SD1x
-    
+
 
 
 def select_control_type(

--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -266,14 +266,25 @@ def update_cn_models():
 
 
 def get_sd_version() -> StableDiffusionVersion:
-    if shared.sd_model.is_sdxl:
-        return StableDiffusionVersion.SDXL
-    elif shared.sd_model.is_sd2:
-        return StableDiffusionVersion.SD2x
-    elif shared.sd_model.is_sd1:
-        return StableDiffusionVersion.SD1x
+    if hasattr(shared.sd_model, 'is_sdxl'):
+        if shared.sd_model.is_sdxl:
+            return StableDiffusionVersion.SDXL
+        elif shared.sd_model.is_sd2:
+            return StableDiffusionVersion.SD2x
+        elif shared.sd_model.is_sd1:
+            return StableDiffusionVersion.SD1x
+        else:
+            return StableDiffusionVersion.UNKNOWN
+
+    # backward compability with webui < 1.5.0
     else:
-        return StableDiffusionVersion.UNKNOWN
+        if hasattr(shared.sd_model, 'conditioner'):
+            return StableDiffusionVersion.SDXL
+        elif hasattr(shared.sd_model.cond_stage_model, 'model'):
+            return StableDiffusionVersion.SD2x
+        else:
+            return StableDiffusionVersion.SD1x
+    
 
 
 def select_control_type(


### PR DESCRIPTION
Fixed 2 minor compatibility issues preventing ControlNet from working in WebUI versions >= 1.3.0 and < 1.5.0.