### PR TITLE
ensure ip-adapter Ensure mask_h * mask_w equals sequence_length in `apply_effective_region_mask` function

### DIFF
--- a/scripts/ipadapter/plugable_ipadapter.py
+++ b/scripts/ipadapter/plugable_ipadapter.py
@@ -193,8 +193,14 @@ class PlugableIPAdapter(torch.nn.Module):
         assert (
             factor > 0
         ), f"{factor}, {sequence_length}, {self.latent_width}, {self.latent_height}"
-        mask_h = int(self.latent_height * factor)
-        mask_w = int(self.latent_width * factor)
+        mask_h = round(self.latent_height * factor)
+        mask_w = round(self.latent_width * factor)
+
+        # Ensure mask_h * mask_w equals sequence_length
+        if mask_h * mask_w < sequence_length:
+            mask_w += 1
+        elif mask_h * mask_w > sequence_length:
+            mask_w -= 1
 
         mask = torch.nn.functional.interpolate(
             self.effective_region_mask.to(out.device),


### PR DESCRIPTION
Hi,

I found that there is an error when I run ip-adapter with size 912x1144. which is one of the recommended pixel values for the generation of stable diffusion XL.

I think rounding to integer for mask_h and mask_w might cause the discrepancy.

I changed like below.

Thanks :)