### PR TITLE
Make ip-adapter face_id pick largest face instead of first face

### DIFF
--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from transformers.models.clip.modeling_clip import CLIPVisionModelOutput
 
 from annotator.util import HWC3
-from typing import Callable, Tuple, Union, List
+from typing import Callable, Tuple, Union
 
 from modules.safe import Extra
 from modules import devices


### PR DESCRIPTION
This PR makes `ip-adapter_face_id*` preprocessors pick largest face detected instead of first face detected. This is the same behaviour in instantid preprocessor.

This change is helps user get more control on preprocessor result, as how insightface decides which face is the first face is not very clear to the user.