### PR TITLE
Fix upscale script checking

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -755,7 +755,7 @@ class Script(scripts.Script, metaclass=(
         # based on `extra_generation_params` these scripts attach on `p`, and subject to change
         # in the future.
         # TODO: Change this to a more robust condition once A1111 offers a way to verify script name.
-        is_upscale_script = any("upscale" in k.lower() for k in getattr(p, "extra_generation_params", {}).keys())
+        is_upscale_script = any("upscale" in k.lower() and "Hires" not in k for k in getattr(p, "extra_generation_params", {}).keys())
         logger.debug(f"is_upscale_script={is_upscale_script}")
         # Note: `inpaint_full_res` is "inpaint area" on UI. The flag is `True` when "Only masked"
         # option is selected.


### PR DESCRIPTION
If Hires fix is enabled, controlnet inpu image will always be cropped since Hires fix's script name is `Hires Upscale(r)`.
This causes issues with some extensions like ADetailer. 
One case is when using IP-Adapter FaceID with ADetailer, the input face image will be cropped, and Insightface will fail to detect faces in the cropped image.

![Screenshot 2024-05-11 052216](https://github.com/Mikubill/sd-webui-controlnet/assets/5442563/74511ef6-bebb-47fa-92b5-058b535cbb6b)


This pull request fixes this issue.

For future improvement, I suggest that a new argument (e.g. `is_cropping_disabled` with default value `False`) should be added to allow third-party extension to disable this cropping feature.

![image](https://github.com/Mikubill/sd-webui-controlnet/assets/5442563/24032cb1-b890-454e-8c6b-a0f4da4de34c)
