### PR TITLE
Add pydantic dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ albumentations==1.4.3
 matplotlib
 facexlib
 timm<=0.9.5
+pydantic<=1.10.17


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2967.

User reported issue with pydantic 2.0+ installed. This PR explicitly adds the pydantic dependency.