### PR TITLE
fix version parsing

### DIFF
--- a/install.py
+++ b/install.py
@@ -5,15 +5,12 @@ import os
 import shutil
 import platform
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Optional
+from packaging.version import parse
 
 
 repo_root = Path(__file__).parent
 main_req_file = repo_root / "requirements.txt"
-
-
-def comparable_version(version: str) -> Tuple:
-    return tuple(version.split("."))
 
 
 def get_installed_version(package: str) -> Optional[str]:
@@ -44,9 +41,9 @@ def install_requirements(req_file):
                 elif ">=" in package:
                     package_name, package_version = package.split(">=")
                     installed_version = get_installed_version(package_name)
-                    if not installed_version or comparable_version(
+                    if not installed_version or parse(
                         installed_version
-                    ) < comparable_version(package_version):
+                    ) < parse(package_version):
                         launch.run_pip(
                             f'install -U "{package}"',
                             f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}",
@@ -54,9 +51,9 @@ def install_requirements(req_file):
                 elif "<=" in package:
                     package_name, package_version = package.split("<=")
                     installed_version = get_installed_version(package_name)
-                    if not installed_version or comparable_version(
+                    if not installed_version or parse(
                         installed_version
-                    ) > comparable_version(package_version):
+                    ) > parse(package_version):
                         launch.run_pip(
                             f'install "{package_name}=={package_version}"',
                             f"sd-webui-controlnet requirement: changing {package_name} version from {installed_version} to {package_version}",
@@ -94,7 +91,7 @@ def try_install_from_wheel(pkg_name: str, wheel_url: str, version: Optional[str]
         if version is None:
             return
         # Version requirement already satisfied.
-        if comparable_version(current_version) >= comparable_version(version):
+        if parse(current_version) >= parse(version):
             return
 
     try:


### PR DESCRIPTION
recently on every launch install.py the message keep poping up on launch
```
Installing sd-webui-controlnet requirement: changing opencv-python version from 4.10.0.84 to 4.8.0
```

this is due to improper version comparison in `install.py`

`comparable_version()` in `install.py` retruns `Tuple of strings`
https://github.com/Mikubill/sd-webui-controlnet/blob/b63899a654ee2f70d475c259691f35ac67c320d4/install.py#L15-L16

until recently directly comparing `Tuple of strings` work good enough but opencv-python updated to vesrion `4.10.x.x`

when checking for [`opencv-python>=4.8.0`](https://github.com/Mikubill/sd-webui-controlnet/blob/b63899a654ee2f70d475c259691f35ac67c320d4/requirements.txt#L3)
 the `Tuple of strings` `('4', '10', '0', '84')` >= `('4', '8', '0')` this retruns `False`
due to the string `'10'` is < string `'8'`

---

solution

as far as I'm aware the best way of passing version number is to use `from packaging.version import parse`
as this also handles more exotic version numbers such as the ones with suffixes
> suffix like pytorch '2.1.2+cu121'

alternatively if you wish to not packaging then one could either write complex regex to handle special cases
or just assume that there's no special version numbers and simply convert str to int
which can be done by modifying `comparable_version`
```py
def comparable_version(version: str) -> Tuple:
    return tuple(int(v) for v in version.split("."))
```
