### PR TITLE
Fix device for multi-gpu env

### DIFF
--- a/annotator/clipvision/__init__.py
+++ b/annotator/clipvision/__init__.py
@@ -83,10 +83,10 @@ downloads = {
 
 
 clip_vision_h_uc = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'clip_vision_h_uc.data')
-clip_vision_h_uc = torch.load(clip_vision_h_uc,  map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))['uc']
+clip_vision_h_uc = torch.load(clip_vision_h_uc,  map_location=torch.device(devices.get_device_for("controlnet") if torch.cuda.is_available() else 'cpu'))['uc']
 
 clip_vision_vith_uc = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'clip_vision_vith_uc.data')
-clip_vision_vith_uc = torch.load(clip_vision_vith_uc, map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))['uc']
+clip_vision_vith_uc = torch.load(clip_vision_vith_uc, map_location=torch.device(devices.get_device_for("controlnet") if torch.cuda.is_available() else 'cpu'))['uc']
 
 
 class ClipVisionDetector:

--- a/annotator/lama/saicinpainting/training/losses/segmentation.py
+++ b/annotator/lama/saicinpainting/training/losses/segmentation.py
@@ -4,6 +4,8 @@ import torch.nn.functional as F
 
 from .constants import weights as constant_weights
 
+from modules import devices
+
 
 class CrossEntropy2d(nn.Module):
     def __init__(self, reduction="mean", ignore_label=255, weights=None, *args, **kwargs):
@@ -16,7 +18,7 @@ class CrossEntropy2d(nn.Module):
         self.ignore_label = ignore_label
         self.weights = weights
         if self.weights is not None:
-            device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+            device = torch.device(devices.get_device_for("controlnet") if torch.cuda.is_available() else 'cpu')
             self.weights = torch.FloatTensor(constant_weights[weights]).to(device)
 
     def forward(self, predict, target):

--- a/annotator/zoe/zoedepth/models/base_models/midas_repo/run.py
+++ b/annotator/zoe/zoedepth/models/base_models/midas_repo/run.py
@@ -13,6 +13,8 @@ import numpy as np
 from imutils.video import VideoStream
 from midas.model_loader import default_models, load_model
 
+from modules import devices
+
 first_execution = True
 def process(device, model, model_type, image, input_size, target_size, optimize, use_camera):
     """
@@ -120,7 +122,7 @@ def run(input_path, output_path, model_path, model_type="dpt_beit_large_512", op
     print("Initialize")
 
     # select device
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(devices.get_device_for("controlnet") if torch.cuda.is_available() else "cpu")
     print("Device: %s" % device)
 
     model, transform, net_w, net_h = load_model(device, model_path, model_type, optimize, height, square)


### PR DESCRIPTION
Relands https://github.com/Mikubill/sd-webui-controlnet/pull/2503.

As discussed in https://github.com/Mikubill/sd-webui-controlnet/pull/2508#issuecomment-1993887097, we should use `devices.get_device_for("controlnet")` to get device if cuda is available so that environment with multiple cuda instances can better utilize the GPU power with multiple A1111 instances running.

The reland will not cause AMD/Intel card to fail as now they will fall back to cpu if cuda is not available.