### PR TITLE
Update processor.py for macOS support

### DIFF
--- a/scripts/preprocessor/legacy/processor.py
+++ b/scripts/preprocessor/legacy/processor.py
@@ -687,7 +687,7 @@ class InsightFaceModel:
             from annotator.annotator_path import models_path
             self.model = FaceAnalysis(
                 name=self.face_analysis_model_name,
-                providers=['CUDAExecutionProvider', 'CPUExecutionProvider'],
+                providers=['CUDAExecutionProvider','CoreMLExecutionProvider', 'CPUExecutionProvider'],
                 root=os.path.join(models_path, "insightface"),
             )
             self.model.prepare(ctx_id=0, det_size=(640, 640))


### PR DESCRIPTION
On macOS 15, somehow the insightface is always fail due to the it fail to fallback to CPU provider, I tested extra CoreML provider and the problem is solved.  Submitted for better compatibility!