### PR TITLE
Unify IP-Adapter preprocessor

### DIFF
--- a/scripts/global_state.py
+++ b/scripts/global_state.py
@@ -179,9 +179,15 @@ preprocessor_aliases = {
     "densepose": "densepose (pruple bg & purple torso)",
     "densepose_parula": "densepose_parula (black bg & blue torso)",
     "te_hed": "softedge_teed",
+    "ip-adapter_clip_sd15": "ip-adapter_clip_h",
+    "ip-adapter_clip_sdxl": "ip-adapter_clip_g",
 }
 
+# Preprocessor that automatically maps to other preprocessors.
+meta_preprocessors = ["ip-adapter-auto"]
+
 ui_preprocessor_keys = ['none', preprocessor_aliases['invert']]
+ui_preprocessor_keys += meta_preprocessors
 ui_preprocessor_keys += sorted([preprocessor_aliases.get(k, k)
                                 for k in cn_preprocessor_modules.keys()
                                 if preprocessor_aliases.get(k, k) not in ui_preprocessor_keys])
@@ -353,22 +359,3 @@ def select_control_type(
         default_option,
         default_model
     )
-
-
-ip_adapter_pairing_model = {
-    "ip-adapter_clip_sdxl": lambda model: "faceid" not in model and "vit" not in model,
-    "ip-adapter_clip_sdxl_plus_vith": lambda model: "faceid" not in model and "vit" in model,
-    "ip-adapter_clip_sd15": lambda model: "faceid" not in model,
-    "ip-adapter_face_id": lambda model: "faceid" in model and "plus" not in model,
-    "ip-adapter_face_id_plus": lambda model: "faceid" in model and "plus" in model,
-}
-
-ip_adapter_pairing_logic_text = """
-{
-    "ip-adapter_clip_sdxl": lambda model: "faceid" not in model and "vit" not in model,
-    "ip-adapter_clip_sdxl_plus_vith": lambda model: "faceid" not in model and "vit" in model,
-    "ip-adapter_clip_sd15": lambda model: "faceid" not in model,
-    "ip-adapter_face_id": lambda model: "faceid" in model and "plus" not in model,
-    "ip-adapter_face_id_plus": lambda model: "faceid" in model and "plus" in model,
-}
-"""

--- a/scripts/ipadapter/presets.py
+++ b/scripts/ipadapter/presets.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from ..enums import StableDiffusionVersion
+from typing import NamedTuple, Optional, List
+
+
+class IPAdapterPreset(NamedTuple):
+    """Preset for IPAdapter."""
+
+    name: str
+    module: str  # Preprocessor
+    model: str  # Name of model file
+    sd_version: StableDiffusionVersion  # Supported SD version.
+    lora: Optional[str] = None
+
+    @staticmethod
+    def match_model(model_name: str) -> IPAdapterPreset:
+        model_name = model_name.split("[")[0].strip()
+        return _preset_by_model[model_name]
+
+
+clip_h = "ip-adapter_clip_h"
+clip_g = "ip-adapter_clip_g"
+insightface = "ip-adapter_face_id"
+insightface_clip_h = "ip-adapter_face_id_plus"
+
+
+ipadapter_presets: List[IPAdapterPreset] = [
+    IPAdapterPreset(
+        name="light",
+        module=clip_h,
+        model="ip-adapter_sd15_light",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="vit-g",
+        module=clip_g,
+        model="ip-adapter_sd15_vit-G",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="standard",
+        module=clip_h,
+        model="ip-adapter_sd15",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="plus",
+        module=clip_h,
+        model="ip-adapter-plus_sd15",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="plus_face",
+        module=clip_h,
+        model="ip-adapter-plus-face_sd15",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="full_face",
+        module=clip_h,
+        model="ip-adapter-full-face_sd15",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="face_id",
+        module=insightface,
+        model="ip-adapter-faceid_sd15",
+        lora="ip-adapter-faceid_sd15_lora",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="face_id_plus",
+        module=insightface_clip_h,
+        model="ip-adapter-faceid-plus_sd15",
+        lora="ip-adapter-faceid-plus_sd15_lora",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="face_id_plus_v2",
+        module=insightface_clip_h,
+        model="ip-adapter-faceid-plusv2_sd15",
+        lora="ip-adapter-faceid-plusv2_sd15_lora",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="face_id_portrait",
+        module=insightface,
+        model="ip-adapter-faceid-portrait_sd15",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="standard-g",
+        module=clip_g,
+        model="ip-adapter_sdxl",
+        sd_version=StableDiffusionVersion.SDXL,
+    ),
+    IPAdapterPreset(
+        name="standard-h",
+        module=clip_h,
+        model="ip-adapter_sdxl_vit-h",
+        sd_version=StableDiffusionVersion.SDXL,
+    ),
+    IPAdapterPreset(
+        name="plus-h",
+        module=clip_h,
+        model="ip-adapter-plus_sdxl_vit-h",
+        sd_version=StableDiffusionVersion.SDXL,
+    ),
+    IPAdapterPreset(
+        name="plus_face-h",
+        module=clip_h,
+        model="ip-adapter-plus-face_sdxl_vit-h",
+        sd_version=StableDiffusionVersion.SDXL,
+    ),
+    IPAdapterPreset(
+        name="face_id",
+        module=insightface,
+        model="ip-adapter-faceid_sdxl",
+        lora="ip-adapter-faceid_sdxl_lora",
+        sd_version=StableDiffusionVersion.SDXL,
+    ),
+    IPAdapterPreset(
+        name="face_id_plusv2",
+        module=insightface_clip_h,
+        model="ip-adapter-faceid-plusv2_sdxl",
+        lora="ip-adapter-faceid-plusv2_sdxl_lora",
+        sd_version=StableDiffusionVersion.SDXL,
+    ),
+    IPAdapterPreset(
+        name="face_id_portrait",
+        module=insightface,
+        model="ip-adapter-faceid-portrait_sdxl",
+        sd_version=StableDiffusionVersion.SDXL,
+    ),
+]
+
+_preset_by_model = {p.model: p for p in ipadapter_presets}

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -1355,7 +1355,7 @@ preprocessor_filters = {
     "Recolor": "recolor_luminance",
     "Revision": "revision_clipvision",
     "T2I-Adapter": "none",
-    "IP-Adapter": "ip-adapter_clip_sd15",
+    "IP-Adapter": "ip-adapter-auto",
     "Instant_ID": "instant_id",
     "SparseCtrl": "none",
 }


### PR DESCRIPTION
Closes #2643.

This PR adds `ip-adapter-auto` meta preprocessor that automatically selects the correct preprocessor based on ipadapter model used.

Note: The preprocessor selection is based on model file name. So please keep the model file name as the same in official huggingface ipadapter repo.

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/2f64a815-733a-4dda-b227-6168e3b8f382)
You should see following log line in your console:
`2024-03-29 23:09:19,001 - ControlNet - INFO - ip-adapter-auto => ip-adapter_clip_g`

This PR is also part of https://github.com/Mikubill/sd-webui-controlnet/issues/2700.
