### PR TITLE
Add ProMax inpaint preprocessor

### DIFF
--- a/scripts/preprocessor/__init__.py
+++ b/scripts/preprocessor/__init__.py
@@ -1,6 +1,7 @@
 from .teed import *
 from .pulid import *
 from .inpaint import *
+from .inpaint_promax import *
 from .lama_inpaint import *
 from .ip_adapter_auto import *
 from .normal_dsine import *

--- a/scripts/preprocessor/inpaint_promax.py
+++ b/scripts/preprocessor/inpaint_promax.py
@@ -1,0 +1,39 @@
+import cv2
+import numpy as np
+
+from ..supported_preprocessor import Preprocessor, PreprocessorParameter
+
+class PreprocessorProMaxInpaint(Preprocessor):
+    def __init__(self):
+        super().__init__(name="inpaint_promax")
+        self.tags = ["Inpaint"]
+        self.returns_image = True
+        self.model = None
+        self.slider_resolution = PreprocessorParameter(visible=False)
+        self.accepts_mask = True
+        self.requires_mask = True
+
+    def __call__(
+        self,
+        input_image,
+        resolution,
+        slider_1=None,
+        slider_2=None,
+        slider_3=None,
+        **kwargs
+    ):
+        img = input_image.copy()
+        H, W, C = img.shape
+        assert C == 4, "No mask is provided!"
+    
+        img[img[:,:,3] > 0.,:3] = 0
+        img[:,:,3]=0
+
+        return Preprocessor.Result(
+            value=img,
+            display_images=[
+                img
+            ],
+        )
+
+Preprocessor.add_supported_preprocessor(PreprocessorProMaxInpaint())


### PR DESCRIPTION
This pull request adds support for inpaint control type for the ProMax controlnet union model of https://github.com/xinsir6/ControlNetPlus.

All it needs as control image is the original image with the mask blacked out.

Some quick testing by me shows it's working in txt2img (although it can modify outside of the mask in this case), and img2img.