### PR TITLE
Auto install insightface for py 3.9 3.11 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,13 +108,13 @@ jobs:
           python -m coverage html -i
         working-directory: stable-diffusion-webui
       - name: Upload main app output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: output
           path: stable-diffusion-webui/output.txt
       - name: Upload coverage HTML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: htmlcov

--- a/install.py
+++ b/install.py
@@ -110,19 +110,19 @@ def try_install_insight_face():
     in principle. Here the solution is to download a precompiled wheel."""
     if get_installed_version("insightface") is not None:
         return
-
-    default_win_wheel = "https://github.com/Gourieff/Assets/raw/main/Insightface/insightface-0.7.3-cp310-cp310-win_amd64.whl"
+    win_wheels = {
+        (3, 9): "https://github.com/Gourieff/Assets/raw/main/Insightface/insightface-0.7.3-cp39-cp39-win_amd64.whl",
+        (3, 10): "https://github.com/Gourieff/Assets/raw/main/Insightface/insightface-0.7.3-cp310-cp310-win_amd64.whl",
+        (3, 11): "https://github.com/Gourieff/Assets/raw/main/Insightface/insightface-0.7.3-cp311-cp311-win_amd64.whl",
+        (3, 12): "https://github.com/Gourieff/Assets/raw/main/Insightface/insightface-0.7.3-cp312-cp312-win_amd64.whl",
+    }
+    default_win_wheel = win_wheels.get((sys.version_info.major, sys.version_info.minor))
     wheel_url = os.environ.get("INSIGHTFACE_WHEEL", default_win_wheel)
 
     system = platform.system().lower()
     architecture = platform.machine().lower()
-    python_version = sys.version_info
-    if wheel_url != default_win_wheel or (
-        system == "windows"
-        and "amd64" in architecture
-        and python_version.major == 3
-        and python_version.minor == 10
-    ):
+
+    if wheel_url is not None and wheel_url != default_win_wheel or (system == "windows" and "amd64" in architecture):
         try:
             launch.run_pip(
                 f"install {wheel_url}",


### PR DESCRIPTION
install.py already have logic to install insightface using custom wheel from https://github.com/Gourieff/Assets/tree/main/Insightface
makes sense to me to apply the same logic for Python 3.9 3.11 3.12 (not that A1111 works on 3.12)
