### PR TITLE
Support union ControlNet

### DIFF
--- a/internal_controlnet/args.py
+++ b/internal_controlnet/args.py
@@ -15,6 +15,7 @@ from scripts.enums import (
     ControlMode,
     HiResFixOption,
     PuLIDMode,
+    ControlNetUnionControlType,
 )
 from annotator.util import HWC3
 
@@ -201,6 +202,11 @@ class ControlNetUnit(BaseModel):
     # The weight mode for PuLID.
     # https://github.com/ToTheBeginning/PuLID
     pulid_mode: PuLIDMode = PuLIDMode.FIDELITY
+
+    # ControlNet control type for ControlNet union model.
+    # https://github.com/xinsir6/ControlNetPlus/tree/main
+    # The value of this field is only used when the model is ControlNetUnion.
+    union_control_type: ControlNetUnionControlType = ControlNetUnionControlType.UNKNOWN
 
     # ------- API only fields -------
     # The tensor input for ipadapter. When this field is set in the API,

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1047,6 +1047,7 @@ class Script(scripts.Script, metaclass=(
                     if unit.effective_region_mask is not None
                     else None
                 ),
+                union_control_types=[unit.union_control_type],
             )
             forward_params.append(forward_param)
 

--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -1027,6 +1027,10 @@ class Script(scripts.Script, metaclass=(
                 control_model_type.is_controlnet and
                 model_net.control_model.global_average_pooling
             )
+
+            if control_model_type == ControlModelType.ControlNetUnion:
+                logger.info(f"ControlNetUnion control type: {unit.union_control_type}")
+
             forward_param = ControlParams(
                 control_model=model_net,
                 preprocessor=preprocessor_dict,
@@ -1047,6 +1051,7 @@ class Script(scripts.Script, metaclass=(
                     if unit.effective_region_mask is not None
                     else None
                 ),
+                # TODO: Implement merge of units with the same union model.
                 union_control_types=[unit.union_control_type],
             )
             forward_params.append(forward_param)

--- a/scripts/controlnet_core/controlnet_union.py
+++ b/scripts/controlnet_core/controlnet_union.py
@@ -1,0 +1,136 @@
+from collections import OrderedDict
+import torch
+import torch.nn as nn
+
+try:
+    from sgm.modules.diffusionmodules.openaimodel import (
+        conv_nd,
+        linear,
+        zero_module,
+        timestep_embedding,
+        TimestepEmbedSequential,
+        ResBlock,
+        Downsample,
+        SpatialTransformer,
+        exists,
+    )
+
+    using_sgm = True
+except ImportError:
+    from ldm.modules.diffusionmodules.openaimodel import (
+        conv_nd,
+        linear,
+        zero_module,
+        timestep_embedding,
+        TimestepEmbedSequential,
+        ResBlock,
+        Downsample,
+        SpatialTransformer,
+        exists,
+    )
+
+    using_sgm = False
+
+
+def attention_pytorch(
+    q, k, v, heads, mask=None, attn_precision=None, skip_reshape=False
+):
+    if skip_reshape:
+        b, _, _, dim_head = q.shape
+    else:
+        b, _, dim_head = q.shape
+        dim_head //= heads
+        q, k, v = map(
+            lambda t: t.view(b, -1, heads, dim_head).transpose(1, 2),
+            (q, k, v),
+        )
+
+    out = torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False
+    )
+    out = out.transpose(1, 2).reshape(b, -1, heads * dim_head)
+    return out
+
+
+class ControlAddEmbedding(nn.Module):
+    def __init__(
+        self,
+        in_dim,
+        out_dim,
+        num_control_type,
+        dtype=None,
+        device=None,
+    ):
+        super().__init__()
+        self.num_control_type = num_control_type
+        self.in_dim = in_dim
+        self.linear_1 = nn.Linear(
+            in_dim * num_control_type, out_dim, dtype=dtype, device=device
+        )
+        self.linear_2 = nn.Linear(out_dim, out_dim, dtype=dtype, device=device)
+
+    def forward(self, control_type, dtype, device):
+        c_type = torch.zeros((self.num_control_type,), device=device)
+        c_type[control_type] = 1.0
+        c_type = (
+            timestep_embedding(c_type.flatten(), self.in_dim, repeat_only=False)
+            .to(dtype)
+            .reshape((-1, self.num_control_type * self.in_dim))
+        )
+        return self.linear_2(torch.nn.functional.silu(self.linear_1(c_type)))
+
+
+class OptimizedAttention(nn.Module):
+    def __init__(self, c, nhead, dropout=0.0, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.heads = nhead
+        self.c = c
+
+        self.in_proj = nn.Linear(
+            c, c * 3, bias=True, dtype=dtype, device=device
+        )
+        self.out_proj = nn.Linear(c, c, bias=True, dtype=dtype, device=device)
+
+    def forward(self, x):
+        x = self.in_proj(x)
+        q, k, v = x.split(self.c, dim=2)
+        out = attention_pytorch(q, k, v, self.heads)
+        return self.out_proj(out)
+
+
+class QuickGELU(nn.Module):
+    def forward(self, x: torch.Tensor):
+        return x * torch.sigmoid(1.702 * x)
+
+
+class ResBlockUnionControlnet(nn.Module):
+    def __init__(self, dim, nhead, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.attn = OptimizedAttention(
+            dim, nhead, dtype=dtype, device=device, operations=operations
+        )
+        self.ln_1 = nn.LayerNorm(dim, dtype=dtype, device=device)
+        self.mlp = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "c_fc",
+                        nn.Linear(dim, dim * 4, dtype=dtype, device=device),
+                    ),
+                    ("gelu", QuickGELU()),
+                    (
+                        "c_proj",
+                        nn.Linear(dim * 4, dim, dtype=dtype, device=device),
+                    ),
+                ]
+            )
+        )
+        self.ln_2 = nn.LayerNorm(dim, dtype=dtype, device=device)
+
+    def attention(self, x: torch.Tensor):
+        return self.attn(x)
+
+    def forward(self, x: torch.Tensor):
+        x = x + self.attention(self.ln_1(x))
+        x = x + self.mlp(self.ln_2(x))
+        return x

--- a/scripts/controlnet_core/controlnet_union.py
+++ b/scripts/controlnet_core/controlnet_union.py
@@ -4,29 +4,13 @@ import torch.nn as nn
 
 try:
     from sgm.modules.diffusionmodules.openaimodel import (
-        conv_nd,
-        linear,
-        zero_module,
         timestep_embedding,
-        TimestepEmbedSequential,
-        ResBlock,
-        Downsample,
-        SpatialTransformer,
-        exists,
     )
 
     using_sgm = True
 except ImportError:
     from ldm.modules.diffusionmodules.openaimodel import (
-        conv_nd,
-        linear,
-        zero_module,
         timestep_embedding,
-        TimestepEmbedSequential,
-        ResBlock,
-        Downsample,
-        SpatialTransformer,
-        exists,
     )
 
     using_sgm = False
@@ -86,9 +70,7 @@ class OptimizedAttention(nn.Module):
         self.heads = nhead
         self.c = c
 
-        self.in_proj = nn.Linear(
-            c, c * 3, bias=True, dtype=dtype, device=device
-        )
+        self.in_proj = nn.Linear(c, c * 3, bias=True, dtype=dtype, device=device)
         self.out_proj = nn.Linear(c, c, bias=True, dtype=dtype, device=device)
 
     def forward(self, x):

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -5,6 +5,7 @@ import itertools
 from typing import List, Optional, Union, Dict, Tuple, Literal, Any
 from dataclasses import dataclass
 import numpy as np
+from scipy.__config__ import show
 
 from scripts.supported_preprocessor import Preprocessor
 from scripts.utils import svg_preprocess, read_image
@@ -266,7 +267,7 @@ class ControlNetUiGroup(object):
         self.output_dir_state = None
         self.advanced_weighting = gr.State(None)
         self.pulid_mode = None
-        self.union_control_type = gr.State(ControlNetUnionControlType.UNKNOWN)
+        self.union_control_type = None
 
         # API-only fields
         self.ipadapter_input = gr.State(None)
@@ -486,6 +487,13 @@ class ControlNetUiGroup(object):
                 label="Crop input image based on A1111 mask",
                 value=False,
                 elem_classes=["cnet-crop-input-image"],
+                visible=False,
+            )
+
+        with gr.Row():
+            self.union_control_type = gr.Textbox(
+                label="Union Control Type",
+                value=ControlNetUnionControlType.UNKNOWN.value,
                 visible=False,
             )
 
@@ -848,7 +856,7 @@ class ControlNetUiGroup(object):
         def filter_selected(k: str):
             control_type = ControlNetUnionControlType.from_str(k)
             logger.debug(f"Switch to union control type {control_type}")
-            return control_type
+            return gr.update(value=control_type.value)
 
         self.type_filter.change(
             fn=filter_selected,

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -5,7 +5,6 @@ import itertools
 from typing import List, Optional, Union, Dict, Tuple, Literal, Any
 from dataclasses import dataclass
 import numpy as np
-from scipy.__config__ import show
 
 from scripts.supported_preprocessor import Preprocessor
 from scripts.utils import svg_preprocess, read_image

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -24,6 +24,7 @@ from scripts.enums import (
     PuLIDMode,
     ControlMode,
     ResizeMode,
+    ControlNetUnionControlType,
 )
 from modules import shared
 from modules.ui_components import FormRow, FormHTML, ToolButton
@@ -265,6 +266,7 @@ class ControlNetUiGroup(object):
         self.output_dir_state = None
         self.advanced_weighting = gr.State(None)
         self.pulid_mode = None
+        self.union_control_type = gr.State(ControlNetUnionControlType.UNKNOWN)
 
         # API-only fields
         self.ipadapter_input = gr.State(None)
@@ -664,6 +666,7 @@ class ControlNetUiGroup(object):
             self.advanced_weighting,
             self.effective_region_mask,
             self.pulid_mode,
+            self.union_control_type,
         )
 
         unit = gr.State(ControlNetUnit())
@@ -838,6 +841,19 @@ class ControlNetUiGroup(object):
             fn=filter_selected,
             inputs=[self.type_filter],
             outputs=[self.module, self.model],
+            show_progress=False,
+        )
+
+    def register_union_control_type(self):
+        def filter_selected(k: str):
+            control_type = ControlNetUnionControlType.from_str(k)
+            logger.debug(f"Switch to union control type {control_type}")
+            return control_type
+
+        self.type_filter.change(
+            fn=filter_selected,
+            inputs=[self.type_filter],
+            outputs=[self.union_control_type],
             show_progress=False,
         )
 
@@ -1227,6 +1243,7 @@ class ControlNetUiGroup(object):
         self.register_webcam_mirror_toggle()
         self.register_refresh_all_models()
         self.register_build_sliders()
+        self.register_union_control_type()
         self.register_shift_preview()
         self.register_shift_upload_mask()
         self.register_shift_pulid_mode()

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
 from enum import Enum
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Set
 from functools import lru_cache
 
 
@@ -173,6 +174,7 @@ class ControlModelType(Enum):
     Controlllite = "Controlllite, Kohya"
     InstantID = "InstantID, Qixun Wang"
     SparseCtrl = "SparseCtrl, Yuwei Guo"
+    ControlNetUnion = "ControlNetUnion, xinsir6"
 
     @property
     def is_controlnet(self) -> bool:
@@ -181,6 +183,7 @@ class ControlModelType(Enum):
             ControlModelType.ControlNet,
             ControlModelType.ControlLoRA,
             ControlModelType.InstantID,
+            ControlModelType.ControlNetUnion,
         )
 
     @property
@@ -273,3 +276,46 @@ class ResizeMode(Enum):
         elif self == ResizeMode.OUTER_FIT:
             return 2
         assert False, "NOTREACHED"
+
+
+class ControlNetUnionControlType(Enum):
+    """
+    ControlNet control type for ControlNet union model.
+    https://github.com/xinsir6/ControlNetPlus/tree/main
+    """
+
+    OPENPOSE = "OpenPose"
+    DEPTH = "Depth"
+    # hed/pidi/scribble/ted
+    SOFT_EDGE = "Soft Edge"
+    # canny/lineart/anime_lineart/mlsd
+    HARD_EDGE = "Hard Edge"
+    NORMAL_MAP = "Normal Map"
+    SEGMENTATION = "Segmentation"
+
+    UNKNOWN = "Unknown"
+
+    @staticmethod
+    def from_str(s: str) -> ControlNetUnionControlType:
+        s = s.lower()
+
+        if s == "openpose":
+            return ControlNetUnionControlType.OPENPOSE
+        elif s == "depth":
+            return ControlNetUnionControlType.DEPTH
+        elif s in ["scribble", "softedge"]:
+            return ControlNetUnionControlType.SOFT_EDGE
+        elif s in ["canny", "lineart", "mlsd"]:
+            return ControlNetUnionControlType.HARD_EDGE
+        elif s == "normalmap":
+            return ControlNetUnionControlType.NORMAL_MAP
+        elif s == "segmentation":
+            return ControlNetUnionControlType.SEGMENTATION
+
+        return ControlNetUnionControlType.UNKNOWN
+
+    def int_value(self) -> int:
+        if self == ControlNetUnionControlType.UNKNOWN:
+            raise ValueError("Unknown control type cannot be encoded.")
+
+        return list(ControlNetUnionControlType).index(self)

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from enum import Enum
-from typing import List, NamedTuple, Set
+from typing import List, NamedTuple
 from functools import lru_cache
 
 

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -296,6 +296,21 @@ class ControlNetUnionControlType(Enum):
     UNKNOWN = "Unknown"
 
     @staticmethod
+    def all_tags() -> List[str]:
+        """ Tags can be handled by union ControlNet """
+        return [
+            "openpose",
+            "depth",
+            "softedge",
+            "scribble",
+            "canny",
+            "lineart",
+            "mlsd",
+            "normalmap",
+            "segmentation",
+        ]
+
+    @staticmethod
     def from_str(s: str) -> ControlNetUnionControlType:
         s = s.lower()
 

--- a/scripts/supported_preprocessor.py
+++ b/scripts/supported_preprocessor.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 
 from modules import shared, devices
+from scripts.enums import ControlNetUnionControlType
 from scripts.logging import logger
 from scripts.utils import ndarray_lru_cache
 
@@ -173,7 +174,8 @@ class Preprocessor(ABC):
         }
 
         tag = tag.lower()
-        return set([tag] + filters_aliases.get(tag, []))
+        union_tags = ["union"] if tag in ControlNetUnionControlType.all_tags() else []
+        return set([tag] + filters_aliases.get(tag, []) + union_tags)
 
     @classmethod
     def unload_unused(cls, active_processors: Set["Preprocessor"]):


### PR DESCRIPTION
Closes https://github.com/Mikubill/sd-webui-controlnet/issues/2986

https://huggingface.co/xinsir/controlnet-union-sdxl-1.0

## Openpose
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/2f08888d-0adc-4677-ae41-678181674a97)
![00021-1413879340](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/e0426c7b-9a7e-473c-8e61-9b777ed5d753)

Do not use key map with face and hand as the union controlnet does not seem to be trained with hand/face annotation
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/702a071c-dec2-4dd9-bf96-87f9b9f8375b)
![00020-1413879340](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/b6b7188d-890c-4e64-a336-9f790e5bf10d)

## Canny
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/625df0a1-9580-48eb-b7bc-f65c052c6804)
![00017-1413879340](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/7f4b7663-3eb6-4bdd-b3f0-49ab8972cf73)

## Depth
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/7c98e394-60b8-4718-b7b8-7bcd54e04dab)
![00018-1413879340](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/cba1f5d7-5a23-4968-a1dc-02ac2707a538)

## SoftEdge
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/c8e47ce5-2673-4029-83d8-c0b72d351609)
![00019-1413879340](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/08198e17-7fea-4026-ab00-7ce11fe0f87a)

## Normal
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/dff25b2b-9755-48ae-acb7-9333bd692fcb)
![00022-1413879340](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/99d9af38-15b0-4bed-9ae5-a6f34bf88553)

## Segmentation
Note: `ofade20k` preprocessor does not seem to work
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/569dcf7d-7ade-4174-b293-c5b79bd1004d)
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/2e5ce5e1-a8b9-4460-8357-2eae5182e42d)


# Multi-ControlNet
Currently the multi-controlnet is not working in the optimal way described in the original paper, but you can still try use it, as it can help you save VRAM by avoid loading another controlnet for different type of control.



## Unit1 setup
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/916d792b-3399-438d-b2e3-16dcb68cf568)

## Unit 2 setup
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/9fcb1cc6-10e0-446a-919f-ff1887297f1c)

## Generation result
![00026-1413879340](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/f10d0e77-e37f-4ad3-8d89-10f2434ceb15)
 
# Appendix
Input images
![image (1)](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/8c29b500-73a0-4b85-8534-efa3297fccb0)
![input](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/75a5f008-dd44-45ca-8421-367ae8bee70e)

Mask
![image](https://github.com/Mikubill/sd-webui-controlnet/assets/20929282/83ae4e69-0625-4514-beb7-080742d79d66)


Generation parameters (Parameters including seed are fixed for all examples)
```
1girl, sitting on throne,, absurdres, highres, (masterpiece:1.2), (best quality, highest quality),
Negative prompt: (lowres, low quality, worst quality:1.2), (text:1.2), watermark, (frame:1.2), deformed, ugly, deformed eyes, blur, out of focus, blurry, deformed cat, deformed, photo, anthropomorphic cat, monochrome, photo, pet collar, gun, weapon, blue, 3d, drones, drone, buildings in background, green
Steps: 30, Sampler: DPM++ 2M, Schedule type: Karras, CFG scale: 7, Seed: 1413879340, Size: 1024x1024, Model hash: 5d973c1f8a, Model: animagine-xl-2.0, ControlNet 0: "Module: none, Model: controlnet++_union_sdxl [15e6ad5d], Weight: 1.0, Resize Mode: Crop and Resize, Processor Res: 512, Threshold A: 0.5, Threshold B: 0.5, Guidance Start: 0.0, Guidance End: 1.0, Pixel Perfect: False, Control Mode: Balanced", ControlNet 1: "Module: canny, Model: controlnet++_union_sdxl [15e6ad5d], Weight: 1.0, Resize Mode: Crop and Resize, Processor Res: 512, Threshold A: 100.0, Threshold B: 200.0, Guidance Start: 0.0, Guidance End: 1.0, Pixel Perfect: False, Control Mode: Balanced", Version: v1.9.4-249-g93c00b2a
```