### PR TITLE
Fix ControlNetUnit copy issue

### DIFF
--- a/internal_controlnet/args.py
+++ b/internal_controlnet/args.py
@@ -471,3 +471,7 @@ class ControlNetUnit(BaseModel):
                 for (key, value) in (item.strip().split(": "),)
             },
         )
+
+    def __copy__(self) -> ControlNetUnit:
+        """Override the behavior on `copy.copy` calls."""
+        return self.copy()

--- a/unit_tests/args_test.py
+++ b/unit_tests/args_test.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import numpy as np
+from copy import copy
 from dataclasses import dataclass
 
 from internal_controlnet.args import ControlNetUnit
@@ -249,3 +250,11 @@ def test_infotext_parsing():
 
 def test_alias():
     ControlNetUnit.from_dict({"lowvram": True})
+
+
+def test_copy():
+    unit1 = ControlNetUnit(enabled=True, module="none")
+    unit2 = copy(unit1)
+    unit2.enabled = False
+    assert unit1.enabled
+    assert not unit2.enabled


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2871.

Pydantic BaseModel does not copy correctly when using python stdlib's `copy.copy` to perform shallow copy by default. This PR fixes that.