### PR TITLE
Fix depth_zoe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ yapf
 albumentations==1.4.3
 matplotlib
 facexlib
+timm<=0.9.5


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2608.

According to https://github.com/Mikubill/sd-webui-controlnet/issues/2608#issuecomment-2125418379, timm 0.9.5 is the last good version that runs depth_zoe without problem.