### PR TITLE
Keep active preprocessor models

### DIFF
--- a/internal_controlnet/external_code.py
+++ b/internal_controlnet/external_code.py
@@ -283,6 +283,13 @@ class ControlNetUnit:
                     f"[{self.module}.{unit_param}] Invalid value({value}), using default value {cfg.value}."
                 )
 
+    def get_actual_preprocessor(self) -> Preprocessor:
+        if self.module == "ip-adapter-auto":
+            return Preprocessor.get_preprocessor(self.module).get_preprocessor_by_model(
+                self.model
+            )
+        return Preprocessor.get_preprocessor(self.module)
+
 
 def to_base64_nparray(encoding: str):
     """

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -187,6 +187,8 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
                 assert json_acceptor.value is not None
                 poses.append(json_acceptor.value)
 
+        preprocessor.unload()
+
         res = {"info": "Success"}
         if poses:
             res["poses"] = poses

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -936,6 +936,12 @@ class Script(scripts.Script, metaclass=(
             Script.clear_control_model_cache()
 
         self.latest_model_hash = p.sd_model.sd_model_hash
+
+        # Unload unused preprocessors
+        Preprocessor.unload_unused(active_processors={
+            unit.get_actual_preprocessor()
+            for unit in self.enabled_units
+        })
         high_res_fix = isinstance(p, StableDiffusionProcessingTxt2Img) and getattr(p, 'enable_hr', False)
 
         for idx, unit in enumerate(self.enabled_units):

--- a/scripts/preprocessor/ip_adapter_auto.py
+++ b/scripts/preprocessor/ip_adapter_auto.py
@@ -11,13 +11,16 @@ class PreprocessorIPAdapterAuto(Preprocessor):
         self.returns_image = False
         self.show_control_mode = False
 
+    @staticmethod
+    def get_preprocessor_by_model(model):
+        module: str = IPAdapterPreset.match_model(model).module
+        return Preprocessor.get_preprocessor(module)
+
     def __call__(self, *args, **kwargs):
         assert "model" in kwargs
         model: str = kwargs["model"]
-        module: str = IPAdapterPreset.match_model(model).module
-        logger.info(f"ip-adapter-auto => {module}")
-
-        p = Preprocessor.get_preprocessor(module)
+        p = PreprocessorIPAdapterAuto.get_preprocessor_by_model(model)
+        logger.info(f"ip-adapter-auto => {p.label}")
         assert p is not None
         return p(*args, **kwargs)
 

--- a/scripts/preprocessor/lama_inpaint.py
+++ b/scripts/preprocessor/lama_inpaint.py
@@ -46,8 +46,6 @@ class PreprocessorLamaInpaint(Preprocessor):
             self.model = LamaInpainting()
         # applied auto inversion
         prd_color = self.model(img_res)
-        self.model.unload_model()
-
         prd_color = remove_pad(prd_color)
         prd_color = cv2.resize(prd_color, (W, H))
 

--- a/scripts/preprocessor/legacy/legacy_preprocessors.py
+++ b/scripts/preprocessor/legacy/legacy_preprocessors.py
@@ -81,6 +81,15 @@ class LegacyPreprocessor(Preprocessor):
                 **legacy_dict["slider_3"], visible=True
             )
 
+        self.active_with_model = False
+
+    def unload(self):
+        if self.active_with_model:
+            self.unload_function()
+            self.active_with_model = False
+            return True
+        return False
+
     def __call__(
         self,
         input_image,
@@ -93,18 +102,14 @@ class LegacyPreprocessor(Preprocessor):
         # Legacy Preprocessors does not have slider 3
         del slider_3
 
-        if self.managed_model is not None:
-            assert self.unload_function is not None
-
         result, is_image = self.call_function(
             img=input_image, res=resolution, thr_a=slider_1, thr_b=slider_2, **kwargs
         )
+        if self.managed_model is not None:
+            self.active_with_model = True
 
         if is_image:
             result = HWC3(result)
-
-        if self.unload_function is not None:
-            self.unload_function()
 
         return result
 

--- a/scripts/preprocessor/normal_dsine.py
+++ b/scripts/preprocessor/normal_dsine.py
@@ -41,7 +41,6 @@ class PreprocessorNormalDsine(Preprocessor):
             iterations=int(slider_2),
             resulotion=resolution,
         )
-        self.model.unload_model()
         return result
 
 


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2800.

Preprocessor model unload behaviour changed in https://github.com/Mikubill/sd-webui-controlnet/pull/2754 to align with SD forge's impl. Forge does eager unload, which is not ideal for CLIP, which takes very long to load/unload. This PR restores the original behaviour which keeps active preprocessors between runs.