### PR TITLE
Add clip mask support

### DIFF
--- a/annotator/clipvision/__init__.py
+++ b/annotator/clipvision/__init__.py
@@ -1,7 +1,9 @@
 import os
 import cv2
 import torch
+import numpy as np
 
+from einops import rearrange
 from modules import devices
 from annotator.annotator_path import models_path
 from transformers import CLIPVisionModelWithProjection, CLIPVisionConfig, CLIPImageProcessor
@@ -126,11 +128,19 @@ class ClipVisionDetector:
         if self.model is not None:
             self.model.to('meta')
 
-    def __call__(self, input_image):
+    def __call__(self, input_image: np.ndarray):
+        assert isinstance(input_image, np.ndarray)
         with torch.no_grad():
+            mask = None
             input_image = cv2.resize(input_image, (224, 224), interpolation=cv2.INTER_AREA)
+            if input_image.shape[2] == 4:  # Has alpha channel.
+                mask = 255 - input_image[:, :, 3:4]
+                input_image = input_image[:, :, :3]
             feat = self.processor(images=input_image, return_tensors="pt")
             feat['pixel_values'] = feat['pixel_values'].to(self.device)
+            # Apply CLIP mask.
+            if mask is not None:
+                feat['pixel_values'] *= rearrange(torch.from_numpy(mask).to(self.device).float() / 255.0, "h w c -> 1 c h w")
             result = self.model(**feat, output_hidden_states=True)
             result['hidden_states'] = [v.to(self.device) for v in result['hidden_states']]
             result = {k: v.to(self.device) if isinstance(v, torch.Tensor) else v for k, v in result.items()}

--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -226,6 +226,14 @@ class ControlNetUnit:
     def is_animate_diff_batch(self) -> bool:
         return getattr(self, "animatediff_batch", False)
 
+    @property
+    def uses_mask(self) -> bool:
+        """Whether this unit uses mask.
+        - inpaint accepts mask for mask area redraw.
+        - ip-adapter accepts mask to ignore part of clip input. (CLIP mask)
+        """
+        return "inpaint" in self.module or "ip-adapter" in self.module
+
 
 def to_base64_nparray(encoding: str):
     """

--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -232,7 +232,7 @@ class ControlNetUnit:
         - inpaint accepts mask for mask area redraw.
         - ip-adapter accepts mask to ignore part of clip input. (CLIP mask)
         """
-        return "inpaint" in self.module or "ip-adapter" in self.module
+        return "inpaint" in self.module or ("ip-adapter" in self.module and "faceid" not in self.module)
 
 
 def to_base64_nparray(encoding: str):

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -647,7 +647,7 @@ class Script(scripts.Script, metaclass=(
                     for idx in range(len(input_image)):
                         while len(image[idx]['mask'].shape) < 3:
                             image[idx]['mask'] = image[idx]['mask'][..., np.newaxis]
-                        if unit.uses_mask:
+                        if unit.is_inpaint or unit.uses_clip:
                             color = HWC3(image[idx]["image"])
                             alpha = image[idx]['mask'][:, :, 0:1]
                             input_image[idx] = np.concatenate([color, alpha], axis=2)
@@ -656,7 +656,7 @@ class Script(scripts.Script, metaclass=(
                 if 'mask' in image and image['mask'] is not None:
                     while len(image['mask'].shape) < 3:
                         image['mask'] = image['mask'][..., np.newaxis]
-                    if unit.uses_mask:
+                    if unit.is_inpaint or unit.uses_clip:
                         logger.info("using mask")
                         color = HWC3(image['image'])
                         alpha = image['mask'][:, :, 0:1]
@@ -681,7 +681,7 @@ class Script(scripts.Script, metaclass=(
             resize_mode = external_code.resize_mode_from_value(a1111_i2i_resize_mode)
 
             a1111_mask_image : Optional[Image.Image] = getattr(p, "image_mask", None)
-            if 'inpaint' in unit.module:
+            if unit.is_inpaint:
                 if a1111_mask_image is not None:
                     a1111_mask = np.array(prepare_mask(a1111_mask_image, p))
                     assert a1111_mask.ndim == 2

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -647,7 +647,7 @@ class Script(scripts.Script, metaclass=(
                     for idx in range(len(input_image)):
                         while len(image[idx]['mask'].shape) < 3:
                             image[idx]['mask'] = image[idx]['mask'][..., np.newaxis]
-                        if 'inpaint' in unit.module:
+                        if unit.uses_mask:
                             color = HWC3(image[idx]["image"])
                             alpha = image[idx]['mask'][:, :, 0:1]
                             input_image[idx] = np.concatenate([color, alpha], axis=2)
@@ -656,8 +656,8 @@ class Script(scripts.Script, metaclass=(
                 if 'mask' in image and image['mask'] is not None:
                     while len(image['mask'].shape) < 3:
                         image['mask'] = image['mask'][..., np.newaxis]
-                    if 'inpaint' in unit.module:
-                        logger.info("using inpaint as input")
+                    if unit.uses_mask:
+                        logger.info("using mask")
                         color = HWC3(image['image'])
                         alpha = image['mask'][:, :, 0:1]
                         input_image = np.concatenate([color, alpha], axis=2)

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -383,7 +383,6 @@ clip_encoder = {
 
 
 def clip(img, res=512, config='clip_vitl', low_vram=False, **kwargs):
-    img = HWC3(img)
     global clip_encoder
     if clip_encoder[config] is None:
         from annotator.clipvision import ClipVisionDetector

--- a/tests/web_api/clip_mask_test.py
+++ b/tests/web_api/clip_mask_test.py
@@ -1,0 +1,55 @@
+from .template import (
+    APITestTemplate,
+    girl_img,
+    mask_img,
+    disable_in_cq,
+    get_model,
+)
+
+
+@disable_in_cq
+def test_clip_mask_txt2img_control():
+    """No mask control group."""
+    assert APITestTemplate(
+        "test_clip_mask_txt2img_control",
+        "txt2img",
+        payload_overrides={},
+        unit_overrides={
+            "module": "ip-adapter-auto",
+            "model": get_model("ip-adapter_sd15"),
+            "image": girl_img,
+        },
+    ).exec()
+
+
+@disable_in_cq
+def test_clip_mask_txt2img_experiment():
+    """With mask experiment group."""
+    assert APITestTemplate(
+        "test_clip_mask_txt2img_experiment",
+        "txt2img",
+        payload_overrides={},
+        unit_overrides={
+            "module": "ip-adapter-auto",
+            "model": get_model("ip-adapter_sd15"),
+            "image": girl_img,
+            "mask_image": mask_img,
+        },
+    ).exec()
+
+
+@disable_in_cq
+def test_clip_mask_img2img():
+    """CLIP mask should not work in img2img inpaint."""
+    assert APITestTemplate(
+        "test_clip_mask_img2img",
+        "img2img",
+        payload_overrides={
+            "init_images": [girl_img],
+            "mask": mask_img,
+        },
+        unit_overrides={
+            "module": "ip-adapter-auto",
+            "model": get_model("ip-adapter_sd15"),
+        },
+    ).exec()


### PR DESCRIPTION
This PR is part of https://github.com/Mikubill/sd-webui-controlnet/issues/2700.

This PR implements CLIP mask. Now ip-adapter non-faceid models can accept mask to ignore part of image.

Here is an example:
### No Mask
![31 03 2024_00 56 26_REC](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/014be6f7-f782-46b8-bfb0-37af80282c71)
![00013-1714864127](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/992d34d8-9a88-4f41-9c26-829de5818d4d)


### With Mask
![31 03 2024_00 57 36_REC](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/4dc98018-afea-4420-a234-8da73fbe81e4)
![00014-1714864127](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/d60ed679-de19-402c-ae29-410a7927b59e)


Infotext
```
skull sheild, absurdres, highres, (masterpiece:1.2), (best quality, highest quality),
Negative prompt: (lowres, low quality, worst quality:1.2), (text:1.2), watermark, (frame:1.2), deformed, ugly, deformed eyes, blur, out of focus, blurry, deformed cat, deformed, photo, anthropomorphic cat, monochrome, photo, pet collar, gun, weapon, blue, 3d, drones, drone, buildings in background, green
Steps: 20, Sampler: DPM++ 2M, Schedule type: Karras, CFG scale: 7, Seed: 1714864127, Size: 512x512, Model hash: b42b09ff12, Model: cetusMix_v4, Clip skip: 2, ControlNet 0: "Module: ip-adapter_clip_h, Model: ip-adapter-plus_sd15 [836b5c2e], Weight: 1, Resize Mode: Crop and Resize, Low Vram: False, Processor Res: 512, Guidance Start: 0, Guidance End: 1, Pixel Perfect: False, Control Mode: Balanced, Hr Option: Both, Save Detected Map: True", Version: v1.8.0-273-g8687163f
```