### PR TITLE
Visible queue false

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,13 +108,13 @@ jobs:
           python -m coverage html -i
         working-directory: stable-diffusion-webui
       - name: Upload main app output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: output
           path: stable-diffusion-webui/output.txt
       - name: Upload coverage HTML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: htmlcov

--- a/scripts/controlnet_ui/controlnet_ui_group.py
+++ b/scripts/controlnet_ui/controlnet_ui_group.py
@@ -823,10 +823,10 @@ class ControlNetUiGroup(object):
             self.control_mode,
         ]
         self.module.change(
-            build_sliders, inputs=inputs, outputs=outputs, show_progress=False
+            build_sliders, inputs=inputs, outputs=outputs, show_progress=False, queue=False
         )
         self.pixel_perfect.change(
-            build_sliders, inputs=inputs, outputs=outputs, show_progress=False
+            build_sliders, inputs=inputs, outputs=outputs, show_progress=False, queue=False
         )
 
         def filter_selected(k: str):
@@ -1029,6 +1029,7 @@ class ControlNetUiGroup(object):
                 self.openpose_editor.modal,
             ],
             show_progress=False,
+            queue=False,
         )
 
     def register_create_canvas(self):
@@ -1126,6 +1127,7 @@ class ControlNetUiGroup(object):
             inputs=[ControlNetUiGroup.a1111_context.txt2img_enable_hr],
             outputs=[self.hr_option],
             show_progress=False,
+            queue=False,
         )
 
     def register_shift_upload_mask(self):
@@ -1140,6 +1142,7 @@ class ControlNetUiGroup(object):
             inputs=[self.mask_upload],
             outputs=[self.mask_image_group, self.effective_region_mask],
             show_progress=False,
+            queue=False,
         )
 
     def register_shift_pulid_mode(self):
@@ -1148,6 +1151,7 @@ class ControlNetUiGroup(object):
             inputs=[self.model],
             outputs=[self.pulid_mode],
             show_progress=False,
+            queue=False,
         )
 
     def register_sync_batch_dir(self):
@@ -1172,14 +1176,12 @@ class ControlNetUiGroup(object):
                 fn=determine_batch_dir,
                 inputs=batch_dirs,
                 outputs=[self.batch_image_dir_state],
-                queue=False,
             )
 
         ControlNetUiGroup.a1111_context.img2img_batch_output_dir.blur(
             fn=lambda a: a,
             inputs=[ControlNetUiGroup.a1111_context.img2img_batch_output_dir],
             outputs=[self.output_dir_state],
-            queue=False,
         )
 
     def register_clear_preview(self):


### PR DESCRIPTION
I found that setting these events to not use gradio's queue works better
more responsive and less likely to desync 

this is related to several behaviors such as showing / hideing of the controlnet `Hires-Fix Option` depending on the state of `Hires-Fix checkbox`

## video example

### before PR with queue
currently desync can happen if the user quickly clicks the `Hires-Fix checkbox` multiple times
in the video I demonstrate double clicking it, and can easily result in the a state that `Hires-Fix checkbox` is check but controlnet `Hires-Fix Option` is hidden vice versa


https://github.com/user-attachments/assets/b1028ff6-b174-447c-8035-d8ccfe4025e8


### with PR queue=False

in video I performing the same action repeatedly double clicking `Hires-Fix checkbox`, 
different from before we can see that the `Hires-Fix checkbox` and show/hide state of controlnet `Hires-Fix Option` is always in sync


https://github.com/user-attachments/assets/633528f6-2b7b-498c-8758-de31bc3cb72e

also believe that it is faster and more responsive


