### PR TITLE
Remove unused field bypass_average

### DIFF
--- a/scripts/ipadapter/ipadapter_model.py
+++ b/scripts/ipadapter/ipadapter_model.py
@@ -20,7 +20,6 @@ class ImageEmbed(NamedTuple):
 
     cond_emb: torch.Tensor
     uncond_emb: torch.Tensor
-    bypass_average: bool = False
 
     def eval(self, cond_mark: torch.Tensor) -> torch.Tensor:
         assert cond_mark.ndim == 4
@@ -40,7 +39,7 @@ class ImageEmbed(NamedTuple):
         ) * cond_mark + self.uncond_emb.to(device=device, dtype=dtype) * (1 - cond_mark)
 
     def average_of(*args: List[Tuple[torch.Tensor, torch.Tensor]]) -> "ImageEmbed":
-        conds, unconds, _ = zip(*args)
+        conds, unconds = zip(*args)
 
         def average_tensors(tensors: List[torch.Tensor]) -> torch.Tensor:
             return torch.sum(torch.stack(tensors), dim=0) / len(tensors)

--- a/scripts/ipadapter/plugable_ipadapter.py
+++ b/scripts/ipadapter/plugable_ipadapter.py
@@ -119,16 +119,13 @@ class PlugableIPAdapter(torch.nn.Module):
         self.dtype = dtype
 
         self.ipadapter.to(device, dtype=self.dtype)
-        if getattr(preprocessor_outputs, "bypass_average", False):
-            self.image_emb = preprocessor_outputs
+        if isinstance(preprocessor_outputs, (list, tuple)):
+            preprocessor_outputs = preprocessor_outputs
         else:
-            if isinstance(preprocessor_outputs, (list, tuple)):
-                preprocessor_outputs = preprocessor_outputs
-            else:
-                preprocessor_outputs = [preprocessor_outputs]
-            self.image_emb = ImageEmbed.average_of(
-                *[self.ipadapter.get_image_emb(o) for o in preprocessor_outputs]
-            )
+            preprocessor_outputs = [preprocessor_outputs]
+        self.image_emb = ImageEmbed.average_of(
+            *[self.ipadapter.get_image_emb(o) for o in preprocessor_outputs]
+        )
         # From https://github.com/laksjdjf/IPAdapter-ComfyUI
         if not self.ipadapter.is_sdxl:
             number = 0  # index of to_kvs


### PR DESCRIPTION
This PR removes `ImageEmbed.bypass_average` as it is never written to.

The field was introduced in https://github.com/Mikubill/sd-webui-controlnet/pull/2661
sd-webui-animatediff also does not write to this field: https://github.com/search?q=repo%3Acontinue-revolution%2Fsd-webui-animatediff%20bypass_average&type=code

The implementation to bypass average is also incorrect as it also bypasses ipadapter's projections.