### PR TITLE
Support ProMax union model

### DIFF
--- a/scripts/cldm.py
+++ b/scripts/cldm.py
@@ -91,7 +91,7 @@ class ControlNet(nn.Module):
         use_linear_in_transformer=False,
         adm_in_channels=None,
         transformer_depth_middle=None,
-        union_controlnet=False,
+        union_controlnet_num_control_type=None,
         device=None,
         global_average_pooling=False,
     ):
@@ -282,8 +282,8 @@ class ControlNet(nn.Module):
         self.middle_block_out = self.make_zero_conv(ch)
         self._feature_size += ch
 
-        if union_controlnet:
-            self.num_control_type = 6
+        if union_controlnet_num_control_type is not None:
+            self.num_control_type = union_controlnet_num_control_type
             num_trans_channel = 320
             num_trans_head = 8
             num_trans_layer = 1

--- a/scripts/controlnet_model_guess.py
+++ b/scripts/controlnet_model_guess.py
@@ -222,7 +222,7 @@ def build_model_by_guess(state_dict, unet, model_path: str) -> ControlModel:
             state_dict = final_state_dict
 
         if "control_add_embedding.linear_1.bias" in state_dict: # Controlnet Union
-            config["union_controlnet"] = True
+            config["union_controlnet_num_control_type"] = state_dict["task_embedding"].shape[0]
             final_state_dict = {}
             for k in list(state_dict.keys()):
                 new_k = k.replace('.attn.in_proj_', '.attn.in_proj.')

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -310,6 +310,8 @@ class ControlNetUnionControlType(Enum):
             "mlsd",
             "normalmap",
             "segmentation",
+            "inpaint",
+            "tile",
         ]
 
     @staticmethod

--- a/scripts/enums.py
+++ b/scripts/enums.py
@@ -292,6 +292,8 @@ class ControlNetUnionControlType(Enum):
     HARD_EDGE = "Hard Edge"
     NORMAL_MAP = "Normal Map"
     SEGMENTATION = "Segmentation"
+    TILE = "Tile"
+    INPAINT = "Inpaint"
 
     UNKNOWN = "Unknown"
 
@@ -326,6 +328,10 @@ class ControlNetUnionControlType(Enum):
             return ControlNetUnionControlType.NORMAL_MAP
         elif s == "segmentation":
             return ControlNetUnionControlType.SEGMENTATION
+        elif s in ["tile", "blur"]:
+            return ControlNetUnionControlType.TILE
+        elif s == "inpaint":
+            return ControlNetUnionControlType.INPAINT
 
         return ControlNetUnionControlType.UNKNOWN
 


### PR DESCRIPTION
The promax union model supports 2 new control types: Tile and Inpaint. You can download the model here: https://huggingface.co/xinsir/controlnet-union-sdxl-1.0/tree/main

## Tile
![image](https://github.com/user-attachments/assets/6f57d3de-ec2f-4dda-8b5e-5fff86624fb1)
![image](https://github.com/user-attachments/assets/413d08ca-947c-4b74-b350-58f4d2490c41)
```
1girl, hatsune miku,, absurdres, highres, (masterpiece:1.2), (best quality, highest quality),
Negative prompt: (lowres, low quality, worst quality:1.2), (text:1.2), watermark, (frame:1.2), deformed, ugly, deformed eyes, blur, out of focus, blurry, deformed cat, deformed, photo, anthropomorphic cat, monochrome, photo, pet collar, gun, weapon, blue, 3d, drones, drone, buildings in background, green
Steps: 30, Sampler: DPM++ 2M, Schedule type: Karras, CFG scale: 7, Seed: 3582562933, Size: 768x1024, Model hash: 5a268fde84, Model: netaArtXL_v10, Clip skip: 2, ControlNet 0: "Module: blur_gaussian, Model: controlnet++_union_promax_sdxl [9460e4db], Weight: 1.0, Resize Mode: Crop and Resize, Processor Res: 512, Threshold A: 9.0, Threshold B: 0.5, Guidance Start: 0.0, Guidance End: 1.0, Pixel Perfect: False, Control Mode: Balanced", Version: v1.9.4-253-gb2453d28
```
![image](https://github.com/user-attachments/assets/ba079792-dc2c-44f5-9c4f-821c7b338544)
![image](https://github.com/user-attachments/assets/d50305bf-37d3-4e99-8098-1e24c79b8eac)
```
absurdres, highres, (masterpiece:1.2), (best quality, highest quality),
Negative prompt: (lowres, low quality, worst quality:1.2), (text:1.2), watermark, (frame:1.2), deformed, ugly, deformed eyes, blur, out of focus, blurry, deformed cat, deformed, photo, anthropomorphic cat, monochrome, photo, pet collar, gun, weapon, blue, 3d, drones, drone, buildings in background, green
Steps: 20, Sampler: DPM++ 2M, Schedule type: Karras, CFG scale: 7, Seed: 3086528334, Size: 768x1024, Model hash: 5a268fde84, Model: netaArtXL_v10, Clip skip: 2, ControlNet 0: "Module: blur_gaussian, Model: controlnet++_union_promax_sdxl [9460e4db], Weight: 1.0, Resize Mode: Crop and Resize, Processor Res: 512, Threshold A: 9.0, Threshold B: 0.5, Guidance Start: 0.0, Guidance End: 1.0, Pixel Perfect: False, Control Mode: Balanced", Version: v1.9.4-253-gb2453d28
```
## Inpaint
Does not work right now. Need to wait author update inference script in https://github.com/xinsir6/ControlNetPlus/tree/main. It probably uses different protocol for inpaint comparing to the current impl in sd-webui-controlnet.
