### PR TITLE
Add preset ip-adapter_sd15_plus

### DIFF
--- a/scripts/ipadapter/presets.py
+++ b/scripts/ipadapter/presets.py
@@ -16,6 +16,9 @@ class IPAdapterPreset(NamedTuple):
     @staticmethod
     def match_model(model_name: str) -> IPAdapterPreset:
         model_name = model_name.split("[")[0].strip()
+        assert (
+            model_name in _preset_by_model
+        ), f"{model_name} not found in ipadapter presets. Please try manually pick preprocessor."
         return _preset_by_model[model_name]
 
 
@@ -54,6 +57,12 @@ ipadapter_presets: List[IPAdapterPreset] = [
         name="plus",
         module=clip_h,
         model="ip-adapter-plus_sd15",
+        sd_version=StableDiffusionVersion.SD1x,
+    ),
+    IPAdapterPreset(
+        name="plus",
+        module=clip_h,
+        model="ip-adapter_sd15_plus",
         sd_version=StableDiffusionVersion.SD1x,
     ),
     IPAdapterPreset(


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2786.

I am not sure why we have both `ip-adapter-plus_sd15` and `ip-adapter_sd15_plus`. I also have `ip-adapter_sd15_plus` downloaded in my models directory, but it is not in the official repo: https://huggingface.co/h94/IP-Adapter/tree/main/models.

Guess I will add it anyway since some people get this model name from legacy downloads.