### PR TITLE
Fix ControlNet unit preset

### DIFF
--- a/scripts/controlnet_ui/preset.py
+++ b/scripts/controlnet_ui/preset.py
@@ -153,15 +153,6 @@ class ControlNetPresetUI(object):
                 logger.error(e)
                 new_control_type = control_type
 
-            if new_control_type != control_type:
-                uigroup.prevent_next_n_module_update += 1
-
-            if preset_unit.module != current_unit.module:
-                uigroup.prevent_next_n_slider_value_update += 1
-
-            if preset_unit.pixel_perfect != current_unit.pixel_perfect:
-                uigroup.prevent_next_n_slider_value_update += 1
-
             return (
                 gr.update(visible=True),
                 gr.update(value=new_control_type),


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2765.

These prevent slider update fields are pretty flaky thus removed on the ui group. The leftover references are removed in this PR.