### PR TITLE
Add effective_region_mask for ControlNet [API]

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -451,7 +451,7 @@ class Script(scripts.Script, metaclass=(
                 # Falls through to load Controlllite model fresh.
                 # TODO Fix context sharing issue for Controlllite.
                 pass
-            elif not control_model.type.allow_context_sharing():
+            elif not control_model.type.allow_context_sharing:
                 # Creates a shallow-copy of control_model so that configs/inputs
                 # from different units can be bind correctly. While heavy objects
                 # of the underlying nn.Module is not copied.
@@ -981,7 +981,7 @@ class Script(scripts.Script, metaclass=(
                     p.controlnet_control_loras.append(control_lora)
 
             if unit.effective_region_mask is not None:
-                assert control_model_type == ControlModelType.IPAdapter, "Currently `effective_region_mask` is only supported for IPAdapter"
+                assert control_model_type.supports_effective_region_mask, f"`effective_region_mask` not supported for {control_model_type}"
 
             if unit.ipadapter_input is not None:
                 # Use ipadapter_input from API call.
@@ -1075,7 +1075,7 @@ class Script(scripts.Script, metaclass=(
             )
 
             global_average_pooling = (
-                control_model_type.is_controlnet() and
+                control_model_type.is_controlnet and
                 model_net.control_model.global_average_pooling
             )
             control_mode = external_code.control_mode_from_value(unit.control_mode)

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -174,6 +174,7 @@ class ControlModelType(Enum):
     InstantID = "InstantID, Qixun Wang"
     SparseCtrl = "SparseCtrl, Yuwei Guo"
 
+    @property
     def is_controlnet(self) -> bool:
         """Returns whether the control model should be treated as ControlNet."""
         return self in (
@@ -182,6 +183,7 @@ class ControlModelType(Enum):
             ControlModelType.InstantID,
         )
 
+    @property
     def allow_context_sharing(self) -> bool:
         """Returns whether this control model type allows the same PlugableControlModel
         object map to multiple ControlNetUnit.
@@ -192,6 +194,17 @@ class ControlModelType(Enum):
         return self not in (
             ControlModelType.IPAdapter,
             ControlModelType.Controlllite,
+        )
+
+    @property
+    def supports_effective_region_mask(self) -> bool:
+        return (
+            self
+            in {
+                ControlModelType.IPAdapter,
+                ControlModelType.T2I_Adapter,
+            }
+            or self.is_controlnet
         )
 
 

--- a/tests/web_api/effective_region_test.py
+++ b/tests/web_api/effective_region_test.py
@@ -2,6 +2,7 @@ from .template import (
     APITestTemplate,
     girl_img,
     realistic_girl_face_img,
+    living_room_img,
     mask_left,
     mask_right,
     disable_in_cq,
@@ -34,4 +35,23 @@ def test_effective_region_ipadapter():
                 "effective_region_mask": mask_right,
             },
         ],
+    ).exec()
+
+
+@disable_in_cq
+def test_effective_region_depth():
+    assert APITestTemplate(
+        "test_effective_region_depth",
+        "txt2img",
+        payload_overrides={
+            "prompt": "(masterpiece: 1.3), (highres: 1.3), best quality, A cozy living room",
+            "width": 768,
+            "height": 512,
+        },
+        unit_overrides={
+            "module": "depth_midas",
+            "model": get_model("control_v11f1p_sd15_depth"),
+            "image": living_room_img,
+            "effective_region_mask": mask_left,
+        },
     ).exec()

--- a/tests/web_api/template.py
+++ b/tests/web_api/template.py
@@ -77,6 +77,7 @@ mask_left = read_image(resource_dir / "mask_left.png")
 mask_right = read_image(resource_dir / "mask_right.png")
 portrait_imgs = read_image_dir(resource_dir / "portrait")
 realistic_girl_face_img = portrait_imgs[0]
+living_room_img = read_image(resource_dir / "living_room.webp")
 
 
 general_negative_prompt = """


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2451.

Currently only API support. GUI support will come later.

Previously effective_region_mask support was added to ipadapter in https://github.com/Mikubill/sd-webui-controlnet/pull/2785. Now it is added to ControlNet/T2IAdapter as well.

Example on depth control:
Input image:
![living_room](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/27ee1f4d-4c3e-42da-bb63-a94ccae2ab25)

Mask image:
![mask_left](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/ec1e2884-a3fc-4b29-b577-b1fc27ae7d50)

Output image:
![test_effective_region_depth_0](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/57a875d7-9e15-4feb-9441-1b1da236c6ce)

You can observe that only the left part of the generation got guided by the depth map.
