### PR TITLE
Fix issue with > in pip cmd causing file creation

### DIFF
--- a/install.py
+++ b/install.py
@@ -38,7 +38,7 @@ def install_requirements(req_file):
                     installed_version = get_installed_version(package_name)
                     if installed_version != package_version:
                         launch.run_pip(
-                            f"install -U {package}",
+                            f'install -U "{package}"',
                             f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}",
                         )
                 elif ">=" in package:
@@ -48,7 +48,7 @@ def install_requirements(req_file):
                         installed_version
                     ) < comparable_version(package_version):
                         launch.run_pip(
-                            f"install -U {package}",
+                            f'install -U "{package}"',
                             f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}",
                         )
                 elif "<=" in package:
@@ -58,12 +58,12 @@ def install_requirements(req_file):
                         installed_version
                     ) > comparable_version(package_version):
                         launch.run_pip(
-                            f"install {package_name}=={package_version}",
+                            f'install "{package_name}=={package_version}"',
                             f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}",
                         )
                 elif not launch.is_installed(extract_base_package(package)):
                     launch.run_pip(
-                        f"install {package}",
+                        f'install "{package}"',
                         f"sd-webui-controlnet requirement: {package}",
                     )
             except Exception as e:


### PR DESCRIPTION
### Problem Summary

When starting the Web UI, the `install.py` script reads `requirements.txt`. If a package version uses ">", it is treated as a redirection in `pip install`, creating an unintended file.

### Steps to Reproduce

Running `webui.bat` or `webui.sh` creates a file named "=4.8.0" due to "opencv-python>=4.8.0" in `requirements.txt` being misinterpreted.

### Fix

I enclosed the package and version specification in double quotes in `install.py`.