### PR TITLE
Add element IDs to advanced weight control components

### DIFF
--- a/scripts/controlnet_ui/advanced_weight_control.py
+++ b/scripts/controlnet_ui/advanced_weight_control.py
@@ -72,7 +72,7 @@ class AdvancedWeightControl:
         self.weight_editor = None
         self.weight_composition = None
 
-    def render(self):
+    def render(self, tabname=None, elem_id_tabname=None):
         with gr.Group(visible=False) as self.group:
             with gr.Row():
                 self.weight_type = gr.Dropdown(
@@ -94,6 +94,7 @@ class AdvancedWeightControl:
                     ],
                     label="Weight Type",
                     value="normal",
+                    elem_id=None if elem_id_tabname is None else f"{elem_id_tabname}_{tabname}_controlnet_weight_type_dropdown"
                 )
                 self.weight_composition = gr.Slider(
                     label="Composition Weight",
@@ -103,7 +104,11 @@ class AdvancedWeightControl:
                     step=0.01,
                     visible=False,
                 )
-                self.weight_editor = gr.Textbox(label="Weights", visible=False)
+                self.weight_editor = gr.Textbox(
+                    label="Weights", 
+                    visible=False,
+                    elem_id=None if elem_id_tabname is None else f"{elem_id_tabname}_{tabname}_controlnet_weights_textbox"
+                )
 
             self.weight_plot = gr.Image(
                 value=None,

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -637,7 +637,7 @@ class ControlNetUiGroup(object):
             visible=False,
         )
 
-        self.advanced_weight_control.render()
+        self.advanced_weight_control.render(tabname, elem_id_tabname)
 
         self.batch_image_dir_state = gr.State("")
         self.output_dir_state = gr.State("")


### PR DESCRIPTION
This PR adds element IDs to the Weight Type dropdown and Weights textbox in the Advanced Weight Control section of ControlNet units. The IDs follow the existing naming pattern used throughout controlnet_ui_group.py.

The primary purpose is to enable compatibility with the Config Presets extension, allowing users to save and reload complex ControlNet configurations including advanced weight settings.

Changes:
- Added elem_id parameters to AdvancedWeightControl.render()
- Added elem_ids to weight_type dropdown and weight_editor textbox
- Maintained backward compatibility for cases where render is called without parameters

The changes to the dropdown have been tested and confirmed working with both ControlNet and Config Presets.  Changes to the advanced weights textbox will need to rely on custom code in the Config Presets to stop propagation of Weight Type events when both the Weight Type and Advanced Weights are updated as part of the same preset (otherwise the UI event for Weight Type overwrites the Advanced Weights).
