### PR TITLE
Add PuLID VRAM leak reproduction tests

### DIFF
--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -5,6 +5,7 @@ from typing import List
 from .template import (
     APITestTemplate,
     realistic_girl_face_img,
+    portrait_imgs,
     girl_img,
     mask_img,
     save_base64,
@@ -89,6 +90,17 @@ def test_inpaint_mask(module: str):
         controlnet_module=module,
     )
     detect_template(payload, f"detect_inpaint_mask_{module}")
+
+
+@disable_in_cq
+@pytest.mark.parametrize("img_index", [i for i, _ in enumerate(portrait_imgs)])
+def test_pulid(img_index: int):
+    """PuLID preprocessor should not memory leak."""
+    payload = dict(
+        controlnet_input_images=[portrait_imgs[img_index]],
+        controlnet_module="ip-adapter_pulid",
+    )
+    detect_template(payload, f"detect_pulid_{img_index}")
 
 
 @pytest.mark.parametrize("module", [m for m in UNSUPPORTED_PREPROCESSORS])

--- a/tests/web_api/generation_test.py
+++ b/tests/web_api/generation_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from .template import (
     APITestTemplate,
+    portrait_imgs,
     girl_img,
     mask_img,
     disable_in_cq,
@@ -305,3 +306,22 @@ def test_ip_adapter_auto():
         ).exec()
 
         assert log_context.is_in_console_logs(["ip-adapter-auto => ip-adapter_clip_h"])
+
+
+@disable_in_cq
+@pytest.mark.parametrize("img_index", [i for i, _ in enumerate(portrait_imgs)])
+def test_pulid(img_index: int):
+    """PuLID should not memory leak."""
+    assert APITestTemplate(
+        f"txt2img_pulid_{img_index}",
+        "txt2img",
+        payload_overrides={
+            "width": 768,
+            "height": 768,
+        },
+        unit_overrides={
+            "image": portrait_imgs[img_index],
+            "model": get_model("ip-adapter_pulid_sdxl_fp16"),
+            "module": "ip-adapter_pulid",
+        },
+    ).exec()


### PR DESCRIPTION
https://github.com/Mikubill/sd-webui-controlnet/issues/2862

This PR adds tests on `detect` endpoint on PuLID and generation with PuLID.

To run test:
- Open task manager to monitor VRAM usage
- Make sure an SDXL model is selected
- Install test dependencies by executing `pip install -r requirements-test.txt` under webui directory
- Under webui directory, execute `python -m pytest --junitxml=test/results.xml --cov .\extensions\sd-webui-controlnet\ --cov-report=xml --verify-base-url .\extensions\sd-webui-controlnet\tests\web_api\generation_test.py::test_pulid` to run generation test.

Observation:
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/848775e0-13c2-49f9-b119-c760e101eab6)
You can observe that vram generally kept stable after 6 runs with different ref images.