### PR TITLE
Add batch_keyframe_idx on ControlNetUnit

### DIFF
--- a/internal_controlnet/args.py
+++ b/internal_controlnet/args.py
@@ -228,6 +228,7 @@ class ControlNetUnit(BaseModel):
     animatediff_batch: bool = False
     batch_modifiers: list = []
     batch_image_files: list = []
+    batch_keyframe_idx: Optional[str|list] = None
 
     @property
     def accepts_multiple_inputs(self) -> bool:


### PR DESCRIPTION
batch_keyframe_idx is needed by AnimateDiff for SparseCtrl