### PR TITLE
Fix seg preprocessor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ mediapipe
 onnxruntime
 opencv-python>=4.8.0
 svglib
+addict
+yapf

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -48,9 +48,6 @@ def detect_template(payload, output_name: str, status: int = 200):
 # FAILED extensions/sd-webui-controlnet/tests/web_api/detect_test.py::test_detect_all_modules[ip-adapter_face_id_plus] - PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x000001589AEE3100>
 # FAILED extensions/sd-webui-controlnet/tests/web_api/detect_test.py::test_detect_all_modules[instant_id_face_embedding] - PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x000001589AFF6CF0>
 
-# https://github.com/Mikubill/sd-webui-controlnet/issues/2693
-# FAILED extensions/sd-webui-controlnet/tests/web_api/detect_test.py::test_detect_all_modules[segmentation] - assert 500 == 200
-
 # TODO: file issue on these failures.
 # FAILED extensions/sd-webui-controlnet/tests/web_api/detect_test.py::test_detect_all_modules[depth_zoe] - assert 500 == 200
 # FAILED extensions/sd-webui-controlnet/tests/web_api/detect_test.py::test_detect_all_modules[inpaint_only+lama] - assert 500 == 200


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2693.

Upstream A1111 change probably dropped `addict` and `yapf` in 1.8.0, so we need to manually include them here.
