### PR TITLE
Restore various control type changes

### DIFF
--- a/scripts/preprocessor/legacy/preprocessor_compiled.py
+++ b/scripts/preprocessor/legacy/preprocessor_compiled.py
@@ -29,7 +29,7 @@ legacy_preprocessors = {
     #     "slider_3": None,
     #     "priority": 20,
     #     "tags": [
-    #         "Canny", "Lineart", "Scribble", "Sketch", "MLSD",
+    #         "Canny", "Lineart", "Scribble", "MLSD",
     #     ]
     # },
     "animal_openpose": {
@@ -929,7 +929,7 @@ legacy_preprocessors = {
         "slider_3": None,
         "priority": 0,
         "tags": [
-            "Scribble", "Sketch", "SparseCtrl",
+            "Scribble", "SparseCtrl",
         ]
     },
     "pidinet_scribble": {
@@ -945,7 +945,7 @@ legacy_preprocessors = {
         "slider_3": None,
         "priority": 100,
         "tags": [
-            "Scribble", "Sketch", "SparseCtrl",
+            "Scribble", "SparseCtrl",
         ]
     },
     # "scribble_xdog": {
@@ -971,7 +971,7 @@ legacy_preprocessors = {
     #     "slider_3": None,
     #     "priority": 0,
     #     "tags": [
-    #         "Scribble", "Sketch",
+    #         "Scribble",
     #     ]
     # },
     "anime_face_segment": {

--- a/scripts/preprocessor/legacy/preprocessor_compiled.py
+++ b/scripts/preprocessor/legacy/preprocessor_compiled.py
@@ -76,7 +76,7 @@ legacy_preprocessors = {
     #     "slider_3": None,
     #     "priority": 0,
     #     "tags": [
-    #         "Tile", "Blur",
+    #         "Tile",
     #     ]
     # },
     # "canny": {
@@ -1262,7 +1262,7 @@ legacy_preprocessors = {
         "slider_3": None,
         "priority": 0,
         "tags": [
-            "Tile", "Blur",
+            "Tile",
         ]
     },
     "tile_colorfix+sharp": {
@@ -1290,7 +1290,7 @@ legacy_preprocessors = {
         "slider_3": None,
         "priority": 0,
         "tags": [
-            "Tile", "Blur",
+            "Tile",
         ]
     },
     "tile_resample": {
@@ -1312,7 +1312,7 @@ legacy_preprocessors = {
         "slider_3": None,
         "priority": 100,
         "tags": [
-            "Tile", "Blur",
+            "Tile",
         ]
     }
 }

--- a/scripts/preprocessor/model_free_preprocessors.py
+++ b/scripts/preprocessor/model_free_preprocessors.py
@@ -12,6 +12,7 @@ class PreprocessorNone(Preprocessor):
     def __init__(self):
         super().__init__(name="none")
         self.sorting_priority = 10
+        self.tags = ["InstructP2P"]
 
     def __call__(
         self,
@@ -71,7 +72,6 @@ class PreprocessorInvert(Preprocessor):
             "Canny",
             "Lineart",
             "Scribble",
-            "Sketch",
             "MLSD",
         ]
         self.slider_resolution = PreprocessorParameter(visible=False)
@@ -121,7 +121,6 @@ class PreprocessorScribbleXdog(Preprocessor):
         )
         self.tags = [
             "Scribble",
-            "Sketch",
             "SparseCtrl",
         ]
 

--- a/scripts/preprocessor/model_free_preprocessors.py
+++ b/scripts/preprocessor/model_free_preprocessors.py
@@ -95,7 +95,7 @@ class PreprocessorBlurGaussian(Preprocessor):
         self.slider_1 = PreprocessorParameter(
             label="Sigma", minimum=64, maximum=2048, value=512
         )
-        self.tags = ["Tile", "Blur"]
+        self.tags = ["Tile"]
 
     def __call__(
         self,

--- a/scripts/supported_preprocessor.py
+++ b/scripts/supported_preprocessor.py
@@ -159,6 +159,7 @@ class Preprocessor(ABC):
             "ip-adapter": ["ip_adapter", "ipadapter"],
             "openpose": ["openpose", "densepose"],
             "instant-id": ["instant_id", "instantid"],
+            "scribble": ["sketch"],
         }
 
         tag = tag.lower()

--- a/scripts/supported_preprocessor.py
+++ b/scripts/supported_preprocessor.py
@@ -160,6 +160,7 @@ class Preprocessor(ABC):
             "openpose": ["openpose", "densepose"],
             "instant-id": ["instant_id", "instantid"],
             "scribble": ["sketch"],
+            "tile": ["blur"],
         }
 
         tag = tag.lower()


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2798

This PR does following tasks:
- Merge "blur" control type into "tile"
- Merge "sketch" control type into "scribble"
- Add "instructp2p" control type to "none" preprocessor

