### PR TITLE
Fix test expectation

### DIFF
--- a/tests/web_api/modules_test.py
+++ b/tests/web_api/modules_test.py
@@ -67,7 +67,7 @@ expected_module_names = {
     "scribble_xdog",
     "segmentation",
     "shuffle",
-    "te_hed",
+    "softedge_teed",
     "threshold",
     "tile_colorfix",
     "tile_colorfix+sharp",


### PR DESCRIPTION
`te_hed` alias will no longer be supported.