### PR TITLE
Install fix, albumentations pydantic insightface, onnxruntime-gpu

### DIFF
--- a/install.py
+++ b/install.py
@@ -63,6 +63,20 @@ def install_requirements(req_file):
                 )
 
 
+def install_onnxruntime():
+    """
+    Install onnxruntime or onnxruntime-gpu based on the availability of CUDA.
+    onnxruntime and onnxruntime-gpu can not be installed together.
+    """
+    if not launch.is_installed("onnxruntime") and not launch.is_installed("onnxruntime-gpu"):
+        import torch.cuda as cuda # torch import head to improve loading time
+        onnxruntime = 'onnxruntime-gpu' if cuda.is_available() else 'onnxruntime'
+        launch.run_pip(
+            f'install {onnxruntime}',
+            f"sd-webui-controlnet requirement: {onnxruntime}",
+        )
+
+
 def try_install_from_wheel(pkg_name: str, wheel_url: str, version: Optional[str] = None):
     current_version = get_installed_version(pkg_name)
     if current_version is not None:
@@ -140,6 +154,7 @@ def try_remove_legacy_submodule():
 
 
 install_requirements(main_req_file)
+install_onnxruntime()
 try_install_insight_face()
 try_install_from_wheel(
     "handrefinerportable",

--- a/install.py
+++ b/install.py
@@ -103,10 +103,17 @@ def try_install_insight_face():
         and python_version.minor == 10
     ):
         try:
+            current_pydantic_version = get_installed_version('pydantic')
             launch.run_pip(
                 f"install {wheel_url}",
                 "sd-webui-controlnet requirement: insightface",
             )
+            post_install_pydantic_version = get_installed_version('pydantic')
+            if current_pydantic_version and post_install_pydantic_version and current_pydantic_version != post_install_pydantic_version:
+                launch.run_pip(
+                    f"install -U pydantic=={current_pydantic_version}",
+                    f"restore pydantic version to {current_pydantic_version}",
+                )
         except Exception as e:
             print(e)
             print(

--- a/install.py
+++ b/install.py
@@ -1,5 +1,5 @@
 import launch
-import pkg_resources
+from importlib import metadata
 import sys
 import os
 import shutil
@@ -18,7 +18,7 @@ def comparable_version(version: str) -> Tuple:
 
 def get_installed_version(package: str) -> Optional[str]:
     try:
-        return pkg_resources.get_distribution(package).version
+        return metadata.version(package)
     except Exception:
         return None
 

--- a/install.py
+++ b/install.py
@@ -117,17 +117,10 @@ def try_install_insight_face():
         and python_version.minor == 10
     ):
         try:
-            current_pydantic_version = get_installed_version('pydantic')
             launch.run_pip(
                 f"install {wheel_url}",
                 "sd-webui-controlnet requirement: insightface",
             )
-            post_install_pydantic_version = get_installed_version('pydantic')
-            if current_pydantic_version and post_install_pydantic_version and current_pydantic_version != post_install_pydantic_version:
-                launch.run_pip(
-                    f"install -U pydantic=={current_pydantic_version}",
-                    f"restore pydantic version to {current_pydantic_version}",
-                )
         except Exception as e:
             print(e)
             print(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ opencv-python>=4.8.0
 svglib
 addict
 yapf
+albumentations==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 fvcore
 mediapipe
-onnxruntime
 opencv-python>=4.8.0
 svglib
 addict


### PR DESCRIPTION
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15556
First critical installation issue
`insightface` specifies `any` version of `albumentations`
and so will pip will install the newest version of `albumentations`
`albumentations` had an update `1.4.4` in the past 24 hr see [pypi/albumentations/history](https://pypi.org/project/albumentations/#history) 
it introduces a new requirement
- pydantic required: >=2.6.4

webui 1.9 with gradio==3.41.2 / fastapi==0.94.0 requires
- pydantic required: >=1.7.4,<3.0.0,!=2.0.1,!=2.0.0,!=1.8.1,!=1.8

webui 1.9 is not compatible with `pydantic>=2.0`
which causes web UI to not launch
- I believe this will change when we update to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14184

solution for now
in controlnet
pin `albumentations==1.4.3` as control net requirement
if `albumentations==1.4.3` is installed before `insightface` pip won't auto install  the newest version `1.4.4`

I did a quick tested with `ip-adapter`, variant all seems to work fine after this PR, but today is the first time I use this so I'm not sure if it's actually working properly

---

To get webui back working
```ps1
pip install albumentations==1.4.3
pip install pydantic==1.10.15
```

<details><summary>outdated</summary>
<p>

First
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15556
after install of `insightface` `pydantic` will update from `1.10.15` -> `2.7.0`
and as far as I'm aware it is not compatible with `fastapi==0.94.0` / `gradio==3.41.2`
and woud cause webui to crash

so to "fix" this I've added some code that would revert the `pydantic` version to what it was after `insightface` is installed
I'm not sure because I have not played with ip-adapter before
but this downgrading `pydantic` to `1.10.15`  seems to casue `ip-adapter_face_id/plus` to break

</p>
</details> 

---

Second issue not as critical
they exist `onnxruntime` and `onnxruntime-gpu`
as far as I know they are interchangeable but they cannot coexist in the same environment (unless things has changed since)
in lots of use cases it doesn't really matter if you're running on CPU but for other extensions they might requires the extra performance

so I believe currently it's best to install the GPU version even if you don't need it as long as GPU is available

these are several instances of extensions checking for GPU  before installing the appropriate onnxruntime
https://github.com/Gourieff/sd-webui-reactor/blob/main/install.py#L104-L124
https://github.com/Gourieff/sd-webui-reactor/pull/170#issuecomment-1793504391
https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/blob/main/install.py
https://github.com/aria1th/sd-webui-nsfw-filter/blob/main/install.py
https://github.com/diffus-me/sd-webui-facefusion/blob/main/install.py#L22-L28


---

other changes
- [pkg_resources -> importlib.metadata](https://github.com/Mikubill/sd-webui-controlnet/pull/2761/commits/400d64844a611dca03b600a02f8d92c569feb13b)
- I originally changed this because it seems in python3.12 pkg_resources will no longer be pre-installed
https://docs.python.org/3/whatsnew/3.12.html
and it seems to work better as in it's able to observe version changes before and after installation of packages
in previous commit I observedly change in the versions of packages and and reverting it
not important but since I already change I didn't bother reverting it