### PR TITLE
actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,13 +108,13 @@ jobs:
           python -m coverage html -i
         working-directory: stable-diffusion-webui
       - name: Upload main app output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: output
           path: stable-diffusion-webui/output.txt
       - name: Upload coverage HTML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: htmlcov


### PR DESCRIPTION
actions/upload-artifact@v3 is Deprecated
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

whitch will cause action to fail
example https://github.com/w-e-w/sd-webui-controlnet/actions/runs/14803134800