### PR TITLE
Set default value of ControlNetUnit.enabled to True

### DIFF
--- a/internal_controlnet/args.py
+++ b/internal_controlnet/args.py
@@ -73,7 +73,7 @@ class ControlNetUnit(BaseModel):
     loopback: bool = False
 
     # General fields.
-    enabled: bool = False
+    enabled: bool = True
     module: str = "none"
 
     @validator("module", always=True, pre=True)

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -666,7 +666,7 @@ class ControlNetUiGroup(object):
             self.pulid_mode,
         )
 
-        unit = gr.State(ControlNetUnit())
+        unit = gr.State(ControlNetUnit(enabled=False))
 
         # It is necessary to update unit state actively to avoid potential
         # flaky racing issue.

--- a/tests/web_api/detect_test.py
+++ b/tests/web_api/detect_test.py
@@ -94,6 +94,7 @@ def test_inpaint_mask(module: str):
 
 @disable_in_cq
 @pytest.mark.parametrize("img_index", [i for i, _ in enumerate(portrait_imgs)])
+@pytest.mark.skip(reason="test is for SDXL only")
 def test_pulid(img_index: int):
     """PuLID preprocessor should not memory leak."""
     payload = dict(

--- a/tests/web_api/generation_test.py
+++ b/tests/web_api/generation_test.py
@@ -310,6 +310,7 @@ def test_ip_adapter_auto():
 
 @disable_in_cq
 @pytest.mark.parametrize("img_index", [i for i, _ in enumerate(portrait_imgs)])
+@pytest.mark.skip(reason="test is for SDXL only")
 def test_pulid(img_index: int):
     """PuLID should not memory leak."""
     assert APITestTemplate(


### PR DESCRIPTION
Previous PR https://github.com/Mikubill/sd-webui-controlnet/pull/2847 set the default value to `False`. However I noticed that some extensions are relying on the default True value of ControlNetUnit.enabled.

This PR restore the old behaviour.